### PR TITLE
Improve the search management of leaves and network variants

### DIFF
--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/Rao.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/Rao.java
@@ -66,6 +66,10 @@ public final class Rao {
             return runAsync(network, crac, LocalComputationManager.getDefault(), parameters);
         }
 
+        public CompletableFuture<RaoComputationResult> runAsync(Network network, Crac crac, String variantId) {
+            return runAsync(network, crac, variantId, LocalComputationManager.getDefault(), RaoParameters.load());
+        }
+
         public CompletableFuture<RaoComputationResult> runAsync(Network network, Crac crac) {
             return runAsync(network, crac, RaoParameters.load());
         }
@@ -84,6 +88,10 @@ public final class Rao {
 
         public RaoComputationResult run(Network network, Crac crac, RaoParameters parameters) {
             return run(network, crac, LocalComputationManager.getDefault(), parameters);
+        }
+
+        public RaoComputationResult run(Network network, Crac crac, String variantId) {
+            return run(network, crac, variantId, LocalComputationManager.getDefault(), RaoParameters.load());
         }
 
         public RaoComputationResult run(Network network, Crac crac) {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/process/search_tree/Leaf.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/process/search_tree/Leaf.java
@@ -33,19 +33,11 @@ class Leaf {
     private final Leaf parentLeaf;
 
     /**
-     * Network Action which will be tested, can be null
+     * Network Actions which will be tested (including the
+     * network actions from the parent leaves as well as from
+     * this leaf), can be empty
      */
-    private final NetworkAction networkAction;
-
-    /**
-     * Network Action list from this Leaf to root leaf
-     */
-    private final List<NetworkAction> legacyNetworkActions;
-
-    /**
-     * Name of the network variant associated with this Leaf
-     */
-    private String networkVariant;
+    private final List<NetworkAction> networkActions;
 
     /**
      * Impact of the network action
@@ -67,11 +59,9 @@ class Leaf {
     /**
      * Root Leaf constructor
      */
-    Leaf(String networkVariant) { //! constructor only for Root Leaf
+    Leaf() { //! constructor only for Root Leaf
         this.parentLeaf = null;
-        this.networkAction = null; //! root leaf has null networkaction
-        this.legacyNetworkActions = new ArrayList<>();
-        this.networkVariant = networkVariant;
+        this.networkActions = new ArrayList<>(); //! root leaf has no network action
         this.raoResult = null;
         this.status = Status.CREATED;
     }
@@ -81,9 +71,11 @@ class Leaf {
      */
     private Leaf(Leaf parentLeaf, NetworkAction networkAction) {
         this.parentLeaf = parentLeaf;
-        this.networkAction = networkAction;
-        this.legacyNetworkActions = getNetworkActionLegacy(); //init legacyNetworkActions in constructor
-        this.networkVariant = null;
+
+        List<NetworkAction> networkActionList = new ArrayList<>(parentLeaf.getNetworkActions());
+        networkActionList.add(networkAction);
+        this.networkActions = networkActionList;
+
         this.raoResult = null;
         this.status = Status.CREATED;
     }
@@ -95,8 +87,8 @@ class Leaf {
         return parentLeaf;
     }
 
-    NetworkAction getNetworkAction() {
-        return networkAction;
+    List<NetworkAction> getNetworkActions() {
+        return networkActions;
     }
 
     /**
@@ -114,13 +106,6 @@ class Leaf {
     }
 
     /**
-     * Leaf Variant getter
-     */
-    String getNetworkVariant() {
-        return networkVariant;
-    }
-
-    /**
      * Is this Leaf the initial one of the tree
      */
     boolean isRoot() {
@@ -128,32 +113,12 @@ class Leaf {
     }
 
     /**
-     * Get the list of Network Actions from the current leaf, and from its
-     * parent leaves
-     */
-    List<NetworkAction> getNetworkActionLegacy() {
-        if (this.legacyNetworkActions == null) { // first time here, need to init the list
-            List<NetworkAction> naList = new ArrayList<>();
-            if (this.networkAction != null) {
-                naList.add(this.getNetworkAction()); // add its own NetworkAction is not null (root's is null)
-            }
-            if (!this.isRoot()) {
-                naList.addAll(this.getParent().getNetworkActionLegacy()); // merge with its parent's list
-            }
-            return naList;
-        } else {
-            return this.legacyNetworkActions;
-        }
-    }
-
-    /**
      * Extend the tree from the current Leaf with N new children Leaves
      * for the N Network Actions given in argument
      */
     List<Leaf> bloom(Set<NetworkAction> availableNetworkActions) {
-        List<NetworkAction> legacy = getNetworkActionLegacy();
         return availableNetworkActions.stream().
-                filter(na -> !legacy.contains(na)).
+                filter(na -> !networkActions.contains(na)).
                 map(na -> new Leaf(this, na)).collect(Collectors.toList());
     }
 
@@ -161,29 +126,29 @@ class Leaf {
      * Evaluate the impact of Network Actions (from the current Leaf and
      * its parents)
      */
-    void evaluate(Network network, Crac crac, RaoParameters parameters) {
+    void evaluate(Network network, Crac crac, String referenceNetworkVariant, RaoParameters parameters) {
         this.status = Status.EVALUATION_RUNNING;
+        String leafNetworkVariant;
 
+        // apply Network Actions
         try {
-            // apply Network Action
-            if (!isRoot()) {
-                Objects.requireNonNull(networkAction);
-                this.networkVariant = createVariant(network, getParent().getNetworkVariant());
-                network.getVariantManager().setWorkingVariant(this.networkVariant);
-                networkAction.apply(network);
-            } else {
-                network.getVariantManager().setWorkingVariant(this.networkVariant);
-            }
+            leafNetworkVariant = createAndSwitchToNewVariant(network, referenceNetworkVariant);
+            networkActions.forEach(na -> na.apply(network));
+        } catch (FaraoException e) {
+            this.status = Status.EVALUATION_ERROR;
+            return;
+        }
 
-            // Optimize the use of Range Actions
-            RaoComputationResult results = Rao.find(getRangeActionRaoName(parameters)).run(network, crac);
-
-            // Get results
+        // Optimize the use of Range Actions
+        try {
+            RaoComputationResult results = Rao.find(getRangeActionRaoName(parameters)).run(network, crac, leafNetworkVariant);
             this.raoResult = results;
             this.status = buildStatus(results);
+            deleteVariant(network, leafNetworkVariant);
 
         } catch (FaraoException e) {
             this.status = Status.EVALUATION_ERROR;
+            deleteVariant(network, leafNetworkVariant);
         }
     }
 
@@ -195,13 +160,14 @@ class Leaf {
         return uniqueId;
     }
 
-    private String createVariant(Network network, String referenceNetworkVariant) {
+    private String createAndSwitchToNewVariant(Network network, String referenceNetworkVariant) {
         Objects.requireNonNull(referenceNetworkVariant);
         if (!network.getVariantManager().getVariantIds().contains(referenceNetworkVariant)) {
             throw new FaraoException(String.format("Unknown network variant %s", referenceNetworkVariant));
         }
         String uniqueId = getUniqueVariantId(network);
         network.getVariantManager().cloneVariant(referenceNetworkVariant, uniqueId);
+        network.getVariantManager().setWorkingVariant(uniqueId);
         return uniqueId;
     }
 
@@ -214,6 +180,12 @@ class Leaf {
             return Status.EVALUATION_SUCCESS;
         } else {
             return Status.EVALUATION_ERROR;
+        }
+    }
+
+    private void deleteVariant(Network network, String leafNetworkVariant) {
+        if (network.getVariantManager().getVariantIds().contains(leafNetworkVariant)) {
+            network.getVariantManager().removeVariant(leafNetworkVariant);
         }
     }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/process/search_tree/Tree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/process/search_tree/Tree.java
@@ -36,9 +36,9 @@ public final class Tree {
         throw new AssertionError("Utility class should not be instantiated");
     }
 
-    public static CompletableFuture<RaoComputationResult> search(Network network, Crac crac, String initialVariantId, RaoParameters parameters) {
-        Leaf optimalLeaf = new Leaf(initialVariantId);
-        optimalLeaf.evaluate(network, crac, parameters);
+    public static CompletableFuture<RaoComputationResult> search(Network network, Crac crac, String referenceNetworkVariant, RaoParameters parameters) {
+        Leaf optimalLeaf = new Leaf();
+        optimalLeaf.evaluate(network, crac, referenceNetworkVariant, parameters);
 
         if (optimalLeaf.getStatus() == Leaf.Status.EVALUATION_ERROR) {
             //TODO : improve error messages depending on leaf error (Sensi divergent, infeasible optimisation, time-out, ...)
@@ -55,7 +55,7 @@ public final class Tree {
             }
 
             //TODO: manage parallel computation
-            generatedLeaves.forEach(leaf -> leaf.evaluate(network, crac, parameters));
+            generatedLeaves.forEach(leaf -> leaf.evaluate(network, crac, referenceNetworkVariant, parameters));
 
             hasImproved = false;
             for (Leaf currentLeaf: generatedLeaves) {

--- a/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/process/search_tree/LeafTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/process/search_tree/LeafTest.java
@@ -156,4 +156,15 @@ public class LeafTest {
 
         assertEquals(Leaf.Status.EVALUATION_ERROR, rootLeaf.getStatus());
     }
+
+    @Test
+    public void evaluateWithUnknownVariantTest() {
+        Mockito.when(crac.getName()).thenReturn("CracOK");
+        String initialVariant = network.getVariantManager().getWorkingVariantId();
+
+        Leaf rootLeaf = new Leaf();
+        rootLeaf.evaluate(network, crac, "unknownVariant", raoParameters);
+
+        assertEquals(Leaf.Status.EVALUATION_ERROR, rootLeaf.getStatus());
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Based on branch `search-tree` of PR "No traversal during search tree init", and go deeper in the idea of having self-supporting Leaf object, not dependent from their parents.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Code improvment

**What is the current behavior?** *(You can also link to an open issue here)*
A Leaf is based on its parent Leaf network variant. This can be quite unstable as we de not know what the LinearRangeActionRao could do with this network variant (for instance, it could add contingencies to run LF/Sensi on the N-1 states).

**What is the new behavior (if this is a feature change)?**
A Leaf is not anymore based on its parent Leaf network variant, but build its own variant and apply to it all legacy of Network Actions. Its variant is built temporarily (only for the duration of the LinearRangeActionRao) and is not accessible anymore !


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*

No
