### PR TITLE
Add in the config of the LinearRao a max number of iterations

### DIFF
--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/remedial_action/network_action/ComplexNetworkAction.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/remedial_action/network_action/ComplexNetworkAction.java
@@ -28,8 +28,6 @@ import java.util.Set;
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS)
 public class ComplexNetworkAction extends AbstractRemedialAction implements NetworkAction {
-
-    @JsonProperty("NetworkActions")
     private Set<NetworkAction> networkActions;
 
     @JsonCreator
@@ -69,7 +67,6 @@ public class ComplexNetworkAction extends AbstractRemedialAction implements Netw
         return networkElements;
     }
 
-    @JsonProperty("networkAction")
     public void addNetworkAction(NetworkAction networkAction) {
         this.networkActions.add(networkAction);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Add one parameter in the LinearRaoParameter, maxIterations. This parameter informs on the max number of iteration (one iteration = one sensi + one LP) that the LinearRao can do.

This parameter can be loaded from .yml or .json config files. Under the name `max-number-of-iterations` 

**What is the current behavior?** *(You can also link to an open issue here)*
maxIterations parameter is fixed (to 10) and hardcoded


**What is the new behavior (if this is a feature change)?**
maxIterations can be loaded from the config and can be chosen by the user


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
