### PR TITLE
Repair crac json importer

### DIFF
--- a/data/crac-file/crac-io-json/src/main/java/com/farao_community/farao/data/crac_io_json/JsonImport.java
+++ b/data/crac-file/crac-io-json/src/main/java/com/farao_community/farao/data/crac_io_json/JsonImport.java
@@ -19,6 +19,7 @@ import java.io.*;
 import org.apache.commons.io.FilenameUtils;
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.loader.SchemaLoader;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 
@@ -59,9 +60,6 @@ public class JsonImport implements CracImporter {
     }
 
     private boolean validCracFile(String fileName, InputStream inputStream) {
-        JSONObject jsonSubject = new JSONObject(
-            new JSONTokener(inputStream));
-        SCHEMA_JSON.validate(jsonSubject);
         return FilenameUtils.getExtension(fileName).equals(JSON_EXTENSION);
     }
 }

--- a/data/crac-file/crac-io-json/src/main/java/com/farao_community/farao/data/crac_io_json/JsonImport.java
+++ b/data/crac-file/crac-io-json/src/main/java/com/farao_community/farao/data/crac_io_json/JsonImport.java
@@ -19,7 +19,6 @@ import java.io.*;
 import org.apache.commons.io.FilenameUtils;
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.loader.SchemaLoader;
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 

--- a/data/crac-file/crac-io-json/src/test/java/com/farao_community/farao/data/crac_io_json/JsonImportExportTest.java
+++ b/data/crac-file/crac-io-json/src/test/java/com/farao_community/farao/data/crac_io_json/JsonImportExportTest.java
@@ -195,4 +195,9 @@ public class JsonImportExportTest {
         assertEquals(crac.getNetworkActions().size(), importedCrac.getNetworkActions().size());
         assertEquals(crac.getRangeActions().size(), importedCrac.getRangeActions().size());
     }
+
+    @Test
+    public void existsNotAJsonTest() {
+        assertFalse(new JsonImport().exists("notAJson.xml", getClass().getResourceAsStream("/notAJson.xml")));
+    }
 }

--- a/data/crac-file/crac-io-json/src/test/resources/notAJson.xml
+++ b/data/crac-file/crac-io-json/src/test/resources/notAJson.xml
@@ -1,0 +1,1 @@
+<thisFileIsNotAJson v="true" />


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bugfix

**What is the current behavior?** *(You can also link to an open issue here)*
Json Crac importer was crashing when checking if a non JSON file could be imported.


**What is the new behavior (if this is a feature change)?**
No crash anymore. Json Crac importer can peacefully recognized that it cannot import a non JSON file.
