### PR TITLE
correction of nodespace when is null or lenght 0

### DIFF
--- a/data/crac-file/crac-file-xlsx-api/src/main/java/com/farao_community/farao/data/crac_file/xlsx/service/RdRemedialActionValidation.java
+++ b/data/crac-file/crac-file-xlsx-api/src/main/java/com/farao_community/farao/data/crac_file/xlsx/service/RdRemedialActionValidation.java
@@ -77,7 +77,7 @@ public final class RdRemedialActionValidation {
     }
 
     public static List<RemedialAction> rdRemedialActionValidation(Validation<FaraoException, List<RedispatchingRemedialActionXlsx>> redispatchingRemedialActionXlsx, Validation<FaraoException, List<RaTimeSeries>> radTimeSeries, TimesSeries timesSeries) {
-        List<RemedialAction>  remedialActionList = new ArrayList<>();
+        List<RemedialAction> remedialActionList = new ArrayList<>();
         HashMap<String, List<UsageRule>> usageRuleHashMap = usageRulesRedispatchingValidation(redispatchingRemedialActionXlsx);
         redispatchingRemedialActionXlsx.forEach(ras -> {
             List<Float> valueTs = new ArrayList<Float>();
@@ -113,7 +113,10 @@ public final class RdRemedialActionValidation {
 
     private static RemedialActionElement buildRemedialActionElements(RedispatchingRemedialActionXlsx ra) {
         String spaceNode = "";
-        int nodeSpace = MAX_NODEID_LENGTH - ra.getUctNodeOrGsk().length();
+        int nodeSpace = 0;
+        if (ra.getUctNodeOrGsk() != null && ra.getUctNodeOrGsk().length() != 0) {
+            nodeSpace = MAX_NODEID_LENGTH - ra.getUctNodeOrGsk().length();
+        }
         for (int i = 0; i < nodeSpace; i++) {
             spaceNode = spaceNode + " ";
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
When we have a node space at 0, the application stop all import.


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Not documentation, only node space correction.


**What is the current behavior?** *(You can also link to an open issue here)*
the application stop all when the node space have a lenght at 0 or is null.


**What is the new behavior (if this is a feature change)?**
the application check the lenght of node space before use.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
not breaking change.


**Other information**:
not really.
(if any of the questions/checkboxes don't apply, please delete them entirely)
