### PR TITLE
Correction of parsing share at import crac xlsx

### DIFF
--- a/data/crac-file/crac-file-xlsx-api/src/main/java/com/farao_community/farao/data/crac_file/xlsx/model/SharingDefinition.java
+++ b/data/crac-file/crac-file-xlsx-api/src/main/java/com/farao_community/farao/data/crac_file/xlsx/model/SharingDefinition.java
@@ -21,7 +21,8 @@ public enum SharingDefinition {
     CSRA_CONTROL_BLOCK("CSRA - Shared for the CBCOs within the TSO's Control Block"),
     CSRA_CBCO_GROUP("CSRA - Shared for the CBCOs within the CBCO Group"),
     CSRA_CBCO("CSRA - Shared for the CBCOs within the CBCO Single"),
-    SRA("SRA - Shared RA");
+    SRA("SRA - Shared RA"),
+    SRA_WITHOUT_RA("SRA - Shared");
 
     private static final Map<String, SharingDefinition> ENUM_MAP = new HashMap<>();
 


### PR DESCRIPTION
Signed-off-by: Amira Kahya <amira.kahya@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix : error during parsing "sharing definition" at import crac xlsx


**What is the current behavior?** *(You can also link to an open issue here)*
error when the value of "sharing definition" in the crac file is "SRA - Shared"


**What is the new behavior (if this is a feature change)?**"
Treat the case when the value of "sharing definition" in crac file is "SRA - Shared"


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No
