### PR TITLE
Extension of cracFile data format 

### DIFF
--- a/data/crac-file/crac-file-api/src/main/java/com/farao_community/farao/data/crac_file/PstElement.java
+++ b/data/crac-file/crac-file-api/src/main/java/com/farao_community/farao/data/crac_file/PstElement.java
@@ -24,14 +24,16 @@ public class PstElement extends RemedialActionElement {
     private final TypeOfLimit typeOfLimit;
     private final int minStepRange;
     private final int maxStepRange;
+    private final double penaltyCost;
 
-    @ConstructorProperties({"id", "typeOfLimit", "minStepRange", "maxStepRange"})
+    @ConstructorProperties({"id", "typeOfLimit", "minStepRange", "maxStepRange", "penaltyCost"})
     @Builder
-    public PstElement(String id, TypeOfLimit typeOfLimit, int minStepRange, int maxStepRange) {
+    public PstElement(String id, TypeOfLimit typeOfLimit, int minStepRange, int maxStepRange, double penaltyCost) {
         super(id);
         this.typeOfLimit = typeOfLimit;
         this.minStepRange = checkMin(minStepRange, maxStepRange);
         this.maxStepRange = checkMax(minStepRange, maxStepRange);
+        this.penaltyCost = penaltyCost;
     }
 
     private int checkMin(int min, int max) {

--- a/data/crac-file/crac-file-api/src/main/java/com/farao_community/farao/data/crac_file/RedispatchRemedialActionElement.java
+++ b/data/crac-file/crac-file-api/src/main/java/com/farao_community/farao/data/crac_file/RedispatchRemedialActionElement.java
@@ -25,21 +25,26 @@ public class RedispatchRemedialActionElement extends RemedialActionElement {
     private final double minimumPower;
     @NotNull(message = "maximumPower")
     private final double maximumPower;
+    private final double targetPower;
     private final double startupCost;
     private final double marginalCost;
+    private final String generatorName;
 
-    @ConstructorProperties({"id", "minimumPower", "maximumPower", "startupCost", "marginalCost"})
+    @ConstructorProperties({"id", "minimumPower", "maximumPower", "targetPower", "startupCost", "marginalCost", "generatorName"})
     @Builder
     public RedispatchRemedialActionElement(final String id,
                                            final double minimumPower,
                                            final double maximumPower,
+                                           final double targetPower,
                                            final double startupCost,
-                                           final double marginalCost) {
+                                           final double marginalCost,
+                                           final String generatorName) {
         super(id);
         this.minimumPower = minimumPower;
         this.maximumPower = maximumPower;
+        this.targetPower = targetPower;
         this.startupCost = startupCost;
         this.marginalCost = marginalCost;
+        this.generatorName = generatorName;
     }
-
 }

--- a/data/crac-file/crac-file-api/src/test/java/com/farao_community/farao/data/crac_file/json/JsonCracFileTest.java
+++ b/data/crac-file/crac-file-api/src/test/java/com/farao_community/farao/data/crac_file/json/JsonCracFileTest.java
@@ -54,7 +54,6 @@ public class JsonCracFileTest extends AbstractConverterTest {
         List<String> filesToTest = Arrays.asList("/cracFileExample.json", "/cracFileExamplePst.json", "/cracFileExampleTopo.json");
         filesToTest.forEach(file -> {
             try {
-                System.out.println(file);
                 roundTripTest(create(file), JsonCracFileTest::write, JsonCracFileTest::read, file);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/data/crac-file/crac-file-api/src/test/java/com/farao_community/farao/data/crac_file/json/JsonCracFileTest.java
+++ b/data/crac-file/crac-file-api/src/test/java/com/farao_community/farao/data/crac_file/json/JsonCracFileTest.java
@@ -54,6 +54,7 @@ public class JsonCracFileTest extends AbstractConverterTest {
         List<String> filesToTest = Arrays.asList("/cracFileExample.json", "/cracFileExamplePst.json", "/cracFileExampleTopo.json");
         filesToTest.forEach(file -> {
             try {
+                System.out.println(file);
                 roundTripTest(create(file), JsonCracFileTest::write, JsonCracFileTest::read, file);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/data/crac-file/crac-file-api/src/test/resources/cracFileExample.json
+++ b/data/crac-file/crac-file-api/src/test/resources/cracFileExample.json
@@ -91,13 +91,15 @@
       "id" : "GENERATOR_10",
       "typeOfLimit" : "RELATIVE",
       "minStepRange" : 0,
-      "maxStepRange" : 40
+      "maxStepRange" : 40,
+      "penaltyCost" : 0.0
     }, {
       "@c" : ".PstElement",
       "id" : "GENERATOR_20",
       "typeOfLimit" : "ABSOLUTE",
       "minStepRange" : -10,
-      "maxStepRange" : 10
+      "maxStepRange" : 10,
+      "penaltyCost" : 0.0
     } ],
     "usageRules" : [ {
       "id" : "RULE1",

--- a/data/crac-file/crac-file-api/src/test/resources/cracFileExample.json
+++ b/data/crac-file/crac-file-api/src/test/resources/cracFileExample.json
@@ -77,15 +77,19 @@
       "id" : "GENERATOR_1",
       "minimumPower" : 100.0,
       "maximumPower" : 1000.0,
+      "targetPower" : 200.0,
       "startupCost" : 100000.0,
-      "marginalCost" : 10.0
+      "marginalCost" : 10.0,
+      "generatorName" : "GENERATOR_1_name"
     }, {
       "@c" : ".RedispatchRemedialActionElement",
       "id" : "GENERATOR_24",
       "minimumPower" : 200.0,
       "maximumPower" : 2000.0,
+      "targetPower" : 2000.0,
       "startupCost" : 200000.0,
-      "marginalCost" : 20.0
+      "marginalCost" : 20.0,
+      "generatorName" : "GENERATOR_24_name"
     }, {
       "@c" : ".PstElement",
       "id" : "GENERATOR_10",
@@ -128,15 +132,19 @@
       "id" : "GENERATOR_3",
       "minimumPower" : 100.0,
       "maximumPower" : 1000.0,
+      "targetPower" : 100.0,
       "startupCost" : 100000.0,
-      "marginalCost" : 10.0
+      "marginalCost" : 10.0,
+      "generatorName" : "GENERATOR_3_name"
     }, {
       "@c" : ".RedispatchRemedialActionElement",
       "id" : "GENERATOR_4",
       "minimumPower" : 200.0,
       "maximumPower" : 2000.0,
+      "targetPower" : 500.0,
       "startupCost" : 200000.0,
-      "marginalCost" : 20.0
+      "marginalCost" : 20.0,
+      "generatorName" : "GENERATOR_4_name"
     } ],
     "usageRules" : [ {
       "id" : "RULE4",

--- a/data/crac-file/crac-file-api/src/test/resources/cracFileExamplePst.json
+++ b/data/crac-file/crac-file-api/src/test/resources/cracFileExamplePst.json
@@ -77,25 +77,29 @@
       "id" : "GENERATOR_1540",
       "typeOfLimit" : "RELATIVE",
       "minStepRange" : 0,
-      "maxStepRange" : 40
+      "maxStepRange" : 40,
+      "penaltyCost" : 0.0
     }, {
       "@c" : ".PstElement",
       "id" : "GENERATOR_1054",
       "typeOfLimit" : "RELATIVE",
       "minStepRange" : 0,
-      "maxStepRange" : 40
+      "maxStepRange" : 40,
+      "penaltyCost" : 0.0
     }, {
       "@c" : ".PstElement",
       "id" : "GENERATOR_10",
       "typeOfLimit" : "RELATIVE",
       "minStepRange" : 0,
-      "maxStepRange" : 40
+      "maxStepRange" : 40,
+      "penaltyCost" : 0.0
     }, {
       "@c" : ".PstElement",
       "id" : "GENERATOR_20",
       "typeOfLimit" : "ABSOLUTE",
       "minStepRange" : -10,
-      "maxStepRange" : 10
+      "maxStepRange" : 10,
+      "penaltyCost" : 0.0
     } ],
     "usageRules" : [ {
       "id" : "RULE1",

--- a/data/crac-file/crac-file-api/src/test/resources/cracFileExamplePst.json
+++ b/data/crac-file/crac-file-api/src/test/resources/cracFileExamplePst.json
@@ -128,15 +128,19 @@
       "id" : "GENERATOR_3",
       "minimumPower" : 100.0,
       "maximumPower" : 1000.0,
+      "targetPower" : 200.0,
       "startupCost" : 100000.0,
-      "marginalCost" : 10.0
+      "marginalCost" : 10.0,
+      "generatorName" : "GENERATOR_3_name"
     }, {
       "@c" : ".RedispatchRemedialActionElement",
       "id" : "GENERATOR_4",
       "minimumPower" : 200.0,
       "maximumPower" : 2000.0,
+      "targetPower" : 200.0,
       "startupCost" : 200000.0,
-      "marginalCost" : 20.0
+      "marginalCost" : 20.0,
+      "generatorName" : "GENERATOR_4_name"
     } ],
     "usageRules" : [ {
       "id" : "RULE4",

--- a/data/crac-file/crac-file-api/src/test/resources/cracFileExampleTopo.json
+++ b/data/crac-file/crac-file-api/src/test/resources/cracFileExampleTopo.json
@@ -113,15 +113,19 @@
       "id" : "GENERATOR_3",
       "minimumPower" : 100.0,
       "maximumPower" : 1000.0,
+      "targetPower" : 200.0,
       "startupCost" : 100000.0,
-      "marginalCost" : 10.0
+      "marginalCost" : 10.0,
+      "generatorName" : "GENERATOR_3_name"
     }, {
       "@c" : ".RedispatchRemedialActionElement",
       "id" : "GENERATOR_4",
       "minimumPower" : 200.0,
       "maximumPower" : 2000.0,
+      "targetPower" : 2000.0,
       "startupCost" : 200000.0,
-      "marginalCost" : 20.0
+      "marginalCost" : 20.0,
+      "generatorName" : "GENERATOR_4_name"
     } ],
     "usageRules" : [ {
       "id" : "RULE4",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
no


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Complete cracFile with :
* penaltyCost for PST remedial actions
* generatorName and targetPower for redispatching remedial actions


**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*

Yes : change of cracFile data format.
"old" .json cracFile can still be imported, the new parameters will take their default value if they are not specifically given in the .json cracFile. Default values are `0` for penaltyCost and targetPower and `null` for generatorName.


**Other information**:

