### PR TITLE
Import single direction CNECs

### DIFF
--- a/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Direction.java
+++ b/data/crac-file/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Direction.java
@@ -13,7 +13,7 @@ package com.farao_community.farao.data.crac_api;
  * @author Viktor Terrier {@literal <viktor.terrier at rte-france.com>}
  */
 public enum Direction {
-    IN,
-    OUT,
+    DIRECT,
+    OPPOSITE,
     BOTH
 }

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
@@ -67,14 +67,22 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
 
     @Override
     public Optional<Double> getMinThreshold(Unit requestedUnit) throws SynchronizationException {
-        // TODO : handle cases where direction != Direction.BOTH
-        return Optional.of(-convert(getAbsoluteMax(), unit, requestedUnit));
+        switch (direction) {
+            case OUT:
+                return Optional.of(Double.NEGATIVE_INFINITY);
+            default:
+                return Optional.of(-convert(getAbsoluteMax(), unit, requestedUnit));
+        }
     }
 
     @Override
     public Optional<Double> getMaxThreshold(Unit requestedUnit) throws SynchronizationException {
-        // TODO : handle cases where direction != Direction.BOTH
-        return Optional.of(convert(getAbsoluteMax(), unit, requestedUnit));
+        switch (direction) {
+            case IN:
+                return Optional.of(Double.POSITIVE_INFINITY);
+            default:
+                return Optional.of(convert(getAbsoluteMax(), unit, requestedUnit));
+        }
     }
 
     @Override

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
@@ -67,18 +67,18 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
 
     @Override
     public Optional<Double> getMinThreshold(Unit requestedUnit) throws SynchronizationException {
-        if (direction == Direction.OUT) {
-            return Optional.of(Double.NEGATIVE_INFINITY);
-        } else { // Direction.IN and Direction.BOTH
+        if (direction == Direction.DIRECT) {
+            return Optional.empty();
+        } else { // Direction.OPPOSITE and Direction.BOTH
             return Optional.of(-convert(getAbsoluteMax(), unit, requestedUnit));
         }
     }
 
     @Override
     public Optional<Double> getMaxThreshold(Unit requestedUnit) throws SynchronizationException {
-        if (direction == Direction.IN) {
-            return Optional.of(Double.POSITIVE_INFINITY);
-        } else { // Direction.OUT and Direction.BOTH
+        if (direction == Direction.OPPOSITE) {
+            return Optional.empty();
+        } else { // Direction.DIRECT and Direction.BOTH
             return Optional.of(convert(getAbsoluteMax(), unit, requestedUnit));
         }
     }
@@ -117,7 +117,7 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
         } else {
             flow = getP(network, cnec);
         }
-        return Math.min(getMaxThreshold(unit).orElse(Double.MAX_VALUE) - flow, flow - getMinThreshold(unit).orElse(Double.MIN_VALUE));
+        return Math.min(getMaxThreshold(unit).orElse(Double.POSITIVE_INFINITY) - flow, flow - getMinThreshold(unit).orElse(Double.NEGATIVE_INFINITY));
     }
 
     @Override

