### PR TITLE
Migrate methods from Threshold interface to Cnec interface

### DIFF
--- a/data/crac/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Cnec.java
+++ b/data/crac/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Cnec.java
@@ -7,8 +7,11 @@
 
 package com.farao_community.farao.data.crac_api;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.powsybl.iidm.network.Network;
+
+import java.util.Optional;
 
 /**
  * Interface for Critical Network Element & Contingencies
@@ -37,6 +40,34 @@ public interface Cnec extends Identifiable, Synchronizable {
     double computeMargin(Network network);
 
     Threshold getThreshold();
+
+    /**
+     * A Threshold consists in monitoring a given physical value (FLOW, VOLTAGE
+     * or ANGLE). This physical value can be retrieved by the getPhysicalParameter()
+     * method.
+     */
+    @JsonIgnore
+    PhysicalParameter getPhysicalParameter();
+
+    /**
+     * If it is defined, this function returns the maximum limit of the Threshold,
+     * below which a Cnec cannot be operated securely. Otherwise, this function
+     * returns an empty Optional, which implicitly means that the Threshold is
+     * unbounded above.
+     * The returned value is given with the Unit given in argument of the function.
+     */
+    @JsonIgnore
+    Optional<Double> getMinThreshold(Unit unit);
+
+    /**
+     * If it is defined, this function returns the maximum limit of the Threshold,
+     * below which a Cnec cannot be operated securely. Otherwise, this function
+     * returns an empty Optional, which implicitly means that the Threshold is
+     * unbounded above.
+     * The returned value is given with the unit given in argument of the function.
+     */
+    @JsonIgnore
+    Optional<Double> getMaxThreshold(Unit unit);
 
     /**
      * Get the flow (in A) transmitted by Cnec in a given Network. Note that an I

--- a/data/crac/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
+++ b/data/crac/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Threshold.java
@@ -7,10 +7,7 @@
 
 package com.farao_community.farao.data.crac_api;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
-import java.util.Optional;
 
 /**
  * The threshold describes the monitored physical parameter of a Cnec (flow, voltage
@@ -28,32 +25,4 @@ import java.util.Optional;
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public interface Threshold extends Synchronizable {
-
-    /**
-     * A Threshold consists in monitoring a given physical value (FLOW, VOLTAGE
-     * or ANGLE). This physical value can be retrieved by the getPhysicalParameter()
-     * method.
-     */
-    @JsonIgnore
-    PhysicalParameter getPhysicalParameter();
-
-    /**
-     * If it is defined, this function returns the maximum limit of the Threshold,
-     * below which a Cnec cannot be operated securely. Otherwise, this function
-     * returns an empty Optional, which implicitly means that the Threshold is
-     * unbounded above.
-     * The returned value is given with the Unit given in argument of the function.
-     */
-    @JsonIgnore
-    Optional<Double> getMinThreshold(Unit unit);
-
-    /**
-     * If it is defined, this function returns the maximum limit of the Threshold,
-     * below which a Cnec cannot be operated securely. Otherwise, this function
-     * returns an empty Optional, which implicitly means that the Threshold is
-     * unbounded above.
-     * The returned value is given with the unit given in argument of the function.
-     */
-    @JsonIgnore
-    Optional<Double> getMaxThreshold(Unit unit);
 }

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnec.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnec.java
@@ -16,6 +16,8 @@ import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.Terminal;
 
+import java.util.Optional;
+
 /**
  * Critical network element and contingency.
  *
@@ -103,6 +105,21 @@ public class SimpleCnec extends AbstractIdentifiable implements Cnec {
     private boolean isCnecDisconnected(Network network) {
         Branch branch = network.getBranch(getNetworkElement().getId());
         return !branch.getTerminal1().isConnected() || !branch.getTerminal2().isConnected();
+    }
+
+    @Override
+    public PhysicalParameter getPhysicalParameter() {
+        return threshold.getPhysicalParameter();
+    }
+
+    @Override
+    public Optional<Double> getMinThreshold(Unit requestedUnit) {
+        return threshold.getMinThreshold(requestedUnit);
+    }
+
+    @Override
+    public Optional<Double> getMaxThreshold(Unit requestedUnit) {
+        return threshold.getMaxThreshold(requestedUnit);
     }
 
     @Override

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnec.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnec.java
@@ -114,11 +114,13 @@ public class SimpleCnec extends AbstractIdentifiable implements Cnec {
 
     @Override
     public Optional<Double> getMinThreshold(Unit requestedUnit) {
+        requestedUnit.checkPhysicalParameter(getPhysicalParameter());
         return threshold.getMinThreshold(requestedUnit);
     }
 
     @Override
     public Optional<Double> getMaxThreshold(Unit requestedUnit) {
+        requestedUnit.checkPhysicalParameter(getPhysicalParameter());
         return threshold.getMaxThreshold(requestedUnit);
     }
 

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractThreshold.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractThreshold.java
@@ -9,12 +9,15 @@ package com.farao_community.farao.data.crac_impl.threshold;
 
 import com.farao_community.farao.commons.FaraoException;
 import com.farao_community.farao.data.crac_api.NetworkElement;
+import com.farao_community.farao.data.crac_api.PhysicalParameter;
 import com.farao_community.farao.data.crac_api.Threshold;
 import com.farao_community.farao.data.crac_api.Unit;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.powsybl.iidm.network.Network;
+
+import java.util.Optional;
 
 /**
  * Generic threshold (flow, voltage, etc.) in the CRAC file.
@@ -55,6 +58,34 @@ public abstract class AbstractThreshold implements Threshold {
     public Unit getUnit() {
         return unit;
     }
+
+    /**
+     * A Threshold consists in monitoring a given physical value (FLOW, VOLTAGE
+     * or ANGLE). This physical value can be retrieved by the getPhysicalParameter()
+     * method.
+     */
+    @JsonIgnore
+    public abstract PhysicalParameter getPhysicalParameter();
+
+    /**
+     * If it is defined, this function returns the maximum limit of the Threshold,
+     * below which a Cnec cannot be operated securely. Otherwise, this function
+     * returns an empty Optional, which implicitly means that the Threshold is
+     * unbounded above.
+     * The returned value is given with the Unit given in argument of the function.
+     */
+    @JsonIgnore
+    public abstract Optional<Double> getMinThreshold(Unit unit);
+
+    /**
+     * If it is defined, this function returns the maximum limit of the Threshold,
+     * below which a Cnec cannot be operated securely. Otherwise, this function
+     * returns an empty Optional, which implicitly means that the Threshold is
+     * unbounded above.
+     * The returned value is given with the unit given in argument of the function.
+     */
+    @JsonIgnore
+    public abstract Optional<Double> getMaxThreshold(Unit unit);
 
     @Override
     public void synchronize(Network network) {

--- a/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/SimpleCnecTest.java
+++ b/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/SimpleCnecTest.java
@@ -160,7 +160,7 @@ public class SimpleCnecTest {
         cnecOnLine2.synchronize(network);
         cnecOnLine1.synchronize(network);
 
-        assertEquals(400, cnecOnLine1.getThreshold().getMaxThreshold(Unit.AMPERE).get(), 0.1);
-        assertEquals(250, cnecOnLine2.getThreshold().getMaxThreshold(Unit.AMPERE).get(), 0.1);
+        assertEquals(400, cnecOnLine1.getMaxThreshold(Unit.AMPERE).get(), 0.1);
+        assertEquals(250, cnecOnLine2.getMaxThreshold(Unit.AMPERE).get(), 0.1);
     }
 }

