### PR TITLE
Unit conversion in thresholds

### DIFF
--- a/data/crac-file/crac-api/pom.xml
+++ b/data/crac-file/crac-api/pom.xml
@@ -16,6 +16,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>farao-commons</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-commons</artifactId>
         </dependency>
@@ -23,13 +28,10 @@
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
-
 </project>

--- a/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Cnec.java
+++ b/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Cnec.java
@@ -28,7 +28,5 @@ public interface Cnec extends Identifiable, Synchronizable {
 
     Threshold getThreshold();
 
-    boolean isMinThresholdViolated(Network network) throws SynchronizationException;
-
-    boolean isMaxThresholdViolated(Network network) throws SynchronizationException;
+    boolean isThresholdViolated(Network network) throws SynchronizationException;
 }

--- a/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/PhysicalParameter.java
+++ b/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/PhysicalParameter.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.farao_community.farao.data.crac_api;
+
+/**
+ * Enum of physical parameters that can be monitored in the Critical
+ * Network Elements.
+ *
+ * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com>}
+ */
+public enum PhysicalParameter {
+    FLOW,
+    ANGLE,
+    VOLTAGE
+}

--- a/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
+++ b/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
@@ -31,11 +31,12 @@ import java.util.Optional;
 public interface Threshold {
 
     /**
-     * A Threshold is based on a given Unit (MEGAWATT, AMPERE, DEGREE or
-     * KILOVOLT). This Unit can be retrieved by the getUnit() method.
+     * A Threshold consists in monitoring a given physical value (FLOW, VOLTAGE
+     * or ANGLE). This physical value can be retrieved by the getPhysicalParameter()
+     * method.
      */
-    @Deprecated
-    Unit getUnit();
+    @JsonIgnore
+    PhysicalParameter getPhysicalParameter();
 
     /**
      * If it is defined, this function returns the minimum limit of the Threshold,

--- a/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
+++ b/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
@@ -39,18 +39,6 @@ public interface Threshold {
     PhysicalParameter getPhysicalParameter();
 
     /**
-     * If it is defined, this function returns the minimum limit of the Threshold,
-     * below which a Cnec cannot be operated securely. Otherwise, this function
-     * returns an empty Optional, which implicitly means that the Threshold is
-     * unbounded below.
-     * The returned value is given with the unit of measure of the Threshold.
-     * @deprecated to avoid any confusion with Threshold units
-     */
-    @JsonIgnore
-    @Deprecated
-    Optional<Double> getMinThreshold() throws SynchronizationException;
-
-    /**
      * If it is defined, this function returns the maximum limit of the Threshold,
      * below which a Cnec cannot be operated securely. Otherwise, this function
      * returns an empty Optional, which implicitly means that the Threshold is
@@ -63,18 +51,6 @@ public interface Threshold {
     /**
      * If it is defined, this function returns the maximum limit of the Threshold,
      * below which a Cnec cannot be operated securely. Otherwise, this function
-     * returns an empty Optional, which implicitly means that the Threshold is
-     * unbounded above.
-     * The returned value is given with the unit of measure of the Threshold.
-     * @deprecated to avoid any confusion with Threshold units
-     */
-    @JsonIgnore
-    @Deprecated
-    Optional<Double> getMaxThreshold() throws SynchronizationException;
-
-    /**
-     * If it is defined, this function returns the maximum limit of the Threshold,
-     * above which a Cnec cannot be operated securely. Otherwise, this function
      * returns an empty Optional, which implicitly means that the Threshold is
      * unbounded above.
      * The returned value is given with the unit given in argument of the function.

--- a/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
+++ b/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
@@ -14,30 +14,92 @@ import com.powsybl.iidm.network.Network;
 import java.util.Optional;
 
 /**
+ * The threshold describes the monitored physical parameter of a Cnec (flow, voltage
+ * or angle), as well as the domain within which the Cnec can be operated securely. This
+ * domain is defined by a min and/or a max. If the two are defined, the secure operating
+ * range of the Cnec is [min, max], otherwise it is [-infinity, max] or [min, +infinity].
+ *
+ * Some Threshold need to be synchronized with a Network to be fully defined (for instance,
+ * a Threshold defined as a percentage of a maximum Network limit). If a Threshold is not
+ * synchronised, most of its method can throw SynchronizationExceptions.
+ *
  * @author Joris Mancini {@literal <joris.mancini at rte-france.com>}
+ * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com>}
+ * @author Viktor Terrier {@literal <viktor.terrier at rte-france.com>}
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS)
 public interface Threshold {
 
-    @JsonIgnore
-    Optional<Double> getMinThreshold() throws SynchronizationException;
-
-    @JsonIgnore
-    Optional<Double> getMinThreshold(Unit unit) throws SynchronizationException;
-
-    @JsonIgnore
-    Optional<Double> getMaxThreshold() throws SynchronizationException;
-
-    @JsonIgnore
-    Optional<Double> getMaxThreshold(Unit unit) throws SynchronizationException;
-
+    /**
+     * A Threshold is based on a given Unit (MEGAWATT, AMPERE, DEGREE or
+     * KILOVOLT). This Unit can be retrieved by the getUnit() method.
+     */
     @JsonIgnore
     Unit getUnit();
 
+    /**
+     * If it is defined, this function returns the minimum limit of the Threshold,
+     * below which a Cnec cannot be operated securely. Otherwise, this function
+     * returns an empty Optional, which implicitly means that the Threshold is
+     * unbounded below.
+     * The returned value is given with the unit of measure of the Threshold,
+     * which can be obtained with getUnit().
+     */
+    @JsonIgnore
+    Optional<Double> getMinThreshold() throws SynchronizationException;
+
+    /**
+     * If it is defined, this function returns the maximum limit of the Threshold,
+     * above which a Cnec cannot be operated securely. Otherwise, this function
+     * returns an empty Optional, which implicitly means that the Threshold is
+     * unbounded above.
+     * The returned value is given with the Unit given in argument of the function.
+     */
+    @JsonIgnore
+    Optional<Double> getMinThreshold(Unit unit) throws SynchronizationException;
+
+    /**
+     * If it is defined, this function returns the maximum limit of the Threshold,
+     * above which a Cnec cannot be operated securely. Otherwise, this function
+     * returns an empty Optional, which implicitly means that the Threshold is
+     * unbounded above.
+     * The returned value is given with the unit of measure of the Threshold,
+     * which can be obtained with getUnit().
+     */
+    @JsonIgnore
+    Optional<Double> getMaxThreshold() throws SynchronizationException;
+
+    /**
+     * If it is defined, this function returns the maximum limit of the Threshold,
+     * above which a Cnec cannot be operated securely. Otherwise, this function
+     * returns an empty Optional, which implicitly means that the Threshold is
+     * unbounded above.
+     * The returned value is given with the unit given in argument of the function.
+     */
+    @JsonIgnore
+    Optional<Double> getMaxThreshold(Unit unit) throws SynchronizationException;
+
+    /**
+     * This function returns, for a given Network situation, a boolean which specify
+     * whether or not the minimum limit of the Threshold has been overcome.
+     */
     boolean isMinThresholdOvercome(Network network, Cnec cnec) throws SynchronizationException;
 
+    /**
+     * This function returns, for a given Network situation, a boolean which specify
+     * whether or not the minimum limit of the Threshold has been overcome.
+     */
     boolean isMaxThresholdOvercome(Network network, Cnec cnec) throws SynchronizationException;
 
+    /**
+     * This function returns, for a given Network situation, the margin of the Threshold.
+     * The margin is the distance, given with the unit of measure of the Threshold, from
+     * the actual monitored physical parameter of a Cnec to the Threshold limits. If it is
+     * positive, it means that the limits of the Threshold are respected. If it is negative,
+     * it means that that a limit of the Threshold has been overcome.
+     *
+     * margin = min(maxThreshold - actualValue, actualValue - minThreshold)
+     */
     double computeMargin(Network network, Cnec cnec) throws SynchronizationException;
 
     void synchronize(Network network, Cnec cnec);

--- a/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
+++ b/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
@@ -23,7 +23,16 @@ public interface Threshold {
     Optional<Double> getMinThreshold() throws SynchronizationException;
 
     @JsonIgnore
+    Optional<Double> getMinThreshold(Unit unit) throws SynchronizationException;
+
+    @JsonIgnore
     Optional<Double> getMaxThreshold() throws SynchronizationException;
+
+    @JsonIgnore
+    Optional<Double> getMaxThreshold(Unit unit) throws SynchronizationException;
+
+    @JsonIgnore
+    Unit getUnit();
 
     boolean isMinThresholdOvercome(Network network, Cnec cnec) throws SynchronizationException;
 

--- a/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
+++ b/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
@@ -52,7 +52,7 @@ public interface Threshold {
 
     /**
      * If it is defined, this function returns the maximum limit of the Threshold,
-     * above which a Cnec cannot be operated securely. Otherwise, this function
+     * below which a Cnec cannot be operated securely. Otherwise, this function
      * returns an empty Optional, which implicitly means that the Threshold is
      * unbounded above.
      * The returned value is given with the Unit given in argument of the function.
@@ -62,7 +62,7 @@ public interface Threshold {
 
     /**
      * If it is defined, this function returns the maximum limit of the Threshold,
-     * above which a Cnec cannot be operated securely. Otherwise, this function
+     * below which a Cnec cannot be operated securely. Otherwise, this function
      * returns an empty Optional, which implicitly means that the Threshold is
      * unbounded above.
      * The returned value is given with the unit of measure of the Threshold.

--- a/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
+++ b/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
@@ -43,8 +43,8 @@ public interface Threshold {
      * below which a Cnec cannot be operated securely. Otherwise, this function
      * returns an empty Optional, which implicitly means that the Threshold is
      * unbounded below.
-     * The returned value is given with the unit of measure of the Threshold,
-     * which can be obtained with getUnit().
+     * The returned value is given with the unit of measure of the Threshold.
+     * @deprecated to avoid any confusion with Threshold units
      */
     @JsonIgnore
     @Deprecated
@@ -65,8 +65,8 @@ public interface Threshold {
      * above which a Cnec cannot be operated securely. Otherwise, this function
      * returns an empty Optional, which implicitly means that the Threshold is
      * unbounded above.
-     * The returned value is given with the unit of measure of the Threshold,
-     * which can be obtained with getUnit().
+     * The returned value is given with the unit of measure of the Threshold.
+     * @deprecated to avoid any confusion with Threshold units
      */
     @JsonIgnore
     @Deprecated

--- a/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
+++ b/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
@@ -34,7 +34,6 @@ public interface Threshold {
      * A Threshold is based on a given Unit (MEGAWATT, AMPERE, DEGREE or
      * KILOVOLT). This Unit can be retrieved by the getUnit() method.
      */
-    @JsonIgnore
     Unit getUnit();
 
     /**

--- a/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
+++ b/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
@@ -86,7 +86,7 @@ public interface Threshold {
 
     /**
      * This function returns, for a given Network situation, a boolean which specify
-     * whether or not the minimum limit of the Threshold has been overcome.
+     * whether or not the maximum limit of the Threshold has been overcome.
      */
     boolean isMaxThresholdOvercome(Network network, Cnec cnec) throws SynchronizationException;
 

--- a/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
+++ b/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
@@ -34,6 +34,7 @@ public interface Threshold {
      * A Threshold is based on a given Unit (MEGAWATT, AMPERE, DEGREE or
      * KILOVOLT). This Unit can be retrieved by the getUnit() method.
      */
+    @Deprecated
     Unit getUnit();
 
     /**
@@ -45,6 +46,7 @@ public interface Threshold {
      * which can be obtained with getUnit().
      */
     @JsonIgnore
+    @Deprecated
     Optional<Double> getMinThreshold() throws SynchronizationException;
 
     /**
@@ -66,6 +68,7 @@ public interface Threshold {
      * which can be obtained with getUnit().
      */
     @JsonIgnore
+    @Deprecated
     Optional<Double> getMaxThreshold() throws SynchronizationException;
 
     /**

--- a/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Unit.java
+++ b/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Unit.java
@@ -27,7 +27,7 @@ public enum Unit {
         this.physicalParameter = physicalParameter;
     }
 
-    public PhysicalParameter physicalParameter() {
+    public PhysicalParameter getPhysicalParameter() {
         return physicalParameter;
     }
 

--- a/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Unit.java
+++ b/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Unit.java
@@ -27,6 +27,7 @@ public enum Unit {
         this.physicalParameter = physicalParameter;
     }
 
+    @Override
     public String toString() {
         return name;
     }

--- a/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Unit.java
+++ b/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Unit.java
@@ -8,13 +8,30 @@
 package com.farao_community.farao.data.crac_api;
 
 /**
- * Units
+ * Physical units
  *
+ * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com>}
  * @author Viktor Terrier {@literal <viktor.terrier at rte-france.com>}
  */
 public enum Unit {
-    AMPERE,
-    DEGREE,
-    MEGAWATT,
-    KILOVOLT
+    AMPERE("AMPERE", PhysicalParameter.FLOW),
+    DEGREE("DEGREE", PhysicalParameter.ANGLE),
+    MEGAWATT("MEGAWATT", PhysicalParameter.FLOW),
+    KILOVOLT("KILOVOLT", PhysicalParameter.VOLTAGE);
+
+    private String name;
+    private PhysicalParameter physicalParameter;
+
+    Unit(String name, PhysicalParameter physicalParameter) {
+        this.name = name;
+        this.physicalParameter = physicalParameter;
+    }
+
+    public String toString() {
+        return name;
+    }
+
+    public PhysicalParameter physicalParameter() {
+        return physicalParameter;
+    }
 }

--- a/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Unit.java
+++ b/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Unit.java
@@ -7,6 +7,8 @@
 
 package com.farao_community.farao.data.crac_api;
 
+import com.farao_community.farao.commons.FaraoException;
+
 /**
  * Physical units
  *
@@ -14,25 +16,24 @@ package com.farao_community.farao.data.crac_api;
  * @author Viktor Terrier {@literal <viktor.terrier at rte-france.com>}
  */
 public enum Unit {
-    AMPERE("AMPERE", PhysicalParameter.FLOW),
-    DEGREE("DEGREE", PhysicalParameter.ANGLE),
-    MEGAWATT("MEGAWATT", PhysicalParameter.FLOW),
-    KILOVOLT("KILOVOLT", PhysicalParameter.VOLTAGE);
+    AMPERE(PhysicalParameter.FLOW),
+    DEGREE(PhysicalParameter.ANGLE),
+    MEGAWATT(PhysicalParameter.FLOW),
+    KILOVOLT(PhysicalParameter.VOLTAGE);
 
-    private String name;
     private PhysicalParameter physicalParameter;
 
-    Unit(String name, PhysicalParameter physicalParameter) {
-        this.name = name;
+    Unit(PhysicalParameter physicalParameter) {
         this.physicalParameter = physicalParameter;
-    }
-
-    @Override
-    public String toString() {
-        return name;
     }
 
     public PhysicalParameter physicalParameter() {
         return physicalParameter;
+    }
+
+    public void checkPhysicalParameter(PhysicalParameter requestedPhysicalParameter) {
+        if (!requestedPhysicalParameter.equals(physicalParameter)) {
+            throw new FaraoException(String.format("%s Unit is not suited to measure a %s value.", this.toString(), requestedPhysicalParameter.toString()));
+        }
     }
 }

--- a/data/crac-file/crac-api/src/test/java/com/farao_community/farao/data/crac_api/UnitTest.java
+++ b/data/crac-file/crac-api/src/test/java/com/farao_community/farao/data/crac_api/UnitTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.farao_community.farao.data.crac_api;
+
+import com.farao_community.farao.commons.FaraoException;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+/**
+ * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com>}
+ */
+public class UnitTest {
+
+    @Test
+    public void checkPhysicalParameterTestOk() {
+        Unit.AMPERE.checkPhysicalParameter(PhysicalParameter.FLOW);
+        Unit.DEGREE.checkPhysicalParameter(PhysicalParameter.ANGLE);
+        Unit.KILOVOLT.checkPhysicalParameter(PhysicalParameter.VOLTAGE);
+        Unit.MEGAWATT.checkPhysicalParameter(PhysicalParameter.FLOW);
+    }
+
+    @Test
+    public void checkPhysicalParameterTestNok() {
+
+        try {
+            Unit.AMPERE.checkPhysicalParameter(PhysicalParameter.ANGLE);
+            fail();
+        } catch (FaraoException e) {
+            // should throw
+        }
+
+        try {
+            Unit.DEGREE.checkPhysicalParameter(PhysicalParameter.VOLTAGE);
+            fail();
+        } catch (FaraoException e) {
+            // should throw
+        }
+
+        try {
+            Unit.KILOVOLT.checkPhysicalParameter(PhysicalParameter.FLOW);
+            fail();
+        } catch (FaraoException e) {
+            // should throw
+        }
+
+        try {
+            Unit.MEGAWATT.checkPhysicalParameter(PhysicalParameter.VOLTAGE);
+            fail();
+        } catch (FaraoException e) {
+            // should throw
+        }
+    }
+}

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnec.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnec.java
@@ -78,13 +78,8 @@ public class SimpleCnec extends AbstractIdentifiable implements Cnec {
     }
 
     @Override
-    public boolean isMinThresholdViolated(Network network) throws SynchronizationException {
-        return threshold.isMinThresholdOvercome(network, this);
-    }
-
-    @Override
-    public boolean isMaxThresholdViolated(Network network) throws SynchronizationException {
-        return threshold.isMaxThresholdOvercome(network, this);
+    public boolean isThresholdViolated(Network network) throws SynchronizationException {
+        return threshold.isMaxThresholdOvercome(network, this) || threshold.isMinThresholdOvercome(network, this);
     }
 
     @Override

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThreshold.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThreshold.java
@@ -7,12 +7,11 @@
 
 package com.farao_community.farao.data.crac_impl.threshold;
 
+import com.farao_community.farao.commons.FaraoException;
 import com.farao_community.farao.data.crac_api.*;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
-import java.util.Optional;
 
 /**
  * Limits of a flow (in MEGAWATT or AMPERE) through a branch. Given as
@@ -31,12 +30,15 @@ public class AbsoluteFlowThreshold extends AbstractFlowThreshold {
                                  @JsonProperty("direction") Direction direction,
                                  @JsonProperty("maxValue") double maxValue) {
         super(unit, side, direction);
+        if (maxValue < 0) {
+            throw new FaraoException("MaxValue of AbsoluteFlowThresholds must be positive.");
+        }
         this.maxValue = maxValue;
     }
 
     @Override
-    public Optional<Double> getMaxThreshold() {
-        return Optional.of(maxValue);
+    protected double getAbsoluteMax() {
+        return maxValue;
     }
 
     @Override

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThreshold.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThreshold.java
@@ -39,6 +39,25 @@ public class AbsoluteFlowThreshold extends AbstractFlowThreshold {
     }
 
     @Override
+    public Optional<Double> getMaxThreshold(Unit unit) throws SynchronizationException {
+        if (unit == this.unit) {
+            return getMaxThreshold();
+        } else {
+            if (getMaxThreshold().isPresent()) {
+                if (unit.equals(Unit.AMPERE)) {
+                    return Optional.of(convertMwToAmps(getMaxThreshold().get()));
+                } else if (unit.equals(Unit.MEGAWATT)) {
+                    return Optional.of(convertAmpsToMw(getMaxThreshold().get()));
+                } else {
+                    throw new FaraoException("Unit of voltage threshold should be A or MW.");
+                }
+            } else {
+                return Optional.empty();
+            }
+        }
+    }
+
+    @Override
     public boolean isMinThresholdOvercome(Network network, Cnec cnec) {
         return false;
     }
@@ -64,10 +83,12 @@ public class AbsoluteFlowThreshold extends AbstractFlowThreshold {
 
     @Override
     public void synchronize(Network network, Cnec cnec) {
+        voltageLevel = Optional.of(network.getBranch(cnec.getCriticalNetworkElement().getId()).getTerminal(getBranchSide()).getVoltageLevel().getNominalV());
     }
 
     @Override
     public void desynchronize() {
+        voltageLevel = Optional.empty();
     }
 
     @Override

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
@@ -18,9 +18,12 @@ import com.powsybl.iidm.network.Terminal;
 import java.util.Optional;
 
 /**
+ * Limits of a flow (in MEGAWATT or AMPERE) through a branch.
+ *
  * @author Joris Mancini {@literal <joris.mancini at rte-france.com>}
+ * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com>}
+ * @author Viktor Terrier {@literal <viktor.terrier at rte-france.com>}
  */
-
 @JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS)
 @JsonSubTypes(
     {
@@ -29,45 +32,35 @@ import java.util.Optional;
     })
 public abstract class AbstractFlowThreshold extends AbstractThreshold {
 
+    /**
+     * Side of the network element which is monitored
+     */
     protected Side side;
+
+    /**
+     * Direction in which the flow is monitored
+     */
     protected Direction direction;
+
+    /**
+     * maximum admissible flow value
+     */
     protected double maxValue;
-    protected Optional<Double> voltageLevel;
 
-    protected Branch.Side getBranchSide() {
-        // TODO: manage matching between LEFT/RIGHT and ONE/TWO
-        if (side.equals(Side.LEFT)) {
-            return Branch.Side.ONE;
-        } else if (side.equals(Side.RIGHT)) {
-            return Branch.Side.TWO;
-        } else {
-            throw new FaraoException("Side is not defined");
-        }
-    }
-
-    protected double convertMwToAmps(double valueInMw) throws SynchronizationException {
-        if (voltageLevel.isPresent()) {
-            double ratio = voltageLevel.get() * Math.sqrt(3) / 1000;
-            return valueInMw / ratio;
-        } else {
-            throw new SynchronizationException("Voltage level is not defined.");
-        }
-    }
-
-    protected double convertAmpsToMw(double valueInA) throws SynchronizationException {
-        if (voltageLevel.isPresent()) {
-            double ratio = voltageLevel.get() * Math.sqrt(3) / 1000;
-            return valueInA * ratio;
-        } else {
-            throw new SynchronizationException("Voltage level is not defined.");
-        }
-    }
+    /**
+     * voltage level of the network element
+     */
+    protected double voltageLevel;
 
     public AbstractFlowThreshold(Unit unit, Side side, Direction direction) {
         super(unit);
+        if (!unit.equals(Unit.AMPERE) && !unit.equals(Unit.MEGAWATT)) {
+            throw new FaraoException(String.format("Unit of flow threshold can only be AMPERE or MEGAWATT, %s is not a valid value", unit.toString()));
+        }
         this.side = side;
         this.direction = direction;
         this.maxValue = Double.NaN;
+        this.voltageLevel = Double.NaN;
     }
 
     public Direction getDirection() {
@@ -94,6 +87,17 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
         this.side = side;
     }
 
+    protected Branch.Side getBranchSide() {
+        // TODO: manage matching between LEFT/RIGHT and ONE/TWO
+        if (side.equals(Side.LEFT)) {
+            return Branch.Side.ONE;
+        } else if (side.equals(Side.RIGHT)) {
+            return Branch.Side.TWO;
+        } else {
+            throw new FaraoException("Side is not defined");
+        }
+    }
+
     private Terminal getTerminal(Network network, Cnec cnec) {
         return network.getBranch(cnec.getCriticalNetworkElement().getId()).getTerminal(getBranchSide());
     }
@@ -103,7 +107,7 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
         return !branch.getTerminal1().isConnected() || !branch.getTerminal2().isConnected();
     }
 
-    protected double getI(Network network, Cnec cnec) {
+    private double getI(Network network, Cnec cnec) {
         double i = isCnecDisconnected(network, cnec) ? 0 : getTerminal(network, cnec).getI();
         if (Double.isNaN(i)) {
             throw new FaraoException(String.format("No intensity (I) data available for CNEC %s", cnec.getName()));
@@ -111,12 +115,49 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
         return i;
     }
 
-    protected double getP(Network network, Cnec cnec) {
+    private double getP(Network network, Cnec cnec) {
         double p = isCnecDisconnected(network, cnec) ? 0 : getTerminal(network, cnec).getP();
         if (Double.isNaN(p)) {
             throw new FaraoException(String.format("No transmitted power (P) data available for CNEC %s", cnec.getName()));
         }
         return p;
+    }
+
+    private double convertMwToAmps(double valueInMw) throws SynchronizationException {
+        if (!Double.isNaN(voltageLevel)) {
+            double ratio = voltageLevel * Math.sqrt(3) / 1000;
+            return valueInMw / ratio;
+        } else {
+            throw new SynchronizationException("Voltage level has not been synchronised.");
+        }
+    }
+
+    protected double convertAmpsToMw(double valueInA) throws SynchronizationException {
+        if (!Double.isNaN(voltageLevel)) {
+            double ratio = voltageLevel * Math.sqrt(3) / 1000;
+            return valueInA * ratio;
+        } else {
+            throw new SynchronizationException("Voltage level has not been synchronised.");
+        }
+    }
+
+    @Override
+    public Optional<Double> getMaxThreshold(Unit unit) throws SynchronizationException {
+        if (unit == this.unit) {
+            return getMaxThreshold();
+        }
+        if (!getMaxThreshold().isPresent()) {
+            return Optional.empty();
+        }
+        if (unit.equals(Unit.AMPERE)) {
+            // get AMPERE from a threshold in MEGAWATT
+            return Optional.of(convertMwToAmps(getMaxThreshold().get()));
+        } else if (unit.equals(Unit.MEGAWATT)) {
+            // get MEGAWATT from a threshold in AMPERE
+            return Optional.of(convertAmpsToMw(getMaxThreshold().get()));
+        } else {
+            throw new FaraoException(String.format("Unit of flow threshold can only be AMPERE or MEGAWATT, %s is not a valid value", unit.toString()));
+        }
     }
 
     @Override
@@ -127,6 +168,40 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
     @Override
     public Optional<Double> getMinThreshold(Unit unit) {
         return Optional.empty();
+    }
+
+    @Override
+    public boolean isMinThresholdOvercome(Network network, Cnec cnec) {
+        return false;
+    }
+
+    @Override
+    public boolean isMaxThresholdOvercome(Network network, Cnec cnec) throws SynchronizationException {
+        return computeMargin(network, cnec) < 0;
+    }
+
+    @Override
+    public double computeMargin(Network network, Cnec cnec) throws SynchronizationException {
+        switch (unit) {
+            case AMPERE:
+                return maxValue - getI(network, cnec);
+            case MEGAWATT:
+                return maxValue - getP(network, cnec);
+            case DEGREE:
+            case KILOVOLT:
+            default:
+                throw new FaraoException(String.format("Unit of flow threshold can only be AMPERE or MEGAWATT, %s is not a valid value", unit.toString()));
+        }
+    }
+
+    @Override
+    public void synchronize(Network network, Cnec cnec) {
+        voltageLevel = network.getBranch(cnec.getCriticalNetworkElement().getId()).getTerminal(getBranchSide()).getVoltageLevel().getNominalV();
+    }
+
+    @Override
+    public void desynchronize() {
+        voltageLevel = Double.NaN;
     }
 
     @Override

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
@@ -54,9 +54,7 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
 
     public AbstractFlowThreshold(Unit unit, Side side, Direction direction) {
         super(unit);
-        if (!unit.physicalParameter().equals(PhysicalParameter.FLOW)) {
-            throw new FaraoException(String.format("Unit of flow threshold can only be AMPERE, MEGAWATT or PERCENTAGE_OF_IMAX. %s is not a valid value", unit.toString()));
-        }
+        unit.checkPhysicalParameter(PhysicalParameter.FLOW);
         this.side = side;
         this.direction = direction;
         this.maxValue = Double.NaN;
@@ -228,9 +226,7 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
      * Flow(MW) = Flow(A) * sqrt(3) * Unom (kV) / 1000
      */
     private double convert(double value, Unit originUnit, Unit requestedUnit) throws SynchronizationException {
-        if (!requestedUnit.physicalParameter().equals(PhysicalParameter.FLOW)) {
-            throw new FaraoException(String.format("FlowThreshold can only be requested in AMPERE or MEGAWATT. %s is not a valid unit.", requestedUnit.toString()));
-        }
+        requestedUnit.checkPhysicalParameter(PhysicalParameter.FLOW);
         if (originUnit.equals(requestedUnit)) {
             return value;
         }

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
@@ -67,23 +67,9 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
     }
 
     @Override
-    @Deprecated
-    public Optional<Double> getMinThreshold() throws SynchronizationException {
-        // TODO : handle cases where direction != Direction.BOTH
-        return Optional.of(-getAbsoluteMax());
-    }
-
-    @Override
     public Optional<Double> getMinThreshold(Unit requestedUnit) throws SynchronizationException {
         // TODO : handle cases where direction != Direction.BOTH
         return Optional.of(-convert(getAbsoluteMax(), unit, requestedUnit));
-    }
-
-    @Override
-    @Deprecated
-    public Optional<Double> getMaxThreshold() throws SynchronizationException {
-        // TODO : handle cases where direction != Direction.BOTH
-        return Optional.of(getAbsoluteMax());
     }
 
     @Override

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
@@ -101,7 +101,7 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
         } else {
             flow = getP(network, cnec);
         }
-        return flow < getMinThreshold(unit).orElse(Double.MIN_VALUE);
+        return flow < getMinThreshold(unit).orElse(Double.NEGATIVE_INFINITY);
     }
 
     @Override
@@ -113,7 +113,7 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
         } else {
             flow = getP(network, cnec);
         }
-        return flow > getMaxThreshold(unit).orElse(Double.MAX_VALUE);
+        return flow > getMaxThreshold(unit).orElse(Double.POSITIVE_INFINITY);
     }
 
     @Override
@@ -231,7 +231,7 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
             return value;
         }
         if (Double.isNaN(voltageLevel)) {
-            throw new SynchronizationException("FlowThreshold unit convesion : voltage level must be synchronised with a Network");
+            throw new SynchronizationException("FlowThreshold unit conversion : voltage level must be synchronised with a Network");
         }
         double ratio = voltageLevel * Math.sqrt(3) / 1000;
         if (originUnit.equals(Unit.AMPERE) && requestedUnit.equals(Unit.MEGAWATT)) {

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
@@ -146,19 +146,17 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
         if (unit == this.unit) {
             return getMaxThreshold();
         }
-        if (!getMaxThreshold().isPresent()) {
-            return Optional.empty();
+        Optional<Double> maxInNativeUnit = getMaxThreshold();
+        if (unit.equals(Unit.AMPERE)) {
+            // get AMPERE from a threshold in MEGAWATT
+            return maxInNativeUnit.isPresent() ? Optional.of(convertMwToAmps(maxInNativeUnit.get())) : Optional.empty();
+        } else if (unit.equals(Unit.MEGAWATT)) {
+            // get MEGAWATT from a threshold in AMPERE
+            return maxInNativeUnit.isPresent() ? Optional.of(convertAmpsToMw(maxInNativeUnit.get())) : Optional.empty();
         } else {
-            if (unit.equals(Unit.AMPERE)) {
-                // get AMPERE from a threshold in MEGAWATT
-                return Optional.of(convertMwToAmps(getMaxThreshold().get()));
-            } else if (unit.equals(Unit.MEGAWATT)) {
-                // get MEGAWATT from a threshold in AMPERE
-                return Optional.of(convertAmpsToMw(getMaxThreshold().get()));
-            } else {
-                throw new FaraoException(String.format("Unit of flow threshold can only be AMPERE or MEGAWATT, %s is not a valid value", unit.toString()));
-            }
+            throw new FaraoException(String.format("Unit of flow threshold can only be AMPERE or MEGAWATT, %s is not a valid value", unit.toString()));
         }
+
     }
 
     @Override

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
@@ -148,15 +148,16 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
         }
         if (!getMaxThreshold().isPresent()) {
             return Optional.empty();
-        }
-        if (unit.equals(Unit.AMPERE)) {
-            // get AMPERE from a threshold in MEGAWATT
-            return Optional.of(convertMwToAmps(getMaxThreshold().get()));
-        } else if (unit.equals(Unit.MEGAWATT)) {
-            // get MEGAWATT from a threshold in AMPERE
-            return Optional.of(convertAmpsToMw(getMaxThreshold().get()));
         } else {
-            throw new FaraoException(String.format("Unit of flow threshold can only be AMPERE or MEGAWATT, %s is not a valid value", unit.toString()));
+            if (unit.equals(Unit.AMPERE)) {
+                // get AMPERE from a threshold in MEGAWATT
+                return Optional.of(convertMwToAmps(getMaxThreshold().get()));
+            } else if (unit.equals(Unit.MEGAWATT)) {
+                // get MEGAWATT from a threshold in AMPERE
+                return Optional.of(convertAmpsToMw(getMaxThreshold().get()));
+            } else {
+                throw new FaraoException(String.format("Unit of flow threshold can only be AMPERE or MEGAWATT, %s is not a valid value", unit.toString()));
+            }
         }
     }
 

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThreshold.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThreshold.java
@@ -43,7 +43,7 @@ public class RelativeFlowThreshold extends AbstractFlowThreshold {
     @Override
     protected double getAbsoluteMax() throws SynchronizationException {
         if (Double.isNaN(maxValue)) {
-            throw new SynchronizationException("Relative flow threshold have not been synchronized with network");
+            throw new SynchronizationException("Relative flow threshold has not been synchronized with network");
         }
         return maxValue;
     }
@@ -51,7 +51,7 @@ public class RelativeFlowThreshold extends AbstractFlowThreshold {
     @Override
     public double computeMargin(Network network, Cnec cnec) throws SynchronizationException {
         if (Double.isNaN(maxValue)) {
-            throw new SynchronizationException("Relative flow threshold have not been synchronized with network");
+            throw new SynchronizationException("Relative flow threshold has not been synchronized with network");
         }
         return super.computeMargin(network, cnec);
     }

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThreshold.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThreshold.java
@@ -42,6 +42,11 @@ public class RelativeFlowThreshold extends AbstractFlowThreshold {
     }
 
     @Override
+    public Optional<Double> getMaxThreshold(Unit unit) throws SynchronizationException {
+        return Optional.empty();
+    }
+
+    @Override
     public boolean isMinThresholdOvercome(Network network, Cnec cnec) {
         return false;
     }

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThreshold.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThreshold.java
@@ -11,17 +11,24 @@ import com.farao_community.farao.data.crac_api.*;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.Network;
 
 import java.util.Optional;
 
 /**
+ * Limits of a flow through a branch. Given as a percentage of the branch limit
+ * defined in a Network.
+ *
  * @author Joris Mancini {@literal <joris.mancini at rte-france.com>}
+ * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com>}
+ * @author Viktor Terrier {@literal <viktor.terrier at rte-france.com>}
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS)
 public class RelativeFlowThreshold extends AbstractFlowThreshold {
 
+    /**
+     * Percentage of the branch limit which shouldn't be overcome
+     */
     private double percentageOfMax;
 
     @JsonCreator
@@ -30,6 +37,9 @@ public class RelativeFlowThreshold extends AbstractFlowThreshold {
                                  @JsonProperty("direction") Direction direction,
                                  @JsonProperty("percentageOfMax") double percentageOfMax) {
         super(unit, side, direction);
+        if (!unit.equals(Unit.AMPERE)) {
+            throw new FaraoException("RelativeFlowThreshold cannot handle a unit different than Unit.AMPERE.");
+        }
         this.percentageOfMax = percentageOfMax;
     }
 
@@ -42,58 +52,22 @@ public class RelativeFlowThreshold extends AbstractFlowThreshold {
     }
 
     @Override
-    public Optional<Double> getMaxThreshold(Unit unit) throws SynchronizationException {
-        return Optional.empty();
-    }
-
-    @Override
-    public boolean isMinThresholdOvercome(Network network, Cnec cnec) {
-        return false;
-    }
-
-    @Override
-    public boolean isMaxThresholdOvercome(Network network, Cnec cnec) throws SynchronizationException {
-        if (Double.isNaN(maxValue)) {
-            throw new SynchronizationException("Relative flow threshold have not been synchronized with network");
-        }
-        return computeMargin(network, cnec) < 0;
-    }
-
-    @Override
     public double computeMargin(Network network, Cnec cnec) throws SynchronizationException {
         if (Double.isNaN(maxValue)) {
             throw new SynchronizationException("Relative flow threshold have not been synchronized with network");
         }
-        switch (unit) {
-            case AMPERE:
-                return maxValue - getI(network, cnec);
-            case MEGAWATT:
-                return maxValue - getP(network, cnec);
-            case DEGREE:
-            case KILOVOLT:
-            default:
-                throw new FaraoException("Incompatible type of unit between FlowThreshold and degree or kV");
-        }
+        return super.computeMargin(network, cnec);
     }
 
     @Override
     public void synchronize(Network network, Cnec cnec) {
-        // TODO: manage matching between LEFT/RIGHT and ONE/TWO
-        switch (side) {
-            case LEFT:
-                maxValue = network.getBranch(cnec.getCriticalNetworkElement().getId()).getCurrentLimits(Branch.Side.ONE).getPermanentLimit() * percentageOfMax / 100;
-                break;
-            case RIGHT:
-                maxValue = network.getBranch(cnec.getCriticalNetworkElement().getId()).getCurrentLimits(Branch.Side.TWO).getPermanentLimit() * percentageOfMax / 100;
-                break;
-            default:
-                throw new FaraoException("Side is not defined");
-        }
-
+        super.synchronize(network, cnec);
+        maxValue = network.getBranch(cnec.getCriticalNetworkElement().getId()).getCurrentLimits(getBranchSide()).getPermanentLimit() * percentageOfMax / 100;
     }
 
     @Override
     public void desynchronize() {
+        super.desynchronize();
         maxValue = Double.NaN;
     }
 

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/VoltageThreshold.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/VoltageThreshold.java
@@ -65,7 +65,7 @@ public class VoltageThreshold extends AbstractThreshold {
         if (unit.equals(KILOVOLT)) {
             return getMinThreshold();
         } else {
-            throw new FaraoException("Unit of voltage threshold should be kilovolt!");
+            throw new FaraoException(String.format("Unit of voltage threshold should be KILOVOLT, %s is not a valid value", unit.toString()));
         }
     }
 
@@ -79,7 +79,7 @@ public class VoltageThreshold extends AbstractThreshold {
         if (unit.equals(KILOVOLT)) {
             return getMaxThreshold();
         } else {
-            throw new FaraoException("Unit of voltage threshold should be kilovolt!");
+            throw new FaraoException(String.format("Unit of voltage threshold should be KILOVOLT, %s is not a valid value", unit.toString()));
         }
     }
 

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/VoltageThreshold.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/VoltageThreshold.java
@@ -62,28 +62,18 @@ public class VoltageThreshold extends AbstractThreshold {
     }
 
     @Override
-    public Optional<Double> getMinThreshold() throws SynchronizationException {
-        return Optional.empty();
-    }
-
-    @Override
     public Optional<Double> getMinThreshold(Unit unit) throws SynchronizationException {
         if (unit.equals(KILOVOLT)) {
-            return getMinThreshold();
+            return Optional.empty();
         } else {
             throw new FaraoException(String.format("Unit of voltage threshold should be KILOVOLT, %s is not a valid value", unit.toString()));
         }
     }
 
     @Override
-    public Optional<Double> getMaxThreshold() throws SynchronizationException {
-        return Optional.empty();
-    }
-
-    @Override
     public Optional<Double> getMaxThreshold(Unit unit) throws SynchronizationException {
         if (unit.equals(KILOVOLT)) {
-            return getMaxThreshold();
+            return Optional.empty();
         } else {
             throw new FaraoException(String.format("Unit of voltage threshold should be KILOVOLT, %s is not a valid value", unit.toString()));
         }

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/VoltageThreshold.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/VoltageThreshold.java
@@ -7,6 +7,8 @@
 
 package com.farao_community.farao.data.crac_impl.threshold;
 
+import com.farao_community.farao.commons.FaraoException;
+import com.farao_community.farao.data.crac_api.Unit;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -59,8 +61,26 @@ public class VoltageThreshold extends AbstractThreshold {
     }
 
     @Override
+    public Optional<Double> getMinThreshold(Unit unit) throws SynchronizationException {
+        if (unit.equals(KILOVOLT)) {
+            return getMinThreshold();
+        } else {
+            throw new FaraoException("Unit of voltage threshold should be kilovolt!");
+        }
+    }
+
+    @Override
     public Optional<Double> getMaxThreshold() throws SynchronizationException {
         return Optional.empty();
+    }
+
+    @Override
+    public Optional<Double> getMaxThreshold(Unit unit) throws SynchronizationException {
+        if (unit.equals(KILOVOLT)) {
+            return getMaxThreshold();
+        } else {
+            throw new FaraoException("Unit of voltage threshold should be kilovolt!");
+        }
     }
 
     @Override

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/VoltageThreshold.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/VoltageThreshold.java
@@ -8,6 +8,7 @@
 package com.farao_community.farao.data.crac_impl.threshold;
 
 import com.farao_community.farao.commons.FaraoException;
+import com.farao_community.farao.data.crac_api.PhysicalParameter;
 import com.farao_community.farao.data.crac_api.Unit;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,6 +38,11 @@ public class VoltageThreshold extends AbstractThreshold {
         super(KILOVOLT);
         this.minValue = minValue;
         this.maxValue = maxValue;
+    }
+
+    @Override
+    public PhysicalParameter getPhysicalParameter() {
+        return PhysicalParameter.VOLTAGE;
     }
 
     public double getMinValue() {

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
@@ -106,7 +106,6 @@ public class AbsoluteFlowThresholdTest {
             fail();
         } catch (FaraoException e) {
             //should throw
-            assertTrue(e.getMessage().contains("AMPERE or MEGAWATT"));
         }
     }
 

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
@@ -109,7 +109,7 @@ public class AbsoluteFlowThresholdTest {
         // on cnec 2, after LF: 384.9 A = 266.7 MW
         // on cnec 3, after LF: 769.8 A
         assertEquals(500.0 - 384.9, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec1), DOUBLE_TOL);
-        assertEquals(1500.0 - 266.7, absoluteFlowThresholdMW.computeMargin(networkWithtLf, cnec2), DOUBLE_TOL);
+        assertEquals(1500.0 - (-266.7), absoluteFlowThresholdMW.computeMargin(networkWithtLf, cnec2), DOUBLE_TOL);
         assertEquals(500.0 - 769.8, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec3), DOUBLE_TOL);
     }
 

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
@@ -79,6 +79,17 @@ public class AbsoluteFlowThresholdTest {
     }
 
     @Test
+    public void getMinMaxThresholdWithUnauthorizedUnit() throws SynchronizationException {
+        try {
+            absoluteFlowThresholdAmps.getMaxThreshold(Unit.KILOVOLT);
+            fail();
+        } catch (FaraoException e) {
+            //should throw
+            assertTrue(e.getMessage().contains("AMPERE or MEGAWATT"));
+        }
+    }
+
+    @Test
     public void getMinMaxThresholdWithUnitUnsynchronized() {
         try {
             absoluteFlowThresholdAmps.getMaxThreshold(Unit.MEGAWATT);

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
@@ -18,6 +18,8 @@ import org.junit.Test;
 
 import java.util.Optional;
 
+import static com.farao_community.farao.data.crac_api.Unit.AMPERE;
+import static com.farao_community.farao.data.crac_api.Unit.MEGAWATT;
 import static org.junit.Assert.*;
 
 /**
@@ -38,8 +40,8 @@ public class AbsoluteFlowThresholdTest {
 
     @Before
     public void setUp() {
-        absoluteFlowThresholdAmps = new AbsoluteFlowThreshold(Unit.AMPERE, Side.RIGHT, Direction.BOTH, 500.0);
-        absoluteFlowThresholdMW = new AbsoluteFlowThreshold(Unit.MEGAWATT, Side.LEFT, Direction.BOTH, 1500.0);
+        absoluteFlowThresholdAmps = new AbsoluteFlowThreshold(AMPERE, Side.RIGHT, Direction.BOTH, 500.0);
+        absoluteFlowThresholdMW = new AbsoluteFlowThreshold(MEGAWATT, Side.LEFT, Direction.BOTH, 1500.0);
 
         cnec1 = new SimpleCnec("cnec1", "cnec1", new NetworkElement("FRANCE_BELGIUM_1", "FRANCE_BELGIUM_1"),
                 absoluteFlowThresholdAmps, new SimpleState(Optional.empty(), new Instant("initial", 0)));
@@ -69,7 +71,7 @@ public class AbsoluteFlowThresholdTest {
         }
         try {
             // forbidden value
-            new AbsoluteFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.BOTH, -500);
+            new AbsoluteFlowThreshold(AMPERE, Side.LEFT, Direction.BOTH, -500);
         } catch (FaraoException e) {
             // should throw
         }
@@ -77,10 +79,10 @@ public class AbsoluteFlowThresholdTest {
 
     @Test
     public void getMinMaxThreshold() throws SynchronizationException {
-        assertEquals(500.0, absoluteFlowThresholdAmps.getMaxThreshold().orElse(Double.MAX_VALUE), DOUBLE_TOL);
-        assertEquals(1500.0, absoluteFlowThresholdMW.getMaxThreshold().orElse(Double.MAX_VALUE), DOUBLE_TOL);
-        assertEquals(-500.0, absoluteFlowThresholdAmps.getMinThreshold().orElse(Double.MIN_VALUE), DOUBLE_TOL);
-        assertEquals(-1500.0, absoluteFlowThresholdMW.getMinThreshold().orElse(Double.MIN_VALUE), DOUBLE_TOL);
+        assertEquals(500.0, absoluteFlowThresholdAmps.getMaxThreshold(AMPERE).orElse(Double.MAX_VALUE), DOUBLE_TOL);
+        assertEquals(1500.0, absoluteFlowThresholdMW.getMaxThreshold(MEGAWATT).orElse(Double.MAX_VALUE), DOUBLE_TOL);
+        assertEquals(-500.0, absoluteFlowThresholdAmps.getMinThreshold(AMPERE).orElse(Double.MIN_VALUE), DOUBLE_TOL);
+        assertEquals(-1500.0, absoluteFlowThresholdMW.getMinThreshold(MEGAWATT).orElse(Double.MIN_VALUE), DOUBLE_TOL);
     }
 
     @Test
@@ -88,15 +90,15 @@ public class AbsoluteFlowThresholdTest {
         absoluteFlowThresholdAmps.synchronize(networkWithLf, cnec1);
         absoluteFlowThresholdMW.synchronize(networkWithLf, cnec2);
 
-        assertEquals(500.0, absoluteFlowThresholdAmps.getMaxThreshold(Unit.AMPERE).orElse(Double.MAX_VALUE), DOUBLE_TOL);
-        assertEquals(346.4, absoluteFlowThresholdAmps.getMaxThreshold(Unit.MEGAWATT).orElse(Double.MAX_VALUE), DOUBLE_TOL);
-        assertEquals(2165.1, absoluteFlowThresholdMW.getMaxThreshold(Unit.AMPERE).orElse(Double.MAX_VALUE), DOUBLE_TOL);
-        assertEquals(1500.0, absoluteFlowThresholdMW.getMaxThreshold(Unit.MEGAWATT).orElse(Double.MAX_VALUE), DOUBLE_TOL);
+        assertEquals(500.0, absoluteFlowThresholdAmps.getMaxThreshold(AMPERE).orElse(Double.MAX_VALUE), DOUBLE_TOL);
+        assertEquals(346.4, absoluteFlowThresholdAmps.getMaxThreshold(MEGAWATT).orElse(Double.MAX_VALUE), DOUBLE_TOL);
+        assertEquals(2165.1, absoluteFlowThresholdMW.getMaxThreshold(AMPERE).orElse(Double.MAX_VALUE), DOUBLE_TOL);
+        assertEquals(1500.0, absoluteFlowThresholdMW.getMaxThreshold(MEGAWATT).orElse(Double.MAX_VALUE), DOUBLE_TOL);
 
-        assertEquals(-500.0, absoluteFlowThresholdAmps.getMinThreshold(Unit.AMPERE).orElse(Double.MIN_VALUE), DOUBLE_TOL);
-        assertEquals(-346.4, absoluteFlowThresholdAmps.getMinThreshold(Unit.MEGAWATT).orElse(Double.MIN_VALUE), DOUBLE_TOL);
-        assertEquals(-2165.1, absoluteFlowThresholdMW.getMinThreshold(Unit.AMPERE).orElse(Double.MIN_VALUE), DOUBLE_TOL);
-        assertEquals(-1500.0, absoluteFlowThresholdMW.getMinThreshold(Unit.MEGAWATT).orElse(Double.MIN_VALUE), DOUBLE_TOL);
+        assertEquals(-500.0, absoluteFlowThresholdAmps.getMinThreshold(AMPERE).orElse(Double.MIN_VALUE), DOUBLE_TOL);
+        assertEquals(-346.4, absoluteFlowThresholdAmps.getMinThreshold(MEGAWATT).orElse(Double.MIN_VALUE), DOUBLE_TOL);
+        assertEquals(-2165.1, absoluteFlowThresholdMW.getMinThreshold(AMPERE).orElse(Double.MIN_VALUE), DOUBLE_TOL);
+        assertEquals(-1500.0, absoluteFlowThresholdMW.getMinThreshold(MEGAWATT).orElse(Double.MIN_VALUE), DOUBLE_TOL);
     }
 
     @Test
@@ -112,7 +114,7 @@ public class AbsoluteFlowThresholdTest {
     @Test
     public void getMinMaxThresholdWithUnitUnsynchronized() {
         try {
-            absoluteFlowThresholdAmps.getMaxThreshold(Unit.MEGAWATT);
+            absoluteFlowThresholdAmps.getMaxThreshold(MEGAWATT);
             fail();
         } catch (SynchronizationException e) {
             // should throw, conversion cannot be made if voltage level has not been synchronised

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
@@ -22,71 +22,89 @@ import static org.junit.Assert.*;
 
 /**
  * @author Joris Mancini {@literal <joris.mancini at rte-france.com>}
+ * @author Baptiste Seguinot {@literal <baptiste.seguino at rte-france.com>}
  */
 public class AbsoluteFlowThresholdTest {
+
+    private static final double DOUBLE_TOL = 0.5;
 
     private AbsoluteFlowThreshold absoluteFlowThresholdAmps;
     private AbsoluteFlowThreshold absoluteFlowThresholdMW;
     private Cnec cnec1;
     private Cnec cnec2;
+    private Cnec cnec3;
     private Network networkWithoutLf;
     private Network networkWithtLf;
 
     @Before
     public void setUp() {
+        absoluteFlowThresholdAmps = new AbsoluteFlowThreshold(Unit.AMPERE, Side.RIGHT, Direction.IN, 500.0);
+        absoluteFlowThresholdMW = new AbsoluteFlowThreshold(Unit.MEGAWATT, Side.RIGHT, Direction.IN, 1500.0);
 
-        absoluteFlowThresholdAmps = new AbsoluteFlowThreshold(
-                Unit.AMPERE,
-                Side.RIGHT,
-                Direction.IN,
-                500
-        );
+        cnec1 = new SimpleCnec("cnec1", "cnec1", new NetworkElement("FRANCE_BELGIUM_1", "FRANCE_BELGIUM_1"),
+                absoluteFlowThresholdAmps, new SimpleState(Optional.empty(), new Instant("initial", 0)));
 
-        absoluteFlowThresholdMW = new AbsoluteFlowThreshold(
-                Unit.MEGAWATT,
-                Side.RIGHT,
-                Direction.IN,
-                500
-        );
+        cnec2 = new SimpleCnec("cnec2", "cnec2", new NetworkElement("FRANCE_BELGIUM_1", "FRANCE_BELGIUM_2"),
+                absoluteFlowThresholdMW, new SimpleState(Optional.empty(), new Instant("initial", 0)));
 
-        cnec1 = new SimpleCnec(
-                "cnec1",
-                "cnec1",
-                new NetworkElement("FRANCE_BELGIUM_1", "FRANCE_BELGIUM_1"),
-                absoluteFlowThresholdAmps,
-                new SimpleState(Optional.empty(), new Instant("initial", 0))
-        );
-
-        cnec2 = new SimpleCnec(
-                "cnec2",
-                "cnec2",
-                new NetworkElement("FRANCE_BELGIUM_2", "FRANCE_BELGIUM_2"),
-                absoluteFlowThresholdAmps,
-                new SimpleState(Optional.empty(), new Instant("initial", 0))
-        );
+        cnec3 = new SimpleCnec("cnec3", "cnec3", new NetworkElement("FRANCE_BELGIUM_2", "FRANCE_BELGIUM_2"),
+                absoluteFlowThresholdAmps, new SimpleState(Optional.empty(), new Instant("initial", 0)));
 
         networkWithoutLf = Importers.loadNetwork("TestCase2Nodes.xiidm", getClass().getResourceAsStream("/TestCase2Nodes.xiidm"));
         networkWithtLf = Importers.loadNetwork("TestCase2Nodes_withLF.xiidm", getClass().getResourceAsStream("/TestCase2Nodes_withLF.xiidm"));
     }
 
     @Test
-    public void isMinThresholdOvercome() throws Exception {
+    public void getMinMaxThreshold() {
+        assertEquals(500.0, absoluteFlowThresholdAmps.getMaxThreshold().orElse(Double.NaN), DOUBLE_TOL);
+        assertEquals(1500.0, absoluteFlowThresholdMW.getMaxThreshold().orElse(Double.NaN), DOUBLE_TOL);
+        assertFalse(absoluteFlowThresholdAmps.getMinThreshold().isPresent());
+        assertFalse(absoluteFlowThresholdMW.getMinThreshold().isPresent());
+    }
+
+    @Test
+    public void getMinMaxThresholdWithUnit() throws SynchronizationException {
+        absoluteFlowThresholdAmps.synchronize(networkWithtLf, cnec1);
+        absoluteFlowThresholdMW.synchronize(networkWithtLf, cnec2);
+        assertEquals(500.0, absoluteFlowThresholdAmps.getMaxThreshold(Unit.AMPERE).orElse(Double.NaN), DOUBLE_TOL);
+        assertEquals(346.4, absoluteFlowThresholdAmps.getMaxThreshold(Unit.MEGAWATT).orElse(Double.NaN), DOUBLE_TOL);
+        assertEquals(2165.1, absoluteFlowThresholdMW.getMaxThreshold(Unit.AMPERE).orElse(Double.NaN), DOUBLE_TOL);
+        assertEquals(1500.0, absoluteFlowThresholdMW.getMaxThreshold(Unit.MEGAWATT).orElse(Double.NaN), DOUBLE_TOL);
+    }
+
+    @Test
+    public void getMinMaxThresholdWithUnitUnsynchronized() {
+        try {
+            absoluteFlowThresholdAmps.getMaxThreshold(Unit.MEGAWATT);
+            fail();
+        } catch (SynchronizationException e) {
+            // should throw, conversion cannot be made if voltage level has not been synchronised
+        }
+    }
+
+    @Test
+    public void isMinThresholdOvercome() {
+        // returns always false
         assertFalse(absoluteFlowThresholdAmps.isMinThresholdOvercome(networkWithoutLf, cnec1));
         assertFalse(absoluteFlowThresholdAmps.isMinThresholdOvercome(networkWithtLf, cnec1));
     }
 
     @Test
     public void isMaxThresholdOvercomeOk() throws Exception {
-        assertFalse(absoluteFlowThresholdAmps.isMaxThresholdOvercome(networkWithtLf, cnec1)); // on cnec1, after LF: 385 A
-        assertTrue(absoluteFlowThresholdAmps.isMaxThresholdOvercome(networkWithtLf, cnec2)); // on cnec2, after LF: 770 A
+        // on cnec 1, after LF: 384.9 A
+        // on cnec 3, after LF: 769.8 A
+        assertFalse(absoluteFlowThresholdAmps.isMaxThresholdOvercome(networkWithtLf, cnec1));
+        assertTrue(absoluteFlowThresholdAmps.isMaxThresholdOvercome(networkWithtLf, cnec3));
     }
 
     @Test
     public void computeMarginOk() throws Exception {
-        assertEquals(500 - 385, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec1), 1); // on cnec1, after LF: 385 A
-        assertEquals(500 - 770, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec2), 1); // on cnec2, after LF: 770 A
-        assertEquals(500 - 266, absoluteFlowThresholdMW.computeMargin(networkWithtLf, cnec1), 1); // on cnec1, after LF: 266 MW
-        assertEquals(500 - 533, absoluteFlowThresholdMW.computeMargin(networkWithtLf, cnec2), 1); // on cnec2, after LF: 533 MW
+        // on cnec 1, after LF: 384.9 A
+        // on cnec 2, after LF: 384.9 A = 266.7 MW
+        // on cnec 3, after LF: 769.8 A
+        assertEquals(500.0 - 384.9, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec1), DOUBLE_TOL);
+        assertEquals(1500.0 - 266.7, absoluteFlowThresholdMW.computeMargin(networkWithtLf, cnec2), DOUBLE_TOL);
+        assertEquals(500.0 - 769.8, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec3), DOUBLE_TOL);
     }
 
     @Test
@@ -101,23 +119,24 @@ public class AbsoluteFlowThresholdTest {
 
     @Test
     public void computeMarginDisconnectedLine() throws Exception {
-        assertEquals(500 - 770, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec2), 1); // on cnec2, after LF: 770 A
+        // on cnec 3, after LF: 769.8 A
+        assertEquals(500.0 - 769.8, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec3), DOUBLE_TOL);
         networkWithtLf.getBranch("FRANCE_BELGIUM_2").getTerminal1().disconnect();
-        assertEquals(500, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec2), 1);
+        assertEquals(500.0, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec3), DOUBLE_TOL);
     }
 
     @Test
     public void synchronize() {
-        assertEquals(500, absoluteFlowThresholdAmps.getMaxValue(), 1);
+        assertEquals(500.0, absoluteFlowThresholdAmps.getMaxValue(), 1);
         cnec1.synchronize(networkWithoutLf);
-        assertEquals(500, absoluteFlowThresholdAmps.getMaxValue(), 1);
+        assertEquals(500.0, absoluteFlowThresholdAmps.getMaxValue(), 1);
     }
 
     @Test
     public void desynchronize() {
         cnec1.synchronize(networkWithoutLf);
-        assertEquals(500, absoluteFlowThresholdAmps.getMaxValue(), 1);
+        assertEquals(500.0, absoluteFlowThresholdAmps.getMaxValue(), 1);
         cnec1.desynchronize();
-        assertEquals(500, absoluteFlowThresholdAmps.getMaxValue(), 1);
+        assertEquals(500.0, absoluteFlowThresholdAmps.getMaxValue(), 1);
     }
 }

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
@@ -34,7 +34,7 @@ public class AbsoluteFlowThresholdTest {
     private Cnec cnec2;
     private Cnec cnec3;
     private Network networkWithoutLf;
-    private Network networkWithtLf;
+    private Network networkWithLf;
 
     @Before
     public void setUp() {
@@ -51,7 +51,7 @@ public class AbsoluteFlowThresholdTest {
                 absoluteFlowThresholdAmps, new SimpleState(Optional.empty(), new Instant("initial", 0)));
 
         networkWithoutLf = Importers.loadNetwork("TestCase2Nodes.xiidm", getClass().getResourceAsStream("/TestCase2Nodes.xiidm"));
-        networkWithtLf = Importers.loadNetwork("TestCase2Nodes_withLF.xiidm", getClass().getResourceAsStream("/TestCase2Nodes_withLF.xiidm"));
+        networkWithLf = Importers.loadNetwork("TestCase2Nodes_withLF.xiidm", getClass().getResourceAsStream("/TestCase2Nodes_withLF.xiidm"));
     }
 
     @Test
@@ -85,8 +85,8 @@ public class AbsoluteFlowThresholdTest {
 
     @Test
     public void getMinMaxThresholdWithUnit() throws SynchronizationException {
-        absoluteFlowThresholdAmps.synchronize(networkWithtLf, cnec1);
-        absoluteFlowThresholdMW.synchronize(networkWithtLf, cnec2);
+        absoluteFlowThresholdAmps.synchronize(networkWithLf, cnec1);
+        absoluteFlowThresholdMW.synchronize(networkWithLf, cnec2);
 
         assertEquals(500.0, absoluteFlowThresholdAmps.getMaxThreshold(Unit.AMPERE).orElse(Double.MAX_VALUE), DOUBLE_TOL);
         assertEquals(346.4, absoluteFlowThresholdAmps.getMaxThreshold(Unit.MEGAWATT).orElse(Double.MAX_VALUE), DOUBLE_TOL);
@@ -122,15 +122,15 @@ public class AbsoluteFlowThresholdTest {
     @Test
     public void isMinThresholdOvercome() throws SynchronizationException {
         // on cnec 1, after LF: 384.9 A
-        assertFalse(absoluteFlowThresholdAmps.isMinThresholdOvercome(networkWithtLf, cnec1));
+        assertFalse(absoluteFlowThresholdAmps.isMinThresholdOvercome(networkWithLf, cnec1));
     }
 
     @Test
     public void isMaxThresholdOvercomeOk() throws SynchronizationException {
         // on cnec 1, after LF: 384.9 A
         // on cnec 3, after LF: 769.8 A
-        assertFalse(absoluteFlowThresholdAmps.isMaxThresholdOvercome(networkWithtLf, cnec1));
-        assertTrue(absoluteFlowThresholdAmps.isMaxThresholdOvercome(networkWithtLf, cnec3));
+        assertFalse(absoluteFlowThresholdAmps.isMaxThresholdOvercome(networkWithLf, cnec1));
+        assertTrue(absoluteFlowThresholdAmps.isMaxThresholdOvercome(networkWithLf, cnec3));
     }
 
     @Test
@@ -138,9 +138,9 @@ public class AbsoluteFlowThresholdTest {
         // on cnec 1, after LF: 384.9 A
         // on cnec 2, after LF: - 384.9 A = - 266.7 MW
         // on cnec 3, after LF: 769.8 A
-        assertEquals(500.0 - 384.9, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec1), DOUBLE_TOL);
-        assertEquals(-266.7 - (-1500), absoluteFlowThresholdMW.computeMargin(networkWithtLf, cnec2), DOUBLE_TOL);
-        assertEquals(500.0 - 769.8, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec3), DOUBLE_TOL);
+        assertEquals(500.0 - 384.9, absoluteFlowThresholdAmps.computeMargin(networkWithLf, cnec1), DOUBLE_TOL);
+        assertEquals(-266.7 - (-1500), absoluteFlowThresholdMW.computeMargin(networkWithLf, cnec2), DOUBLE_TOL);
+        assertEquals(500.0 - 769.8, absoluteFlowThresholdAmps.computeMargin(networkWithLf, cnec3), DOUBLE_TOL);
     }
 
     @Test
@@ -156,15 +156,15 @@ public class AbsoluteFlowThresholdTest {
     @Test
     public void computeMarginDisconnectedLine() throws Exception {
         // terminal 1 disconnected
-        networkWithtLf.getBranch("FRANCE_BELGIUM_2").getTerminal1().disconnect();
-        assertEquals(500.0 - 0.0, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec3), DOUBLE_TOL);
+        networkWithLf.getBranch("FRANCE_BELGIUM_2").getTerminal1().disconnect();
+        assertEquals(500.0 - 0.0, absoluteFlowThresholdAmps.computeMargin(networkWithLf, cnec3), DOUBLE_TOL);
         // terminal 2 disconnected
-        networkWithtLf.getBranch("FRANCE_BELGIUM_2").getTerminal1().connect();
-        networkWithtLf.getBranch("FRANCE_BELGIUM_2").getTerminal2().disconnect();
-        assertEquals(500.0 - 0.0, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec3), DOUBLE_TOL);
+        networkWithLf.getBranch("FRANCE_BELGIUM_2").getTerminal1().connect();
+        networkWithLf.getBranch("FRANCE_BELGIUM_2").getTerminal2().disconnect();
+        assertEquals(500.0 - 0.0, absoluteFlowThresholdAmps.computeMargin(networkWithLf, cnec3), DOUBLE_TOL);
         // both terminal disconnected
-        networkWithtLf.getBranch("FRANCE_BELGIUM_2").getTerminal1().disconnect();
-        assertEquals(500.0 - 0.0, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec3), DOUBLE_TOL);
+        networkWithLf.getBranch("FRANCE_BELGIUM_2").getTerminal1().disconnect();
+        assertEquals(500.0 - 0.0, absoluteFlowThresholdAmps.computeMargin(networkWithLf, cnec3), DOUBLE_TOL);
     }
 
     @Test

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
@@ -39,7 +39,7 @@ public class AbsoluteFlowThresholdTest {
     @Before
     public void setUp() {
         absoluteFlowThresholdAmps = new AbsoluteFlowThreshold(Unit.AMPERE, Side.RIGHT, Direction.IN, 500.0);
-        absoluteFlowThresholdMW = new AbsoluteFlowThreshold(Unit.MEGAWATT, Side.RIGHT, Direction.IN, 1500.0);
+        absoluteFlowThresholdMW = new AbsoluteFlowThreshold(Unit.MEGAWATT, Side.LEFT, Direction.IN, 1500.0);
 
         cnec1 = new SimpleCnec("cnec1", "cnec1", new NetworkElement("FRANCE_BELGIUM_1", "FRANCE_BELGIUM_1"),
                 absoluteFlowThresholdAmps, new SimpleState(Optional.empty(), new Instant("initial", 0)));
@@ -66,10 +66,16 @@ public class AbsoluteFlowThresholdTest {
     public void getMinMaxThresholdWithUnit() throws SynchronizationException {
         absoluteFlowThresholdAmps.synchronize(networkWithtLf, cnec1);
         absoluteFlowThresholdMW.synchronize(networkWithtLf, cnec2);
+
         assertEquals(500.0, absoluteFlowThresholdAmps.getMaxThreshold(Unit.AMPERE).orElse(Double.NaN), DOUBLE_TOL);
         assertEquals(346.4, absoluteFlowThresholdAmps.getMaxThreshold(Unit.MEGAWATT).orElse(Double.NaN), DOUBLE_TOL);
         assertEquals(2165.1, absoluteFlowThresholdMW.getMaxThreshold(Unit.AMPERE).orElse(Double.NaN), DOUBLE_TOL);
         assertEquals(1500.0, absoluteFlowThresholdMW.getMaxThreshold(Unit.MEGAWATT).orElse(Double.NaN), DOUBLE_TOL);
+
+        assertFalse(absoluteFlowThresholdAmps.getMinThreshold(Unit.AMPERE).isPresent());
+        assertFalse(absoluteFlowThresholdAmps.getMinThreshold(Unit.MEGAWATT).isPresent());
+        assertFalse(absoluteFlowThresholdMW.getMinThreshold(Unit.AMPERE).isPresent());
+        assertFalse(absoluteFlowThresholdMW.getMinThreshold(Unit.MEGAWATT).isPresent());
     }
 
     @Test

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
@@ -78,14 +78,6 @@ public class AbsoluteFlowThresholdTest {
     }
 
     @Test
-    public void getMinMaxThreshold() throws SynchronizationException {
-        assertEquals(500.0, absoluteFlowThresholdAmps.getMaxThreshold(AMPERE).orElse(Double.MAX_VALUE), DOUBLE_TOL);
-        assertEquals(1500.0, absoluteFlowThresholdMW.getMaxThreshold(MEGAWATT).orElse(Double.MAX_VALUE), DOUBLE_TOL);
-        assertEquals(-500.0, absoluteFlowThresholdAmps.getMinThreshold(AMPERE).orElse(Double.MIN_VALUE), DOUBLE_TOL);
-        assertEquals(-1500.0, absoluteFlowThresholdMW.getMinThreshold(MEGAWATT).orElse(Double.MIN_VALUE), DOUBLE_TOL);
-    }
-
-    @Test
     public void getMinMaxThresholdWithUnit() throws SynchronizationException {
         absoluteFlowThresholdAmps.synchronize(networkWithLf, cnec1);
         absoluteFlowThresholdMW.synchronize(networkWithLf, cnec2);

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
@@ -55,6 +55,27 @@ public class AbsoluteFlowThresholdTest {
     }
 
     @Test
+    public void getPhysicalParameter() {
+        assertEquals(PhysicalParameter.FLOW, absoluteFlowThresholdAmps.getPhysicalParameter());
+    }
+
+    @Test
+    public void forbiddenThresholdConstruction() {
+        try {
+            // forbidden unit
+            new AbsoluteFlowThreshold(Unit.KILOVOLT, Side.LEFT, Direction.BOTH, 500);
+        } catch (FaraoException e) {
+            // should throw
+        }
+        try {
+            // forbidden value
+            new AbsoluteFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.BOTH, -500);
+        } catch (FaraoException e) {
+            // should throw
+        }
+    }
+
+    @Test
     public void getMinMaxThreshold() throws SynchronizationException {
         assertEquals(500.0, absoluteFlowThresholdAmps.getMaxThreshold().orElse(Double.MAX_VALUE), DOUBLE_TOL);
         assertEquals(1500.0, absoluteFlowThresholdMW.getMaxThreshold().orElse(Double.MAX_VALUE), DOUBLE_TOL);
@@ -135,10 +156,16 @@ public class AbsoluteFlowThresholdTest {
 
     @Test
     public void computeMarginDisconnectedLine() throws Exception {
-        // on cnec 3, after LF: 769.8 A
-        assertEquals(500.0 - 769.8, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec3), DOUBLE_TOL);
+        // terminal 1 disconnected
         networkWithtLf.getBranch("FRANCE_BELGIUM_2").getTerminal1().disconnect();
-        assertEquals(500.0, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec3), DOUBLE_TOL);
+        assertEquals(500.0 - 0.0, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec3), DOUBLE_TOL);
+        // terminal 2 disconnected
+        networkWithtLf.getBranch("FRANCE_BELGIUM_2").getTerminal1().connect();
+        networkWithtLf.getBranch("FRANCE_BELGIUM_2").getTerminal2().disconnect();
+        assertEquals(500.0 - 0.0, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec3), DOUBLE_TOL);
+        // both terminal disconnected
+        networkWithtLf.getBranch("FRANCE_BELGIUM_2").getTerminal1().disconnect();
+        assertEquals(500.0 - 0.0, absoluteFlowThresholdAmps.computeMargin(networkWithtLf, cnec3), DOUBLE_TOL);
     }
 
     @Test

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThresholdTest.java
@@ -164,6 +164,7 @@ public class RelativeFlowThresholdTest {
         relativeFlowThresholdAmps.synchronize(networkWithoutLf, cnec1);
         try {
             relativeFlowThresholdAmps.computeMargin(networkWithoutLf, cnec1);
+            fail();
         } catch (FaraoException e) {
             // should throw
         }

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThresholdTest.java
@@ -31,7 +31,7 @@ public class RelativeFlowThresholdTest {
     private Cnec cnec1;
     private Cnec cnec2;
     private Network networkWithoutLf;
-    private Network networkWithtLf;
+    private Network networkWithLf;
 
     @Before
     public void setUp() {
@@ -44,7 +44,7 @@ public class RelativeFlowThresholdTest {
                 relativeFlowThresholdAmps, new SimpleState(Optional.empty(), new Instant("initial", 0)));
 
         networkWithoutLf = Importers.loadNetwork("TestCase2Nodes.xiidm", getClass().getResourceAsStream("/TestCase2Nodes.xiidm"));
-        networkWithtLf = Importers.loadNetwork("TestCase2Nodes_withLF.xiidm", getClass().getResourceAsStream("/TestCase2Nodes_withLF.xiidm"));
+        networkWithLf = Importers.loadNetwork("TestCase2Nodes_withLF.xiidm", getClass().getResourceAsStream("/TestCase2Nodes_withLF.xiidm"));
     }
 
     @Test
@@ -110,23 +110,23 @@ public class RelativeFlowThresholdTest {
 
     @Test
     public void isMinThresholdOvercome() throws Exception {
-        relativeFlowThresholdAmps.synchronize(networkWithtLf, cnec1);
-        assertFalse(relativeFlowThresholdAmps.isMinThresholdOvercome(networkWithtLf, cnec1));
+        relativeFlowThresholdAmps.synchronize(networkWithLf, cnec1);
+        assertFalse(relativeFlowThresholdAmps.isMinThresholdOvercome(networkWithLf, cnec1));
     }
 
     @Test
     public void isMaxThresholdOvercome() throws SynchronizationException {
         assertTrue(Double.isNaN(relativeFlowThresholdAmps.getMaxValue()));
 
-        relativeFlowThresholdAmps.synchronize(networkWithtLf, cnec1);
+        relativeFlowThresholdAmps.synchronize(networkWithLf, cnec1);
         // relativeFlowThresholdAmps -> 60% * 721 A = 432.6 A
         // on cnec 1, after LF -> 384.9 A
-        assertFalse(relativeFlowThresholdAmps.isMaxThresholdOvercome(networkWithtLf, cnec1));
+        assertFalse(relativeFlowThresholdAmps.isMaxThresholdOvercome(networkWithLf, cnec1));
 
-        relativeFlowThresholdAmps.synchronize(networkWithtLf, cnec2);
+        relativeFlowThresholdAmps.synchronize(networkWithLf, cnec2);
         // relativeFlowThresholdAmps -> 60% * 721 A = 432.6 A
         // on cnec 2, after LF -> 769.8 A
-        assertTrue(relativeFlowThresholdAmps.isMaxThresholdOvercome(networkWithtLf, cnec2));
+        assertTrue(relativeFlowThresholdAmps.isMaxThresholdOvercome(networkWithLf, cnec2));
     }
 
     @Test
@@ -140,21 +140,21 @@ public class RelativeFlowThresholdTest {
     public void computeMarginInAmpsOk() throws SynchronizationException {
         assertTrue(Double.isNaN(relativeFlowThresholdAmps.getMaxValue()));
 
-        relativeFlowThresholdAmps.synchronize(networkWithtLf, cnec1);
+        relativeFlowThresholdAmps.synchronize(networkWithLf, cnec1);
         // relativeFlowThresholdAmps -> 60% * 721 A = 432 A
         // on cnec 1, after LF -> 384.9 A
-        assertEquals(432.6 - 384.9, relativeFlowThresholdAmps.computeMargin(networkWithtLf, cnec1), DOUBLE_TOL);
+        assertEquals(432.6 - 384.9, relativeFlowThresholdAmps.computeMargin(networkWithLf, cnec1), DOUBLE_TOL);
 
-        relativeFlowThresholdAmps.synchronize(networkWithtLf, cnec2);
+        relativeFlowThresholdAmps.synchronize(networkWithLf, cnec2);
         // relativeFlowThresholdAmps -> 60% * 721 A = 432 A
         // on cnec 2, after LF -> 769.8 A
-        assertEquals(432.6 - 769.8, relativeFlowThresholdAmps.computeMargin(networkWithtLf, cnec2), DOUBLE_TOL);
+        assertEquals(432.6 - 769.8, relativeFlowThresholdAmps.computeMargin(networkWithLf, cnec2), DOUBLE_TOL);
     }
 
     @Test
     public void computeMarginWithNoSynchronization() {
         try {
-            relativeFlowThresholdAmps.computeMargin(networkWithtLf, cnec1);
+            relativeFlowThresholdAmps.computeMargin(networkWithLf, cnec1);
             fail();
         } catch (SynchronizationException ignored) {
         }

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThresholdTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.*;
  */
 public class RelativeFlowThresholdTest {
 
-    private static final double DOUBLE_TOL = 1.0;
+    private static final double DOUBLE_TOL = 0.5;
 
     private RelativeFlowThreshold relativeFlowThresholdAmps;
     private Cnec cnec1;
@@ -68,6 +68,18 @@ public class RelativeFlowThresholdTest {
 
         assertFalse(relativeFlowThresholdAmps.getMinThreshold(Unit.AMPERE).isPresent());
         assertFalse(relativeFlowThresholdAmps.getMinThreshold(Unit.MEGAWATT).isPresent());
+    }
+
+    @Test
+    public void getMinMaxThresholdWithUnauthorizedUnit() throws SynchronizationException {
+        try {
+            relativeFlowThresholdAmps.synchronize(networkWithoutLf, cnec1);
+            relativeFlowThresholdAmps.getMaxThreshold(Unit.KILOVOLT);
+            fail();
+        } catch (FaraoException e) {
+            //should throw
+            assertTrue(e.getMessage().contains("AMPERE or MEGAWATT"));
+        }
     }
 
     @Test

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThresholdTest.java
@@ -51,13 +51,15 @@ public class RelativeFlowThresholdTest {
     public void forbiddenThresholdConstruction() {
         try {
             // forbidden value
-            new AbsoluteFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.BOTH, -1);
+            new RelativeFlowThreshold(Side.LEFT, Direction.BOTH, -1);
+            fail();
         } catch (FaraoException e) {
             // should throw
         }
         try {
             // forbidden value
-            new AbsoluteFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.BOTH, 101);
+            new RelativeFlowThreshold(Side.LEFT, Direction.BOTH, 101);
+            fail();
         } catch (FaraoException e) {
             // should throw
         }
@@ -93,7 +95,6 @@ public class RelativeFlowThresholdTest {
             fail();
         } catch (FaraoException e) {
             //should throw
-            assertTrue(e.getMessage().contains("AMPERE or MEGAWATT"));
         }
     }
 

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThresholdTest.java
@@ -35,7 +35,6 @@ public class RelativeFlowThresholdTest {
 
     @Before
     public void setUp() {
-
         relativeFlowThresholdAmps = new RelativeFlowThreshold(Side.RIGHT, Direction.BOTH, 60);
 
         cnec1 = new SimpleCnec("cnec1", "cnec1", new NetworkElement("FRANCE_BELGIUM_1", "FRANCE_BELGIUM_1"),
@@ -46,6 +45,22 @@ public class RelativeFlowThresholdTest {
 
         networkWithoutLf = Importers.loadNetwork("TestCase2Nodes.xiidm", getClass().getResourceAsStream("/TestCase2Nodes.xiidm"));
         networkWithtLf = Importers.loadNetwork("TestCase2Nodes_withLF.xiidm", getClass().getResourceAsStream("/TestCase2Nodes_withLF.xiidm"));
+    }
+
+    @Test
+    public void forbiddenThresholdConstruction() {
+        try {
+            // forbidden value
+            new AbsoluteFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.BOTH, -1);
+        } catch (FaraoException e) {
+            // should throw
+        }
+        try {
+            // forbidden value
+            new AbsoluteFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.BOTH, 101);
+        } catch (FaraoException e) {
+            // should throw
+        }
     }
 
     @Test

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThresholdTest.java
@@ -17,6 +17,8 @@ import org.junit.Before;
 import org.junit.Test;
 import java.util.Optional;
 
+import static com.farao_community.farao.data.crac_api.Unit.AMPERE;
+import static com.farao_community.farao.data.crac_api.Unit.MEGAWATT;
 import static org.junit.Assert.*;
 
 /**
@@ -72,19 +74,19 @@ public class RelativeFlowThresholdTest {
         // relativeFlowThresholdAmps -> 60% * 721 A = 432 A
         // relativeFlowThresholdMW -> 75% * 500 MW = 375 MW
 
-        assertEquals(432.6, relativeFlowThresholdAmps.getMaxThreshold().orElse(Double.MAX_VALUE), DOUBLE_TOL);
-        assertEquals(-432.6, relativeFlowThresholdAmps.getMinThreshold().orElse(Double.MIN_VALUE), DOUBLE_TOL);
+        assertEquals(432.6, relativeFlowThresholdAmps.getMaxThreshold(AMPERE).orElse(Double.MAX_VALUE), DOUBLE_TOL);
+        assertEquals(-432.6, relativeFlowThresholdAmps.getMinThreshold(AMPERE).orElse(Double.MIN_VALUE), DOUBLE_TOL);
     }
 
     @Test
     public void getMinMaxThresholdWithUnit() throws SynchronizationException {
         relativeFlowThresholdAmps.synchronize(networkWithoutLf, cnec1);
 
-        assertEquals(432.6, relativeFlowThresholdAmps.getMaxThreshold(Unit.AMPERE).orElse(Double.MAX_VALUE), DOUBLE_TOL);
-        assertEquals(300.0, relativeFlowThresholdAmps.getMaxThreshold(Unit.MEGAWATT).orElse(Double.MAX_VALUE), DOUBLE_TOL);
+        assertEquals(432.6, relativeFlowThresholdAmps.getMaxThreshold(AMPERE).orElse(Double.MAX_VALUE), DOUBLE_TOL);
+        assertEquals(300.0, relativeFlowThresholdAmps.getMaxThreshold(MEGAWATT).orElse(Double.MAX_VALUE), DOUBLE_TOL);
 
-        assertEquals(-432.6, relativeFlowThresholdAmps.getMinThreshold(Unit.AMPERE).orElse(Double.MAX_VALUE), DOUBLE_TOL);
-        assertEquals(-300.0, relativeFlowThresholdAmps.getMinThreshold(Unit.MEGAWATT).orElse(Double.MAX_VALUE), DOUBLE_TOL);
+        assertEquals(-432.6, relativeFlowThresholdAmps.getMinThreshold(AMPERE).orElse(Double.MAX_VALUE), DOUBLE_TOL);
+        assertEquals(-300.0, relativeFlowThresholdAmps.getMinThreshold(MEGAWATT).orElse(Double.MAX_VALUE), DOUBLE_TOL);
     }
 
     @Test
@@ -101,7 +103,7 @@ public class RelativeFlowThresholdTest {
     @Test
     public void getMinMaxThresholdWithUnitNotSynchronised()  {
         try {
-            relativeFlowThresholdAmps.getMaxThreshold(Unit.MEGAWATT);
+            relativeFlowThresholdAmps.getMaxThreshold(MEGAWATT);
             fail();
         } catch (SynchronizationException e) {
             // should throw, conversion cannot be made if voltage level has not been synchronised

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThresholdTest.java
@@ -68,17 +68,6 @@ public class RelativeFlowThresholdTest {
     }
 
     @Test
-    public void getMinMaxThreshold() throws SynchronizationException {
-        relativeFlowThresholdAmps.synchronize(networkWithoutLf, cnec1);
-
-        // relativeFlowThresholdAmps -> 60% * 721 A = 432 A
-        // relativeFlowThresholdMW -> 75% * 500 MW = 375 MW
-
-        assertEquals(432.6, relativeFlowThresholdAmps.getMaxThreshold(AMPERE).orElse(Double.MAX_VALUE), DOUBLE_TOL);
-        assertEquals(-432.6, relativeFlowThresholdAmps.getMinThreshold(AMPERE).orElse(Double.MIN_VALUE), DOUBLE_TOL);
-    }
-
-    @Test
     public void getMinMaxThresholdWithUnit() throws SynchronizationException {
         relativeFlowThresholdAmps.synchronize(networkWithoutLf, cnec1);
 

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThresholdTest.java
@@ -65,6 +65,9 @@ public class RelativeFlowThresholdTest {
 
         assertEquals(432.6, relativeFlowThresholdAmps.getMaxThreshold(Unit.AMPERE).orElse(Double.NaN), DOUBLE_TOL);
         assertEquals(300.0, relativeFlowThresholdAmps.getMaxThreshold(Unit.MEGAWATT).orElse(Double.NaN), DOUBLE_TOL);
+
+        assertFalse(relativeFlowThresholdAmps.getMinThreshold(Unit.AMPERE).isPresent());
+        assertFalse(relativeFlowThresholdAmps.getMinThreshold(Unit.MEGAWATT).isPresent());
     }
 
     @Test

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/VoltageThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/VoltageThresholdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/VoltageThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/VoltageThresholdTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.farao_community.farao.data.crac_impl.threshold;
+
+import com.farao_community.farao.commons.FaraoException;
+import com.farao_community.farao.data.crac_api.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Baptiste Seguinot {@literal <baptiste.seguino at rte-france.com>}
+ */
+public class VoltageThresholdTest {
+
+    private static final double DOUBLE_TOL = 0.5;
+
+    private VoltageThreshold voltageThreshold;
+
+    @Before
+    public void setUp() {
+        voltageThreshold = new VoltageThreshold(380.0, 425.0);
+    }
+
+    @Test
+    public void getMinMaxThreshold() throws SynchronizationException {
+        // for now, method always returns empty
+        assertFalse(voltageThreshold.getMinThreshold().isPresent());
+        assertFalse(voltageThreshold.getMaxThreshold().isPresent());
+    }
+
+    @Test
+    public void getMinMaxThresholdWithUnit() throws SynchronizationException {
+        // for now, method always returns empty
+        assertFalse(voltageThreshold.getMinThreshold(Unit.KILOVOLT).isPresent());
+        assertFalse(voltageThreshold.getMaxThreshold(Unit.KILOVOLT).isPresent());
+    }
+
+    @Test
+    public void getMinMaxThresholdWithUnauthorizedUnit() throws SynchronizationException {
+        try {
+            voltageThreshold.getMaxThreshold(Unit.AMPERE);
+            fail();
+        } catch (FaraoException e) {
+            // should throw
+            assertTrue(e.getMessage().contains("KILOVOLT"));
+        }
+
+        try {
+            voltageThreshold.getMinThreshold(Unit.MEGAWATT);
+            fail();
+        } catch (FaraoException e) {
+            // should throw
+            assertTrue(e.getMessage().contains("KILOVOLT"));
+        }
+    }
+}

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/VoltageThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/VoltageThresholdTest.java
@@ -12,6 +12,7 @@ import com.farao_community.farao.data.crac_api.*;
 import org.junit.Before;
 import org.junit.Test;
 
+import static com.farao_community.farao.data.crac_api.Unit.KILOVOLT;
 import static org.junit.Assert.*;
 
 /**
@@ -31,15 +32,15 @@ public class VoltageThresholdTest {
     @Test
     public void getMinMaxThreshold() throws SynchronizationException {
         // for now, method always returns empty
-        assertFalse(voltageThreshold.getMinThreshold().isPresent());
-        assertFalse(voltageThreshold.getMaxThreshold().isPresent());
+        assertFalse(voltageThreshold.getMinThreshold(KILOVOLT).isPresent());
+        assertFalse(voltageThreshold.getMaxThreshold(KILOVOLT).isPresent());
     }
 
     @Test
     public void getMinMaxThresholdWithUnit() throws SynchronizationException {
         // for now, method always returns empty
-        assertFalse(voltageThreshold.getMinThreshold(Unit.KILOVOLT).isPresent());
-        assertFalse(voltageThreshold.getMaxThreshold(Unit.KILOVOLT).isPresent());
+        assertFalse(voltageThreshold.getMinThreshold(KILOVOLT).isPresent());
+        assertFalse(voltageThreshold.getMaxThreshold(KILOVOLT).isPresent());
     }
 
     @Test

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/usage_rule/OnConstraintTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/usage_rule/OnConstraintTest.java
@@ -173,7 +173,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Unit.MEGAWATT, Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 80),
                 initialState
             )
         );
@@ -269,7 +269,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Unit.MEGAWATT, Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Unit.AMPERE, Side.RIGHT, Direction.IN, 80),
                 initialState
             )
         );

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/usage_rule/OnConstraintTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/usage_rule/OnConstraintTest.java
@@ -35,7 +35,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
                 initialState
             )
         );
@@ -56,7 +56,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
                 initialState
             )
         );
@@ -77,7 +77,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
                 initialState
             )
         );
@@ -88,7 +88,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
                 initialState
             )
         );
@@ -109,7 +109,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
                 initialState
             )
         );
@@ -130,7 +130,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
                 initialState
             )
         );
@@ -141,7 +141,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
                 initialState
             )
         );
@@ -162,7 +162,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
                 initialState
             )
         );
@@ -173,7 +173,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
                 initialState
             )
         );
@@ -194,7 +194,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
                 initialState
             )
         );
@@ -205,7 +205,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
                 initialState
             )
         );
@@ -226,7 +226,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
                 initialState
             )
         );
@@ -237,7 +237,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
                 initialState
             )
         );
@@ -258,7 +258,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
                 initialState
             )
         );
@@ -269,7 +269,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Unit.AMPERE, Side.RIGHT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.RIGHT, Direction.IN, 80),
                 initialState
             )
         );

--- a/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/fillers/PositiveMinMarginFiller.java
+++ b/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/fillers/PositiveMinMarginFiller.java
@@ -16,6 +16,8 @@ import com.farao_community.farao.linear_rao.LinearRaoData;
 import com.farao_community.farao.linear_rao.LinearRaoProblem;
 import com.powsybl.iidm.network.Network;
 
+import static com.farao_community.farao.data.crac_api.Unit.MEGAWATT;
+
 /**
  * @author Viktor Terrier {@literal <viktor.terrier at rte-france.com>}
  */
@@ -46,7 +48,7 @@ public class PositiveMinMarginFiller extends AbstractProblemFiller {
 
     private void fillConstraintsCnec(Cnec cnec) {
         try {
-            linearRaoProblem.addMinimumMarginConstraints(cnec.getId(), cnec.getThreshold().getMinThreshold().orElse(-LinearRaoProblem.infinity()), cnec.getThreshold().getMaxThreshold().orElse(LinearRaoProblem.infinity()));
+            linearRaoProblem.addMinimumMarginConstraints(cnec.getId(), cnec.getThreshold().getMinThreshold(MEGAWATT).orElse(-LinearRaoProblem.infinity()), cnec.getThreshold().getMaxThreshold(MEGAWATT).orElse(LinearRaoProblem.infinity()));
         } catch (SynchronizationException e) {
             throw new FaraoException(e);
         }

--- a/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/LinearRaoTest.java
+++ b/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/LinearRaoTest.java
@@ -124,7 +124,7 @@ public class LinearRaoTest {
 
         // Thresholds
         AbsoluteFlowThreshold thresholdAbsFlow = new AbsoluteFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 1500);
-        RelativeFlowThreshold thresholdRelativeFlow = new RelativeFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 30);
+        RelativeFlowThreshold thresholdRelativeFlow = new RelativeFlowThreshold(Side.LEFT, Direction.IN, 30);
 
         // CNECs
         SimpleCnec cnec1basecase = new SimpleCnec("cnec1basecase", "", monitoredElement1, null, stateBasecase);

--- a/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/mocks/CnecMock.java
+++ b/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/mocks/CnecMock.java
@@ -45,12 +45,7 @@ public class CnecMock implements Cnec {
     }
 
     @Override
-    public boolean isMinThresholdViolated(Network network) throws SynchronizationException {
-        return false;
-    }
-
-    @Override
-    public boolean isMaxThresholdViolated(Network network) throws SynchronizationException {
+    public boolean isThresholdViolated(Network network) throws SynchronizationException {
         return false;
     }
 

--- a/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/mocks/ThresholdMock.java
+++ b/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/mocks/ThresholdMock.java
@@ -46,7 +46,6 @@ public class ThresholdMock implements Threshold {
         return Optional.of(max);
     }
 
-
     @Override
     public Unit getUnit() {
         return Unit.AMPERE;
@@ -74,6 +73,5 @@ public class ThresholdMock implements Threshold {
 
     @Override
     public void desynchronize() {
-
     }
 }

--- a/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/mocks/ThresholdMock.java
+++ b/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/mocks/ThresholdMock.java
@@ -24,18 +24,8 @@ public class ThresholdMock implements Threshold {
     }
 
     @Override
-    public Optional<Double> getMinThreshold() throws SynchronizationException {
-        return Optional.of(min);
-    }
-
-    @Override
     public Optional<Double> getMinThreshold(Unit unit) throws SynchronizationException {
         return Optional.of(min);
-    }
-
-    @Override
-    public Optional<Double> getMaxThreshold() throws SynchronizationException {
-        return Optional.of(max);
     }
 
     @Override

--- a/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/mocks/ThresholdMock.java
+++ b/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/mocks/ThresholdMock.java
@@ -6,10 +6,7 @@
  */
 package com.farao_community.farao.linear_rao.mocks;
 
-import com.farao_community.farao.data.crac_api.Cnec;
-import com.farao_community.farao.data.crac_api.SynchronizationException;
-import com.farao_community.farao.data.crac_api.Threshold;
-import com.farao_community.farao.data.crac_api.Unit;
+import com.farao_community.farao.data.crac_api.*;
 import com.powsybl.iidm.network.Network;
 
 import java.util.Optional;
@@ -47,8 +44,8 @@ public class ThresholdMock implements Threshold {
     }
 
     @Override
-    public Unit getUnit() {
-        return Unit.AMPERE;
+    public PhysicalParameter getPhysicalParameter() {
+        return PhysicalParameter.FLOW;
     }
 
     @Override

--- a/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/mocks/ThresholdMock.java
+++ b/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/mocks/ThresholdMock.java
@@ -9,6 +9,7 @@ package com.farao_community.farao.linear_rao.mocks;
 import com.farao_community.farao.data.crac_api.Cnec;
 import com.farao_community.farao.data.crac_api.SynchronizationException;
 import com.farao_community.farao.data.crac_api.Threshold;
+import com.farao_community.farao.data.crac_api.Unit;
 import com.powsybl.iidm.network.Network;
 
 import java.util.Optional;
@@ -31,8 +32,24 @@ public class ThresholdMock implements Threshold {
     }
 
     @Override
+    public Optional<Double> getMinThreshold(Unit unit) throws SynchronizationException {
+        return Optional.of(min);
+    }
+
+    @Override
     public Optional<Double> getMaxThreshold() throws SynchronizationException {
         return Optional.of(max);
+    }
+
+    @Override
+    public Optional<Double> getMaxThreshold(Unit unit) throws SynchronizationException {
+        return Optional.of(max);
+    }
+
+
+    @Override
+    public Unit getUnit() {
+        return Unit.AMPERE;
     }
 
     @Override

--- a/util/src/main/java/com/farao_community/farao/util/SystematicSensitivityAnalysisService.java
+++ b/util/src/main/java/com/farao_community/farao/util/SystematicSensitivityAnalysisService.java
@@ -25,6 +25,8 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 
+import static com.farao_community.farao.data.crac_api.Unit.MEGAWATT;
+
 /**
  * @author Pengbo Wang {@literal <pengbo.wang at rte-international.com>}
  */
@@ -101,7 +103,7 @@ public final class SystematicSensitivityAnalysisService {
         states.forEach(state -> crac.getCnecs(state).forEach(cnec -> {
             try {
                 cnecMarginMap.put(cnec, cnec.computeMargin(network));
-                Optional<Double> maxThreshold = cnec.getThreshold().getMaxThreshold();
+                Optional<Double> maxThreshold = cnec.getThreshold().getMaxThreshold(MEGAWATT);
                 maxThreshold.ifPresent(threshold -> cnecMaxThresholdMap.put(cnec, threshold));
             } catch (SynchronizationException | FaraoException e) {
                 //Hades config "hades2-default-parameters:" should be set to "dcMode: false"

--- a/util/src/main/java/com/farao_community/farao/util/SystematicSensitivityAnalysisService.java
+++ b/util/src/main/java/com/farao_community/farao/util/SystematicSensitivityAnalysisService.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 
-import static com.farao_community.farao.data.crac_api.Unit.MEGAWATT;
+import static com.farao_community.farao.data.crac_api.Unit.AMPERE;
 
 /**
  * @author Pengbo Wang {@literal <pengbo.wang at rte-international.com>}
@@ -103,7 +103,7 @@ public final class SystematicSensitivityAnalysisService {
         states.forEach(state -> crac.getCnecs(state).forEach(cnec -> {
             try {
                 cnecMarginMap.put(cnec, cnec.computeMargin(network));
-                Optional<Double> maxThreshold = cnec.getThreshold().getMaxThreshold(MEGAWATT);
+                Optional<Double> maxThreshold = cnec.getThreshold().getMaxThreshold(AMPERE);
                 maxThreshold.ifPresent(threshold -> cnecMaxThresholdMap.put(cnec, threshold));
             } catch (SynchronizationException | FaraoException e) {
                 //Hades config "hades2-default-parameters:" should be set to "dcMode: false"

--- a/util/src/test/java/com/farao_community/farao/util/SystematicSensitivityAnalysisServiceTest.java
+++ b/util/src/test/java/com/farao_community/farao/util/SystematicSensitivityAnalysisServiceTest.java
@@ -117,7 +117,7 @@ public class SystematicSensitivityAnalysisServiceTest {
 
         // Thresholds
         AbsoluteFlowThreshold thresholdAbsFlow = new AbsoluteFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 1500);
-        RelativeFlowThreshold thresholdRelativeFlow = new RelativeFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 30);
+        RelativeFlowThreshold thresholdRelativeFlow = new RelativeFlowThreshold(Side.LEFT, Direction.IN, 30);
 
         // CNECs
         SimpleCnec cnec1basecase = new SimpleCnec("cnec1basecase", "", monitoredElement1, null, stateBasecase);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

* New feature : Add methods getMaxThreshold(Unit unit) and getMinThreshold(Unit unit) which enable to get the min/max bounds of a threshold measured in the unit given in argument
* New feature : Add a method getPhysicalParameter() to the Thresholds, which informs on what is the physical value monitored by the Threshold (FLOW, VOLTAGE or ANGLE). 
* Fix : getMinThresold(), getMaxThrehold(), computeMargin(), isMinThresholdOvercome() and isMaxThresholdOvercome() now works as if the direction of the Threshold was Direction.BOTH (most common case, Direction.IN and Direction.OUT will be dealt with later)
* Code cleaning/refactoring in the threshold


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*

Changes in crac-api
* Deletion of methods isMinThresholdViolated() and isMaxThresholdViolated() in Cnec, replaced by isThresholdViolated().
* Addition of methods getPhysicalParameter(), getMaxThreshold(Unit) and getMinThreshold(Unit) in Threshold
* Deprecation of getMaxThrehold() and getMinThreshold()

Changes in crac-impl
* RelativeFlowThreshold constructor changed -> it does not take a Unit anymore in argument as its Unit is automatically Unit.AMPERE