--- a/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
+++ b/data/crac-file/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
@@ -67,21 +67,19 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
 
     @Override
     public Optional<Double> getMinThreshold(Unit requestedUnit) throws SynchronizationException {
-        switch (direction) {
-            case OUT:
-                return Optional.of(Double.NEGATIVE_INFINITY);
-            default:
-                return Optional.of(-convert(getAbsoluteMax(), unit, requestedUnit));
+        if (direction == Direction.OUT) {
+            return Optional.of(Double.NEGATIVE_INFINITY);
+        } else { // Direction.IN and Direction.BOTH
+            return Optional.of(-convert(getAbsoluteMax(), unit, requestedUnit));
         }
     }
 
     @Override
     public Optional<Double> getMaxThreshold(Unit requestedUnit) throws SynchronizationException {
-        switch (direction) {
-            case IN:
-                return Optional.of(Double.POSITIVE_INFINITY);
-            default:
-                return Optional.of(convert(getAbsoluteMax(), unit, requestedUnit));
+        if (direction == Direction.IN) {
+            return Optional.of(Double.POSITIVE_INFINITY);
+        } else { // Direction.OUT and Direction.BOTH
+            return Optional.of(convert(getAbsoluteMax(), unit, requestedUnit));
         }
     }
 

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/CracFileTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/CracFileTest.java
@@ -396,7 +396,7 @@ public class CracFileTest {
         Cnec cnec = new SimpleCnec(
                 "cnec",
                 new NetworkElement("network-element-1"),
-                new AbsoluteFlowThreshold(Unit.AMPERE, LEFT, IN, 1000.),
+                new AbsoluteFlowThreshold(Unit.AMPERE, LEFT, OPPOSITE, 1000.),
                 new SimpleState(
                     Optional.of(new ComplexContingency("co", Collections.singleton(new NetworkElement("network-element-2")))),
                     new Instant("after-co", 60)
@@ -477,7 +477,7 @@ public class CracFileTest {
         Cnec cnec1 = new SimpleCnec(
                 "cnec1",
                 new NetworkElement("network-element-1"),
-                new AbsoluteFlowThreshold(Unit.AMPERE, LEFT, IN, 1000.),
+                new AbsoluteFlowThreshold(Unit.AMPERE, LEFT, OPPOSITE, 1000.),
                 new SimpleState(Optional.empty(), new Instant("initial-instant", 0))
         );
 
@@ -491,7 +491,7 @@ public class CracFileTest {
         Cnec cnec2 = new SimpleCnec(
                 "cnec2",
                 new NetworkElement("network-element-1"),
-                new AbsoluteFlowThreshold(Unit.AMPERE, LEFT, IN, 1000.),
+                new AbsoluteFlowThreshold(Unit.AMPERE, LEFT, OPPOSITE, 1000.),
                 new SimpleState(
                     Optional.of(new ComplexContingency("co", Collections.singleton(new NetworkElement("network-element-2")))),
                     new Instant("after-co", 60)
@@ -519,7 +519,7 @@ public class CracFileTest {
         Cnec cnec = new SimpleCnec(
                 "cnec2",
                 new NetworkElement("network-element-1"),
-                new AbsoluteFlowThreshold(Unit.AMPERE, LEFT, IN, 1000.),
+                new AbsoluteFlowThreshold(Unit.AMPERE, LEFT, OPPOSITE, 1000.),
                 new SimpleState(
                     Optional.of(new ComplexContingency("co", Collections.singleton(new NetworkElement("network-element-2")))),
                     new Instant("after-co", 60)
@@ -540,7 +540,7 @@ public class CracFileTest {
         Cnec cnec1 = new SimpleCnec(
                 "cnec1",
                 new NetworkElement("network-element-1"),
-                new AbsoluteFlowThreshold(Unit.AMPERE, LEFT, IN, 1000.),
+                new AbsoluteFlowThreshold(Unit.AMPERE, LEFT, OPPOSITE, 1000.),
                 new SimpleState(
                     Optional.of(new ComplexContingency("co", Collections.singleton(new NetworkElement("network-element-2")))),
                     new Instant("after-co", 60)
@@ -550,7 +550,7 @@ public class CracFileTest {
         Cnec cnec2 = new SimpleCnec(
                 "cnec1",
                 new NetworkElement("network-element-1"),
-                new AbsoluteFlowThreshold(Unit.AMPERE, LEFT, IN, 1000.),
+                new AbsoluteFlowThreshold(Unit.AMPERE, LEFT, OPPOSITE, 1000.),
                 new SimpleState(
                     Optional.of(new ComplexContingency("co", Collections.singleton(new NetworkElement("network-element-2")))),
                     new Instant("after-co", 60)

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
@@ -32,9 +32,13 @@ public class AbsoluteFlowThresholdTest {
 
     private AbsoluteFlowThreshold absoluteFlowThresholdAmps;
     private AbsoluteFlowThreshold absoluteFlowThresholdMW;
+    private AbsoluteFlowThreshold absoluteFlowThresholdMWIn;
+    private AbsoluteFlowThreshold absoluteFlowThresholdMWOut;
     private Cnec cnec1;
     private Cnec cnec2;
     private Cnec cnec3;
+    private Cnec cnec4;
+    private Cnec cnec5;
     private Network networkWithoutLf;
     private Network networkWithLf;
 
@@ -42,6 +46,8 @@ public class AbsoluteFlowThresholdTest {
     public void setUp() {
         absoluteFlowThresholdAmps = new AbsoluteFlowThreshold(AMPERE, Side.RIGHT, Direction.BOTH, 500.0);
         absoluteFlowThresholdMW = new AbsoluteFlowThreshold(MEGAWATT, Side.LEFT, Direction.BOTH, 1500.0);
+        absoluteFlowThresholdMWIn = new AbsoluteFlowThreshold(MEGAWATT, Side.LEFT, Direction.IN, 1500.0);
+        absoluteFlowThresholdMWOut = new AbsoluteFlowThreshold(MEGAWATT, Side.LEFT, Direction.OUT, 1500.0);
 
         cnec1 = new SimpleCnec("cnec1", "cnec1", new NetworkElement("FRANCE_BELGIUM_1", "FRANCE_BELGIUM_1"),
                 absoluteFlowThresholdAmps, new SimpleState(Optional.empty(), new Instant("initial", 0)));
@@ -51,6 +57,12 @@ public class AbsoluteFlowThresholdTest {
 
         cnec3 = new SimpleCnec("cnec3", "cnec3", new NetworkElement("FRANCE_BELGIUM_2", "FRANCE_BELGIUM_2"),
                 absoluteFlowThresholdAmps, new SimpleState(Optional.empty(), new Instant("initial", 0)));
+
+        cnec4 = new SimpleCnec("cnec4", "cnec4", new NetworkElement("FRANCE_BELGIUM_2", "FRANCE_BELGIUM_2"),
+                absoluteFlowThresholdMWIn, new SimpleState(Optional.empty(), new Instant("initial", 0)));
+
+        cnec5 = new SimpleCnec("cnec5", "cnec5", new NetworkElement("FRANCE_BELGIUM_2", "FRANCE_BELGIUM_2"),
+                absoluteFlowThresholdMWOut, new SimpleState(Optional.empty(), new Instant("initial", 0)));
 
         networkWithoutLf = Importers.loadNetwork("TestCase2Nodes.xiidm", getClass().getResourceAsStream("/TestCase2Nodes.xiidm"));
         networkWithLf = Importers.loadNetwork("TestCase2Nodes_withLF.xiidm", getClass().getResourceAsStream("/TestCase2Nodes_withLF.xiidm"));
@@ -81,6 +93,8 @@ public class AbsoluteFlowThresholdTest {
     public void getMinMaxThresholdWithUnit() throws SynchronizationException {
         absoluteFlowThresholdAmps.synchronize(networkWithLf, cnec1);
         absoluteFlowThresholdMW.synchronize(networkWithLf, cnec2);
+        absoluteFlowThresholdMWIn.synchronize(networkWithLf, cnec4);
+        absoluteFlowThresholdMWOut.synchronize(networkWithLf, cnec5);
 
         assertEquals(500.0, absoluteFlowThresholdAmps.getMaxThreshold(AMPERE).orElse(Double.MAX_VALUE), DOUBLE_TOL);
         assertEquals(346.4, absoluteFlowThresholdAmps.getMaxThreshold(MEGAWATT).orElse(Double.MAX_VALUE), DOUBLE_TOL);
@@ -91,6 +105,11 @@ public class AbsoluteFlowThresholdTest {
         assertEquals(-346.4, absoluteFlowThresholdAmps.getMinThreshold(MEGAWATT).orElse(Double.MIN_VALUE), DOUBLE_TOL);
         assertEquals(-2165.1, absoluteFlowThresholdMW.getMinThreshold(AMPERE).orElse(Double.MIN_VALUE), DOUBLE_TOL);
         assertEquals(-1500.0, absoluteFlowThresholdMW.getMinThreshold(MEGAWATT).orElse(Double.MIN_VALUE), DOUBLE_TOL);
+
+        assertEquals(-1500.0, absoluteFlowThresholdMWIn.getMinThreshold(MEGAWATT).orElse(Double.NEGATIVE_INFINITY), DOUBLE_TOL);
+        assertEquals(Double.POSITIVE_INFINITY, absoluteFlowThresholdMWIn.getMaxThreshold(MEGAWATT).orElse(Double.POSITIVE_INFINITY), DOUBLE_TOL);
+        assertEquals(Double.NEGATIVE_INFINITY, absoluteFlowThresholdMWOut.getMinThreshold(MEGAWATT).orElse(Double.NEGATIVE_INFINITY), DOUBLE_TOL);
+        assertEquals(1500.0, absoluteFlowThresholdMWOut.getMaxThreshold(MEGAWATT).orElse(Double.POSITIVE_INFINITY), DOUBLE_TOL);
     }
 
     @Test

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
@@ -46,8 +46,8 @@ public class AbsoluteFlowThresholdTest {
     public void setUp() {
         absoluteFlowThresholdAmps = new AbsoluteFlowThreshold(AMPERE, Side.RIGHT, Direction.BOTH, 500.0);
         absoluteFlowThresholdMW = new AbsoluteFlowThreshold(MEGAWATT, Side.LEFT, Direction.BOTH, 1500.0);
-        absoluteFlowThresholdMWIn = new AbsoluteFlowThreshold(MEGAWATT, Side.LEFT, Direction.IN, 1500.0);
-        absoluteFlowThresholdMWOut = new AbsoluteFlowThreshold(MEGAWATT, Side.LEFT, Direction.OUT, 1500.0);
+        absoluteFlowThresholdMWIn = new AbsoluteFlowThreshold(MEGAWATT, Side.LEFT, Direction.OPPOSITE, 1500.0);
+        absoluteFlowThresholdMWOut = new AbsoluteFlowThreshold(MEGAWATT, Side.LEFT, Direction.DIRECT, 1500.0);
 
         cnec1 = new SimpleCnec("cnec1", "cnec1", new NetworkElement("FRANCE_BELGIUM_1", "FRANCE_BELGIUM_1"),
                 absoluteFlowThresholdAmps, new SimpleState(Optional.empty(), new Instant("initial", 0)));
@@ -96,15 +96,15 @@ public class AbsoluteFlowThresholdTest {
         absoluteFlowThresholdMWIn.synchronize(networkWithLf, cnec4);
         absoluteFlowThresholdMWOut.synchronize(networkWithLf, cnec5);
 
-        assertEquals(500.0, absoluteFlowThresholdAmps.getMaxThreshold(AMPERE).orElse(Double.MAX_VALUE), DOUBLE_TOL);
-        assertEquals(346.4, absoluteFlowThresholdAmps.getMaxThreshold(MEGAWATT).orElse(Double.MAX_VALUE), DOUBLE_TOL);
-        assertEquals(2165.1, absoluteFlowThresholdMW.getMaxThreshold(AMPERE).orElse(Double.MAX_VALUE), DOUBLE_TOL);
-        assertEquals(1500.0, absoluteFlowThresholdMW.getMaxThreshold(MEGAWATT).orElse(Double.MAX_VALUE), DOUBLE_TOL);
+        assertEquals(500.0, absoluteFlowThresholdAmps.getMaxThreshold(AMPERE).orElse(Double.POSITIVE_INFINITY), DOUBLE_TOL);
+        assertEquals(346.4, absoluteFlowThresholdAmps.getMaxThreshold(MEGAWATT).orElse(Double.POSITIVE_INFINITY), DOUBLE_TOL);
+        assertEquals(2165.1, absoluteFlowThresholdMW.getMaxThreshold(AMPERE).orElse(Double.POSITIVE_INFINITY), DOUBLE_TOL);
+        assertEquals(1500.0, absoluteFlowThresholdMW.getMaxThreshold(MEGAWATT).orElse(Double.POSITIVE_INFINITY), DOUBLE_TOL);
 
-        assertEquals(-500.0, absoluteFlowThresholdAmps.getMinThreshold(AMPERE).orElse(Double.MIN_VALUE), DOUBLE_TOL);
-        assertEquals(-346.4, absoluteFlowThresholdAmps.getMinThreshold(MEGAWATT).orElse(Double.MIN_VALUE), DOUBLE_TOL);
-        assertEquals(-2165.1, absoluteFlowThresholdMW.getMinThreshold(AMPERE).orElse(Double.MIN_VALUE), DOUBLE_TOL);
-        assertEquals(-1500.0, absoluteFlowThresholdMW.getMinThreshold(MEGAWATT).orElse(Double.MIN_VALUE), DOUBLE_TOL);
+        assertEquals(-500.0, absoluteFlowThresholdAmps.getMinThreshold(AMPERE).orElse(Double.NEGATIVE_INFINITY), DOUBLE_TOL);
+        assertEquals(-346.4, absoluteFlowThresholdAmps.getMinThreshold(MEGAWATT).orElse(Double.NEGATIVE_INFINITY), DOUBLE_TOL);
+        assertEquals(-2165.1, absoluteFlowThresholdMW.getMinThreshold(AMPERE).orElse(Double.NEGATIVE_INFINITY), DOUBLE_TOL);
+        assertEquals(-1500.0, absoluteFlowThresholdMW.getMinThreshold(MEGAWATT).orElse(Double.NEGATIVE_INFINITY), DOUBLE_TOL);
 
         assertEquals(-1500.0, absoluteFlowThresholdMWIn.getMinThreshold(MEGAWATT).orElse(Double.NEGATIVE_INFINITY), DOUBLE_TOL);
         assertEquals(Double.POSITIVE_INFINITY, absoluteFlowThresholdMWIn.getMaxThreshold(MEGAWATT).orElse(Double.POSITIVE_INFINITY), DOUBLE_TOL);

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThresholdTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThresholdTest.java
@@ -71,11 +71,11 @@ public class RelativeFlowThresholdTest {
     public void getMinMaxThresholdWithUnit() throws SynchronizationException {
         relativeFlowThresholdAmps.synchronize(networkWithoutLf, cnec1);
 
-        assertEquals(432.6, relativeFlowThresholdAmps.getMaxThreshold(AMPERE).orElse(Double.MAX_VALUE), DOUBLE_TOL);
-        assertEquals(300.0, relativeFlowThresholdAmps.getMaxThreshold(MEGAWATT).orElse(Double.MAX_VALUE), DOUBLE_TOL);
+        assertEquals(432.6, relativeFlowThresholdAmps.getMaxThreshold(AMPERE).orElse(Double.POSITIVE_INFINITY), DOUBLE_TOL);
+        assertEquals(300.0, relativeFlowThresholdAmps.getMaxThreshold(MEGAWATT).orElse(Double.POSITIVE_INFINITY), DOUBLE_TOL);
 
-        assertEquals(-432.6, relativeFlowThresholdAmps.getMinThreshold(AMPERE).orElse(Double.MAX_VALUE), DOUBLE_TOL);
-        assertEquals(-300.0, relativeFlowThresholdAmps.getMinThreshold(MEGAWATT).orElse(Double.MAX_VALUE), DOUBLE_TOL);
+        assertEquals(-432.6, relativeFlowThresholdAmps.getMinThreshold(AMPERE).orElse(Double.POSITIVE_INFINITY), DOUBLE_TOL);
+        assertEquals(-300.0, relativeFlowThresholdAmps.getMinThreshold(MEGAWATT).orElse(Double.POSITIVE_INFINITY), DOUBLE_TOL);
     }
 
     @Test

--- a/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/usage_rule/OnConstraintTest.java
+++ b/data/crac-file/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/usage_rule/OnConstraintTest.java
@@ -35,7 +35,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.OPPOSITE, 80),
                 initialState
             )
         );
@@ -56,7 +56,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.OPPOSITE, 80),
                 initialState
             )
         );
@@ -77,7 +77,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.OPPOSITE, 80),
                 initialState
             )
         );
@@ -88,7 +88,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.OPPOSITE, 80),
                 initialState
             )
         );
@@ -109,7 +109,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.OPPOSITE, 80),
                 initialState
             )
         );
@@ -130,7 +130,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.OPPOSITE, 80),
                 initialState
             )
         );
@@ -141,7 +141,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.OPPOSITE, 80),
                 initialState
             )
         );
@@ -162,7 +162,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.OPPOSITE, 80),
                 initialState
             )
         );
@@ -173,7 +173,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.OPPOSITE, 80),
                 initialState
             )
         );
@@ -194,7 +194,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.OPPOSITE, 80),
                 initialState
             )
         );
