### PR TITLE
Correction of parsing empty status at import xlsx crac file

### DIFF
--- a/data/crac-file/crac-file-xlsx-api/src/main/java/com/farao_community/farao/data/crac_file/xlsx/handler/EntityExcelSheetHandler.java
+++ b/data/crac-file/crac-file-xlsx-api/src/main/java/com/farao_community/farao/data/crac_file/xlsx/handler/EntityExcelSheetHandler.java
@@ -111,7 +111,7 @@ public final class EntityExcelSheetHandler<T> implements CellExcelReader {
 
         ExcelColumnInfo currentColumnInfo = columns[column];
 
-        if (Objects.isNull(entity) || Objects.isNull(formattedValue)) {
+        if (Objects.isNull(entity) || Objects.isNull(formattedValue) || formattedValue.isEmpty()) {
             return;
         }
         writeColumnField(entity, formattedValue, currentColumnInfo, timesSeries, currentRow);


### PR DESCRIPTION
Signed-off-by: Amira Kahya <amira.kahya@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix : error during parsing empty "status" at import crac xlsx


**What is the current behavior?** *(You can also link to an open issue here)*
error when the value of "status" in the crac file is empty


**What is the new behavior (if this is a feature change)?**
Treat the case when the value of "status" in crac file is empty


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No
