### PR TITLE
Implement switch contingency in closed optimisation RAO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <maven.templating.version>1.0.0</maven.templating.version>
         <mockito.version>2.19.0</mockito.version>
         <powermock.version>2.0.2</powermock.version>
-        <powsybl.core.version>3.0.0-alpha1</powsybl.core.version>
+        <powsybl.core.version>2.6.0</powsybl.core.version>
         <powsybl.hades2.version>2.6.0</powsybl.hades2.version>
         <slf4j.version>1.7.22</slf4j.version>
         <test.assert.version>1.4</test.assert.version>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <maven.templating.version>1.0.0</maven.templating.version>
         <mockito.version>2.19.0</mockito.version>
         <powermock.version>2.0.2</powermock.version>
-        <powsybl.core.version>2.6.0</powsybl.core.version>
+        <powsybl.core.version>3.0.0-alpha1</powsybl.core.version>
         <powsybl.hades2.version>2.6.0</powsybl.hades2.version>
         <slf4j.version>1.7.22</slf4j.version>
         <test.assert.version>1.4</test.assert.version>

--- a/ra-optimisation/closed-optimisation-rao/src/main/java/com/farao_community/farao/closed_optimisation_rao/pre_processors/ReferenceFlowsPreProcessor.java
+++ b/ra-optimisation/closed-optimisation-rao/src/main/java/com/farao_community/farao/closed_optimisation_rao/pre_processors/ReferenceFlowsPreProcessor.java
@@ -19,6 +19,7 @@ import com.powsybl.contingency.BranchContingency;
 import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.Switch;
 import com.powsybl.loadflow.LoadFlowResult;
 
 import java.util.HashMap;
@@ -115,6 +116,10 @@ public class ReferenceFlowsPreProcessor implements OptimisationPreProcessor {
         if (element instanceof Branch) {
             BranchContingency contingency = new BranchContingency(contingencyElement.getElementId());
             contingency.toTask().modify(network, computationManager);
+        } else if (element instanceof Switch) {
+            // TODO: convert into a PowSyBl ContingencyElement ?
+            Switch switchElement = (Switch) element;
+            switchElement.setOpen(true);
         } else {
             throw new FaraoException("Unable to apply contingency element " + contingencyElement.getElementId());
         }

--- a/ra-optimisation/closed-optimisation-rao/src/main/java/com/farao_community/farao/closed_optimisation_rao/pre_processors/SensitivityPreProcessor.java
+++ b/ra-optimisation/closed-optimisation-rao/src/main/java/com/farao_community/farao/closed_optimisation_rao/pre_processors/SensitivityPreProcessor.java
@@ -197,6 +197,10 @@ public class SensitivityPreProcessor implements OptimisationPreProcessor {
         if (element instanceof Branch) {
             BranchContingency contingency = new BranchContingency(contingencyElement.getElementId());
             contingency.toTask().modify(network, computationManager);
+        } else if (element instanceof Switch) {
+            // TODO: convert into a PowSyBl ContingencyElement ?
+            Switch switchElement = (Switch) element;
+            switchElement.setOpen(true);
         } else {
             throw new FaraoException("Unable to apply contingency element " + contingencyElement.getElementId());
         }


### PR DESCRIPTION
Signed-off-by: Sébastien MURGEY <sebastien.murgey@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature

**What is the current behavior?** *(You can also link to an open issue here)*
Currently, it is not possible to simulate switch opening as contingency in FARAO

**What is the new behavior (if this is a feature change)?**
Switch contingency are now correctly taken into account