@@ -205,7 +205,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.OPPOSITE, 80),
                 initialState
             )
         );
@@ -226,7 +226,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.OPPOSITE, 80),
                 initialState
             )
         );
@@ -237,7 +237,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.OPPOSITE, 80),
                 initialState
             )
         );
@@ -258,7 +258,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Side.LEFT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.LEFT, Direction.OPPOSITE, 80),
                 initialState
             )
         );
@@ -269,7 +269,7 @@ public class OnConstraintTest {
             new SimpleCnec(
                 "cnec",
                 new NetworkElement("ne1"),
-                new RelativeFlowThreshold(Side.RIGHT, Direction.IN, 80),
+                new RelativeFlowThreshold(Side.RIGHT, Direction.OPPOSITE, 80),
                 initialState
             )
         );

--- a/data/crac-file/crac-io-json/src/test/java/com/farao_community/farao/data/crac_io_json/CracImportExportTest.java
+++ b/data/crac-file/crac-io-json/src/test/java/com/farao_community/farao/data/crac_io_json/CracImportExportTest.java
@@ -52,9 +52,9 @@ public class CracImportExportTest {
         State postContingencyState = simpleCrac.addState(contingency, outageInstant);
         simpleCrac.addState("contingency2Id", "postContingencyId");
 
-        Cnec preventiveCnec1 = simpleCrac.addCnec("cnec1prev", "neId1", new AbsoluteFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 500), preventiveState.getId());
-        simpleCrac.addCnec("cnec2prev", "neId2", new RelativeFlowThreshold(Side.LEFT, Direction.IN, 30), preventiveState.getId());
-        simpleCrac.addCnec("cnec1cur", "neId1", new AbsoluteFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 800), postContingencyState.getId());
+        Cnec preventiveCnec1 = simpleCrac.addCnec("cnec1prev", "neId1", new AbsoluteFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.OPPOSITE, 500), preventiveState.getId());
+        simpleCrac.addCnec("cnec2prev", "neId2", new RelativeFlowThreshold(Side.LEFT, Direction.OPPOSITE, 30), preventiveState.getId());
+        simpleCrac.addCnec("cnec1cur", "neId1", new AbsoluteFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.OPPOSITE, 800), postContingencyState.getId());
 
         List<UsageRule> usageRules = new ArrayList<>();
         usageRules.add(new FreeToUse(UsageMethod.AVAILABLE, preventiveState));

