### PR TITLE
Refactor computeMargin

### DIFF
--- a/data/crac/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Cnec.java
+++ b/data/crac/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Cnec.java
@@ -35,9 +35,9 @@ public interface Cnec extends Identifiable<Cnec>, Synchronizable {
      * positive, it means that the limits of the Threshold are respected. If it is negative,
      * it means that that a limit of the Threshold has been overcome.
      *
-     * margin = min(maxThreshold - actualValue, actualValue - minThreshold)
+     * margin = min(maxThreshold - actualFlow, actualFlow - minThreshold)
      */
-    double computeMargin(Network network, Unit requestedUnit);
+    double computeMargin(double actualFlow, Unit flowUnit);
 
     /**
      * A Threshold consists in monitoring a given physical value (FLOW, VOLTAGE

--- a/data/crac/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Cnec.java
+++ b/data/crac/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Cnec.java
@@ -35,9 +35,9 @@ public interface Cnec extends Identifiable<Cnec>, Synchronizable {
      * positive, it means that the limits of the Threshold are respected. If it is negative,
      * it means that that a limit of the Threshold has been overcome.
      *
-     * margin = min(maxThreshold - actualFlow, actualFlow - minThreshold)
+     * margin = min(maxThreshold - actualValue, actualValue - minThreshold)
      */
-    double computeMargin(double actualFlow, Unit flowUnit);
+    double computeMargin(double actualValue, Unit unit);
 
     /**
      * A Threshold consists in monitoring a given physical value (FLOW, VOLTAGE

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnec.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnec.java
@@ -54,15 +54,8 @@ public class SimpleCnec extends AbstractIdentifiable<Cnec> implements Cnec {
         return networkElement;
     }
 
-    public double computeMargin(Network network, Unit requestedUnit) {
-        // todo : switch units if no I is available but P is available
-        double flow;
-        if (requestedUnit.equals(Unit.AMPERE)) {
-            flow = getI(network);
-        } else {
-            flow = getP(network);
-        }
-        return Math.min(getMaxThreshold(requestedUnit).orElse(Double.POSITIVE_INFINITY) - flow, flow - getMinThreshold(requestedUnit).orElse(Double.NEGATIVE_INFINITY));
+    public double computeMargin(double actualFlow, Unit requestedUnit) {
+        return Math.min(getMaxThreshold(requestedUnit).orElse(Double.POSITIVE_INFINITY) - actualFlow, actualFlow - getMinThreshold(requestedUnit).orElse(Double.NEGATIVE_INFINITY));
     }
 
     public void setNetworkElement(NetworkElement networkElement) {

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnec.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnec.java
@@ -54,8 +54,8 @@ public class SimpleCnec extends AbstractIdentifiable<Cnec> implements Cnec {
         return networkElement;
     }
 
-    public double computeMargin(double actualFlow, Unit requestedUnit) {
-        return Math.min(getMaxThreshold(requestedUnit).orElse(Double.POSITIVE_INFINITY) - actualFlow, actualFlow - getMinThreshold(requestedUnit).orElse(Double.NEGATIVE_INFINITY));
+    public double computeMargin(double actualValue, Unit unit) {
+        return Math.min(getMaxThreshold(unit).orElse(Double.POSITIVE_INFINITY) - actualValue, actualValue - getMinThreshold(unit).orElse(Double.NEGATIVE_INFINITY));
     }
 
     public void setNetworkElement(NetworkElement networkElement) {

--- a/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/SimpleCnecTest.java
+++ b/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/SimpleCnecTest.java
@@ -101,12 +101,12 @@ public class SimpleCnecTest {
         // threshold = [-500;500]
         Mockito.when(threshold.getMinThreshold(Unit.AMPERE)).thenReturn(Optional.of(-500.0));
         Mockito.when(threshold.getMaxThreshold(Unit.AMPERE)).thenReturn(Optional.of(500.0));
-        assertEquals(500.0 - flow, cnec1.computeMargin(networkWithLf, Unit.AMPERE), DOUBLE_TOLERANCE);
+        assertEquals(500.0 - flow, cnec1.computeMargin(flow, Unit.AMPERE), DOUBLE_TOLERANCE);
 
         // threshold = [-inf ; 300]
         Mockito.when(threshold.getMinThreshold(Unit.AMPERE)).thenReturn(Optional.empty());
         Mockito.when(threshold.getMaxThreshold(Unit.AMPERE)).thenReturn(Optional.of(300.0));
-        assertEquals(300.0 - flow, cnec1.computeMargin(networkWithLf, Unit.AMPERE), DOUBLE_TOLERANCE);
+        assertEquals(300.0 - flow, cnec1.computeMargin(flow, Unit.AMPERE), DOUBLE_TOLERANCE);
     }
 
     @Test
@@ -119,17 +119,17 @@ public class SimpleCnecTest {
         // threshold = [-500;500]
         Mockito.when(threshold.getMinThreshold(Unit.MEGAWATT)).thenReturn(Optional.of(-500.0));
         Mockito.when(threshold.getMaxThreshold(Unit.MEGAWATT)).thenReturn(Optional.of(500.0));
-        assertEquals(flow - (-500.0), cnec1.computeMargin(networkWithLf, Unit.MEGAWATT), DOUBLE_TOLERANCE);
+        assertEquals(flow - (-500.0), cnec1.computeMargin(flow, Unit.MEGAWATT), DOUBLE_TOLERANCE);
 
         // threshold = [-inf ; 300]
         Mockito.when(threshold.getMinThreshold(Unit.MEGAWATT)).thenReturn(Optional.empty());
         Mockito.when(threshold.getMaxThreshold(Unit.MEGAWATT)).thenReturn(Optional.of(300.0));
-        assertEquals(300.0 - flow, cnec1.computeMargin(networkWithLf, Unit.MEGAWATT), DOUBLE_TOLERANCE);
+        assertEquals(300.0 - flow, cnec1.computeMargin(flow, Unit.MEGAWATT), DOUBLE_TOLERANCE);
 
         // threshold = [-300 ; +inf]
         Mockito.when(threshold.getMinThreshold(Unit.MEGAWATT)).thenReturn(Optional.of(-300.0));
         Mockito.when(threshold.getMaxThreshold(Unit.MEGAWATT)).thenReturn(Optional.empty());
-        assertEquals(flow - (-300.0), cnec1.computeMargin(networkWithLf, Unit.MEGAWATT), DOUBLE_TOLERANCE);
+        assertEquals(flow - (-300.0), cnec1.computeMargin(flow, Unit.MEGAWATT), DOUBLE_TOLERANCE);
     }
 
     @Test
@@ -143,16 +143,16 @@ public class SimpleCnecTest {
 
         // terminal 1 disconnected
         networkWithLf.getBranch("FRANCE_BELGIUM_2").getTerminal1().disconnect();
-        assertEquals(500.0 - 0.0, cnec2.computeMargin(networkWithLf, Unit.MEGAWATT), DOUBLE_TOLERANCE);
+        assertEquals(500.0 - 0.0, cnec2.computeMargin(cnec2.getP(networkWithLf), Unit.MEGAWATT), DOUBLE_TOLERANCE);
 
         // terminal 2 disconnected
         networkWithLf.getBranch("FRANCE_BELGIUM_2").getTerminal1().connect();
         networkWithLf.getBranch("FRANCE_BELGIUM_2").getTerminal2().disconnect();
-        assertEquals(500.0 - 0.0, cnec2.computeMargin(networkWithLf, Unit.MEGAWATT), DOUBLE_TOLERANCE);
+        assertEquals(500.0 - 0.0, cnec2.computeMargin(cnec2.getP(networkWithLf), Unit.MEGAWATT), DOUBLE_TOLERANCE);
 
         // both terminal disconnected
         networkWithLf.getBranch("FRANCE_BELGIUM_2").getTerminal1().disconnect();
-        assertEquals(500.0 - 0.0, cnec2.computeMargin(networkWithLf, Unit.MEGAWATT), DOUBLE_TOLERANCE);
+        assertEquals(500.0 - 0.0, cnec2.computeMargin(cnec2.getP(networkWithLf), Unit.MEGAWATT), DOUBLE_TOLERANCE);
     }
 
     @Test

--- a/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
+++ b/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
@@ -222,9 +222,9 @@ public class LinearRao implements RaoProvider {
         }
 
         double marginPostOptim =  cnec.computeMargin(postOptimFlow, Unit.MEGAWATT);
-        double limitingThreshold = cnec.getMaxThreshold(Unit.MEGAWATT).orElse(-cnec.getMinThreshold(Unit.MEGAWATT).orElseThrow(FaraoException::new));
+        double absoluteThreshold = cnec.getMaxThreshold(Unit.MEGAWATT).orElse(-cnec.getMinThreshold(Unit.MEGAWATT).orElseThrow(FaraoException::new));
         linearRaoResult.updateResult(marginPostOptim);
 
-        return new MonitoredBranchResult(cnec.getId(), cnec.getName(), cnec.getNetworkElement().getId(), limitingThreshold, preOptimFlow, postOptimFlow);
+        return new MonitoredBranchResult(cnec.getId(), cnec.getName(), cnec.getNetworkElement().getId(), absoluteThreshold, preOptimFlow, postOptimFlow);
     }
 }

--- a/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
+++ b/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
@@ -171,11 +171,8 @@ public class LinearRao implements RaoProvider {
     private double getMinMargin(Crac crac, SystematicSensitivityAnalysisResult systematicSensitivityAnalysisResult) {
         double minMargin = Double.POSITIVE_INFINITY;
         for (Cnec cnec : crac.getCnecs()) {
-            double margin;
             double flow = systematicSensitivityAnalysisResult.getCnecFlowMap().getOrDefault(cnec, Double.NaN);
-            double margin1 = cnec.getMaxThreshold(Unit.MEGAWATT).orElse(Double.POSITIVE_INFINITY) - flow;
-            double margin2 = flow - cnec.getMinThreshold(Unit.MEGAWATT).orElse(Double.NEGATIVE_INFINITY);
-            margin = Math.min(margin1, margin2);
+            double margin = cnec.computeMargin(flow, Unit.MEGAWATT);
             if (Double.isNaN(margin)) {
                 throw new FaraoException(format("Cnec %s is not present in the linear RAO result. Bad behaviour.", cnec.getId()));
             }
@@ -224,11 +221,8 @@ public class LinearRao implements RaoProvider {
             throw new FaraoException(format("Cnec %s is not present in the linear RAO result. Bad behaviour.", cnec.getId()));
         }
 
-        double limitingThreshold;
-        double margin1 = cnec.getMaxThreshold(Unit.MEGAWATT).orElse(Double.POSITIVE_INFINITY) - postOptimFlow;
-        double margin2 = postOptimFlow - cnec.getMinThreshold(Unit.MEGAWATT).orElse(Double.NEGATIVE_INFINITY);
-        double marginPostOptim =  Math.min(margin1, margin2);
-        limitingThreshold = cnec.getMaxThreshold(Unit.MEGAWATT).orElse(-cnec.getMinThreshold(Unit.MEGAWATT).orElseThrow(FaraoException::new));
+        double marginPostOptim =  cnec.computeMargin(postOptimFlow, Unit.MEGAWATT);
+        double limitingThreshold = cnec.getMaxThreshold(Unit.MEGAWATT).orElse(-cnec.getMinThreshold(Unit.MEGAWATT).orElseThrow(FaraoException::new));
         linearRaoResult.updateResult(marginPostOptim);
 
         return new MonitoredBranchResult(cnec.getId(), cnec.getName(), cnec.getNetworkElement().getId(), limitingThreshold, preOptimFlow, postOptimFlow);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
Currently the computeMargin(Network) method inside crac-api for cnec interface is possibly wrong because a cnec is associated to a state (which corresponds to a network state), so the margin of a cnec has to be computed on the corresponding network state. Here, as an argument, we have no guarantee that the network object will be the correct one associated to the good state.

**What is the new behavior (if this is a feature change)?**
Min and max thresholds will be directly accessible from the cnec so the only remaining thing is to implement a method which computes the margin directly from the flow (double value). The user can already do it by comparing the flow value and cnec min and max values but we can internalize this method inside the cnec to make it more readable.
