### PR TITLE
reset linear rao attributes at the end of the run method

### DIFF
--- a/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
+++ b/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
@@ -113,7 +113,11 @@ public class LinearRao implements RaoProvider {
             linearRaoModeller.updateProblem(network, tempSensitivityAnalysisResult);
         }
         crac.synchronize(network);
-        return CompletableFuture.completedFuture(buildRaoComputationResult(crac, oldScore));
+        RaoComputationResult linearRaoComputationResult = buildRaoComputationResult(crac, oldScore);
+        preOptimSensitivityAnalysisResult = null;
+        postOptimSensitivityAnalysisResult = null;
+        oldRemedialActionResultList = new ArrayList<>();
+        return CompletableFuture.completedFuture(linearRaoComputationResult);
     }
 
     //defined to be able to run unit tests


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*
When running several times in a row the linear rao with the same inputs (Crac and Network), the results are not the same.

**What is the new behavior (if this is a feature change)?**
When running several times in a row  the linear rao with the same inputs (Crac and Network), the results are the same.