--- a/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/LinearRaoTest.java
+++ b/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/LinearRaoTest.java
@@ -181,8 +181,8 @@ public class LinearRaoTest {
         State stateCurativeContingency2 = new SimpleState(Optional.of(contingency2), curative);
 
         // Thresholds
-        AbsoluteFlowThreshold thresholdAbsFlow = new AbsoluteFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 1500);
-        RelativeFlowThreshold thresholdRelativeFlow = new RelativeFlowThreshold(Side.LEFT, Direction.IN, 30);
+        AbsoluteFlowThreshold thresholdAbsFlow = new AbsoluteFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.OPPOSITE, 1500);
+        RelativeFlowThreshold thresholdRelativeFlow = new RelativeFlowThreshold(Side.LEFT, Direction.OPPOSITE, 30);
 
         // CNECs
         SimpleCnec cnec1basecase = new SimpleCnec("cnec1basecase", "", monitoredElement1, null, stateBasecase);

--- a/util/src/test/java/com/farao_community/farao/util/SystematicSensitivityAnalysisServiceTest.java
+++ b/util/src/test/java/com/farao_community/farao/util/SystematicSensitivityAnalysisServiceTest.java
@@ -116,8 +116,8 @@ public class SystematicSensitivityAnalysisServiceTest {
         State stateCurativeContingency2 = new SimpleState(Optional.of(contingency2), curative);
 
         // Thresholds
-        AbsoluteFlowThreshold thresholdAbsFlow = new AbsoluteFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.IN, 1500);
-        RelativeFlowThreshold thresholdRelativeFlow = new RelativeFlowThreshold(Side.LEFT, Direction.IN, 30);
+        AbsoluteFlowThreshold thresholdAbsFlow = new AbsoluteFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.OPPOSITE, 1500);
+        RelativeFlowThreshold thresholdRelativeFlow = new RelativeFlowThreshold(Side.LEFT, Direction.OPPOSITE, 30);
 
         // CNECs
         SimpleCnec cnec1basecase = new SimpleCnec("cnec1basecase", "", monitoredElement1, null, stateBasecase);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
allows the use of single direction CNECs


**What is the current behavior?** *(You can also link to an open issue here)*
The getMinThreshold and getMaxThreshold functions act as if the CNEC threshold is in both directions.


**What is the new behavior (if this is a feature change)?**
The getMinThreshold and getMaxThreshold functions return different values depending on the direction of the threshold.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
