### PR TITLE
Addition of a range definition parameter to the AbsoluteFixedRanges

### DIFF
--- a/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/RangeDefinition.java
+++ b/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/RangeDefinition.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.farao_community.farao.data.crac_api;
+
+/**
+ * Definition of the range
+ *
+ * @author Viktor Terrier {@literal <viktor.terrier at rte-france.com>}
+ */
+public enum RangeDefinition {
+    CENTERED_ON_ZERO, // Taps from -x to x
+    STARTS_AT_ONE // Taps from 1 to y
+}

--- a/data/crac-file/crac-api/src/test/java/com/farao_community/farao/data/crac_api/RangeDefinitionTest.java
+++ b/data/crac-file/crac-api/src/test/java/com/farao_community/farao/data/crac_api/RangeDefinitionTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.*;
 public class RangeDefinitionTest {
 
     @Test
-    public void basicTest(){
+    public void basicTest() {
         assertEquals(2, RangeDefinition.values().length);
         RangeDefinition rangeDefinition1 = RangeDefinition.CENTERED_ON_ZERO;
         RangeDefinition rangeDefinition2 = RangeDefinition.STARTS_AT_ONE;

--- a/data/crac-file/crac-api/src/test/java/com/farao_community/farao/data/crac_api/RangeDefinitionTest.java
+++ b/data/crac-file/crac-api/src/test/java/com/farao_community/farao/data/crac_api/RangeDefinitionTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.farao_community.farao.data.crac_api;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Alexandre Montigny {@literal <alexandre.montigny at rte-france.com>}
+ */
+public class RangeDefinitionTest {
+
+    @Test
+    public void basicTest(){
+        assertEquals(2, RangeDefinition.values().length);
+        RangeDefinition rangeDefinition1 = RangeDefinition.CENTERED_ON_ZERO;
+        RangeDefinition rangeDefinition2 = RangeDefinition.STARTS_AT_ONE;
+    }
+
+}

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/range_domain/AbsoluteFixedRange.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/range_domain/AbsoluteFixedRange.java
@@ -7,6 +7,7 @@
 
 package com.farao_community.farao.data.crac_impl.range_domain;
 
+import com.farao_community.farao.data.crac_api.RangeDefinition;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.powsybl.iidm.network.Network;
@@ -18,9 +19,12 @@ import com.powsybl.iidm.network.Network;
  */
 public class AbsoluteFixedRange extends AbstractRange {
 
+    private RangeDefinition rangeDefinition;
+
     @JsonCreator
-    public AbsoluteFixedRange(@JsonProperty("min") double min, @JsonProperty("max") double max) {
+    public AbsoluteFixedRange(@JsonProperty("min") double min, @JsonProperty("max") double max, @JsonProperty("rangeDefinition") RangeDefinition rangeDefinition) {
         super(min, max);
+        this.rangeDefinition = rangeDefinition;
     }
 
     @Override
@@ -31,5 +35,13 @@ public class AbsoluteFixedRange extends AbstractRange {
     @Override
     public double getMaxValue(Network network) {
         return max;
+    }
+
+    public void setRangeDefinition(RangeDefinition rangeDefinition) {
+        this.rangeDefinition = rangeDefinition;
+    }
+
+    public RangeDefinition getRangeDefinition() {
+        return rangeDefinition;
     }
 }

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/CracFileTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/CracFileTest.java
@@ -27,6 +27,7 @@ import java.util.*;
 
 import static com.farao_community.farao.data.crac_api.ActionType.*;
 import static com.farao_community.farao.data.crac_api.Direction.*;
+import static com.farao_community.farao.data.crac_api.RangeDefinition.CENTERED_ON_ZERO;
 import static com.farao_community.farao.data.crac_api.Side.*;
 import static org.junit.Assert.*;
 
@@ -57,7 +58,7 @@ public class CracFileTest {
         RelativeDynamicRange relativeDynamicRange = new RelativeDynamicRange(0, 1);
         relativeDynamicRange.setMin(100);
         relativeDynamicRange.setMax(1000);
-        AbsoluteFixedRange absoluteFixedRange = new AbsoluteFixedRange(0, 1);
+        AbsoluteFixedRange absoluteFixedRange = new AbsoluteFixedRange(0, 1, CENTERED_ON_ZERO);
         absoluteFixedRange.setMin(10);
         absoluteFixedRange.setMax(1000);
 

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/CracFileTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/CracFileTest.java
@@ -28,6 +28,7 @@ import java.util.*;
 import static com.farao_community.farao.data.crac_api.ActionType.*;
 import static com.farao_community.farao.data.crac_api.Direction.*;
 import static com.farao_community.farao.data.crac_api.RangeDefinition.CENTERED_ON_ZERO;
+import static com.farao_community.farao.data.crac_api.RangeDefinition.STARTS_AT_ONE;
 import static com.farao_community.farao.data.crac_api.Side.*;
 import static org.junit.Assert.*;
 
@@ -61,6 +62,9 @@ public class CracFileTest {
         AbsoluteFixedRange absoluteFixedRange = new AbsoluteFixedRange(0, 1, CENTERED_ON_ZERO);
         absoluteFixedRange.setMin(10);
         absoluteFixedRange.setMax(1000);
+        if (absoluteFixedRange.getRangeDefinition().equals(CENTERED_ON_ZERO)) {
+            absoluteFixedRange.setRangeDefinition(STARTS_AT_ONE);
+        }
 
         // PstRange
         NetworkElement pst1 = new NetworkElement("idPst1", "My Pst 1");

--- a/data/crac-file/crac-io-json/src/main/resources/CracSchema.json
+++ b/data/crac-file/crac-io-json/src/main/resources/CracSchema.json
@@ -44,10 +44,6 @@
         "type" : "object",
         "id" : "urn:jsonschema:com:farao_community:farao:data:crac_api:Cnec",
         "properties" : {
-          "criticalNetworkElement" : {
-            "type" : "object",
-            "$ref" : "urn:jsonschema:com:farao_community:farao:data:crac_api:NetworkElement"
-          },
           "state" : {
             "type" : "object",
             "id" : "urn:jsonschema:com:farao_community:farao:data:crac_api:State",
@@ -60,7 +56,7 @@
                     "type" : "string"
                   },
                   "seconds" : {
-                    "type" : "number"
+                    "type" : "integer"
                   },
                   "name" : {
                     "type" : "string"
@@ -88,6 +84,14 @@
               }
             }
           },
+          "criticalNetworkElement" : {
+            "type" : "object",
+            "$ref" : "urn:jsonschema:com:farao_community:farao:data:crac_api:NetworkElement"
+          },
+          "threshold" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:com:farao_community:farao:data:crac_api:Threshold"
+          },
           "name" : {
             "type" : "string"
           },
@@ -103,21 +107,25 @@
         "type" : "object",
         "id" : "urn:jsonschema:com:farao_community:farao:data:crac_api:RangeAction",
         "properties" : {
-          "operator" : {
-            "type" : "string"
-          },
           "usageRules" : {
             "type" : "array",
             "items" : {
               "type" : "object",
               "id" : "urn:jsonschema:com:farao_community:farao:data:crac_api:UsageRule",
               "properties" : {
+                "state" : {
+                  "type" : "object",
+                  "$ref" : "urn:jsonschema:com:farao_community:farao:data:crac_api:State"
+                },
                 "usageMethod" : {
                   "type" : "string",
                   "enum" : [ "FORCED", "AVAILABLE", "UNAVAILABLE" ]
                 }
               }
             }
+          },
+          "operator" : {
+            "type" : "string"
           },
           "name" : {
             "type" : "string"
@@ -134,15 +142,15 @@
         "type" : "object",
         "id" : "urn:jsonschema:com:farao_community:farao:data:crac_api:NetworkAction",
         "properties" : {
-          "operator" : {
-            "type" : "string"
-          },
           "usageRules" : {
             "type" : "array",
             "items" : {
               "type" : "object",
               "$ref" : "urn:jsonschema:com:farao_community:farao:data:crac_api:UsageRule"
             }
+          },
+          "operator" : {
+            "type" : "string"
           },
           "name" : {
             "type" : "string"
@@ -152,10 +160,6 @@
           }
         }
       }
-    },
-    "preventiveState" : {
-      "type" : "object",
-      "$ref" : "urn:jsonschema:com:farao_community:farao:data:crac_api:State"
     }
   }
 }

--- a/data/crac-file/crac-io-json/src/test/java/com/farao_community/farao/data/crac_io_json/JsonImportExportTest.java
+++ b/data/crac-file/crac-io-json/src/test/java/com/farao_community/farao/data/crac_io_json/JsonImportExportTest.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 
 import static com.farao_community.farao.data.crac_api.ActionType.*;
 import static com.farao_community.farao.data.crac_api.Direction.*;
+import static com.farao_community.farao.data.crac_api.RangeDefinition.STARTS_AT_ONE;
 import static com.farao_community.farao.data.crac_api.Side.*;
 import static org.junit.Assert.*;
 
@@ -58,7 +59,7 @@ public class JsonImportExportTest {
         RelativeDynamicRange relativeDynamicRange = new RelativeDynamicRange(0, 1);
         relativeDynamicRange.setMin(100);
         relativeDynamicRange.setMax(1000);
-        AbsoluteFixedRange absoluteFixedRange = new AbsoluteFixedRange(0, 1);
+        AbsoluteFixedRange absoluteFixedRange = new AbsoluteFixedRange(0, 1, STARTS_AT_ONE);
         absoluteFixedRange.setMin(10);
         absoluteFixedRange.setMax(1000);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
The information about the range definition (from 1 to y, from -x to x) is now saved in the CRAC, so that various formats can be imported, without knowing the network at the import.