--- a/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
+++ b/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
@@ -173,8 +173,8 @@ public class LinearRao implements RaoProvider {
         for (Cnec cnec : crac.getCnecs()) {
             double margin;
             double flow = systematicSensitivityAnalysisResult.getCnecFlowMap().getOrDefault(cnec, Double.NaN);
-            double margin1 = cnec.getThreshold().getMaxThreshold(Unit.MEGAWATT).orElse(Double.POSITIVE_INFINITY) - flow;
-            double margin2 = flow - cnec.getThreshold().getMinThreshold(Unit.MEGAWATT).orElse(Double.NEGATIVE_INFINITY);
+            double margin1 = cnec.getMaxThreshold(Unit.MEGAWATT).orElse(Double.POSITIVE_INFINITY) - flow;
+            double margin2 = flow - cnec.getMinThreshold(Unit.MEGAWATT).orElse(Double.NEGATIVE_INFINITY);
             margin = Math.min(margin1, margin2);
             if (Double.isNaN(margin)) {
                 throw new FaraoException(format("Cnec %s is not present in the linear RAO result. Bad behaviour.", cnec.getId()));
@@ -225,10 +225,10 @@ public class LinearRao implements RaoProvider {
         }
 
         double limitingThreshold;
-        double margin1 = cnec.getThreshold().getMaxThreshold(Unit.MEGAWATT).orElse(Double.POSITIVE_INFINITY) - postOptimFlow;
-        double margin2 = postOptimFlow - cnec.getThreshold().getMinThreshold(Unit.MEGAWATT).orElse(Double.NEGATIVE_INFINITY);
+        double margin1 = cnec.getMaxThreshold(Unit.MEGAWATT).orElse(Double.POSITIVE_INFINITY) - postOptimFlow;
+        double margin2 = postOptimFlow - cnec.getMinThreshold(Unit.MEGAWATT).orElse(Double.NEGATIVE_INFINITY);
         double marginPostOptim =  Math.min(margin1, margin2);
-        limitingThreshold = cnec.getThreshold().getMaxThreshold(Unit.MEGAWATT).orElse(-cnec.getThreshold().getMinThreshold(Unit.MEGAWATT).orElseThrow(FaraoException::new));
+        limitingThreshold = cnec.getMaxThreshold(Unit.MEGAWATT).orElse(-cnec.getMinThreshold(Unit.MEGAWATT).orElseThrow(FaraoException::new));
         linearRaoResult.updateResult(marginPostOptim);
 
         return new MonitoredBranchResult(cnec.getId(), cnec.getName(), cnec.getNetworkElement().getId(), limitingThreshold, preOptimFlow, postOptimFlow);

--- a/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/fillers/MaxMinMarginFiller.java
+++ b/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/fillers/MaxMinMarginFiller.java
@@ -87,8 +87,8 @@ public class MaxMinMarginFiller extends AbstractProblemFiller {
 
             Optional<Double> minFlow;
             Optional<Double> maxFlow;
-            minFlow = cnec.getThreshold().getMinThreshold(MEGAWATT);
-            maxFlow = cnec.getThreshold().getMaxThreshold(MEGAWATT);
+            minFlow = cnec.getMinThreshold(MEGAWATT);
+            maxFlow = cnec.getMaxThreshold(MEGAWATT);
 
             if (minFlow.isPresent()) {
                 MPConstraint minimumMarginNegative = linearRaoProblem.addMinimumMarginConstraint(-linearRaoProblem.infinity(), -minFlow.get(), cnec, LinearRaoProblem.MarginExtension.BELOW_THRESHOLD);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*
Currently you can only access a threshold from the cnec. 


**What is the new behavior (if this is a feature change)?**
The purpose here is to be able to compute directly min and max values on a line at a given state (meaning a cnec) given the side, the direction and the unit. We have to consider that a cnec can have got several thresholds which are defined in a different way. So all the information have to be gathered to return a unique value considering the side of the line, the direction and the unit.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
