### PR TITLE
skips linear rao loop if crac contains no range action

### DIFF
--- a/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
+++ b/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
@@ -75,7 +75,7 @@ public class LinearRao implements RaoProvider {
         crac.synchronize(network);
         double oldScore = getMinMargin(crac, preOptimSensitivityAnalysisResult);
 
-        if (linearRaoParameters.getSecurityAnalysisWithoutRao() || linearRaoParameters.getMaxIterations() == 0) {
+        if (linearRaoParameters.getSecurityAnalysisWithoutRao() || linearRaoParameters.getMaxIterations() == 0 || crac.getRangeActions().isEmpty()) {
             return CompletableFuture.completedFuture(buildRaoComputationResult(crac, oldScore));
         }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
The linear rao builds the LP and solves it once even if no range actions are present in the crac.


**What is the new behavior (if this is a feature change)?**
The linear rao will exit and build the solution before creating the LP if no range action is present in the crac.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
