### PR TITLE
fixing export for contingencies

### DIFF
--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/ComplexContingency.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/ComplexContingency.java
@@ -11,7 +11,9 @@ import com.farao_community.farao.commons.FaraoException;
 import com.farao_community.farao.data.crac_api.AbstractIdentifiable;
 import com.farao_community.farao.data.crac_api.Contingency;
 import com.farao_community.farao.data.crac_api.NetworkElement;
+import com.farao_community.farao.data.crac_impl.json.serializers.ComplexContingencySerializer;
 import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.contingency.BranchContingency;
 import com.powsybl.iidm.network.Branch;
@@ -27,15 +29,12 @@ import java.util.Set;
  * @author Viktor Terrier {@literal <viktor.terrier at rte-france.com>}
  */
 @JsonTypeName("complex-contingency")
-@JsonIdentityInfo(scope = ComplexContingency.class, generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+@JsonSerialize(using = ComplexContingencySerializer.class)
 public class ComplexContingency extends AbstractIdentifiable implements Contingency {
 
-    @JsonProperty("networkElements")
     private Set<NetworkElement> networkElements;
 
-    @JsonCreator
-    public ComplexContingency(@JsonProperty("id") String id,  @JsonProperty("name") String name,
-                              @JsonProperty("networkElements") final Set<NetworkElement> networkElements) {
+    public ComplexContingency(String id, String name, final Set<NetworkElement> networkElements) {
         super(id, name);
         this.networkElements = networkElements;
     }

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/json/CracImplJsonModule.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/json/CracImplJsonModule.java
@@ -7,9 +7,11 @@
 package com.farao_community.farao.data.crac_impl.json;
 
 import com.farao_community.farao.data.crac_api.NetworkAction;
+import com.farao_community.farao.data.crac_impl.ComplexContingency;
 import com.farao_community.farao.data.crac_impl.SimpleCnec;
 import com.farao_community.farao.data.crac_impl.SimpleCrac;
 import com.farao_community.farao.data.crac_impl.SimpleState;
+import com.farao_community.farao.data.crac_impl.json.serializers.ComplexContingencySerializer;
 import com.farao_community.farao.data.crac_impl.json.serializers.SimpleCnecSerializer;
 import com.farao_community.farao.data.crac_impl.json.serializers.SimpleCracSerializer;
 import com.farao_community.farao.data.crac_impl.json.serializers.SimpleStateSerializer;
@@ -35,6 +37,7 @@ public class CracImplJsonModule extends SimpleModule {
 
     public CracImplJsonModule() {
         super();
+        this.addSerializer(ComplexContingency.class, new ComplexContingencySerializer());
         this.addSerializer(FreeToUse.class, new FreeToUseSerializer());
         this.addSerializer(OnConstraint.class, new OnConstraintSerializer());
         this.addSerializer(OnContingency.class, new OnContingencySerializer());

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/json/serializers/ComplexContingencySerializer.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/json/serializers/ComplexContingencySerializer.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ */
+
+package com.farao_community.farao.data.crac_impl.json.serializers;
+
+import com.farao_community.farao.data.crac_api.*;
+import com.farao_community.farao.data.crac_impl.ComplexContingency;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.WritableTypeId;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+
+import java.io.IOException;
+
+/**
+ * @author Philippe Edwards {@literal <philippe.edwards at rte-france.com>}
+ */
+public class ComplexContingencySerializer extends JsonSerializer<ComplexContingency> {
+    @Override
+    public void serialize(ComplexContingency value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeStringField("id", value.getId());
+        gen.writeStringField("name", value.getName());
+        gen.writeArrayFieldStart("networkElements");
+        for (NetworkElement networkElement: value.getNetworkElements()) {
+            gen.writeObject(networkElement.getId());
+        }
+        gen.writeEndArray();
+    }
+
+    @Override
+    public void serializeWithType(ComplexContingency contingency, JsonGenerator jsonGenerator, SerializerProvider serializerProvider, TypeSerializer typeSerializer) throws IOException {
+        WritableTypeId writableTypeId = typeSerializer.typeId(contingency, JsonToken.START_OBJECT);
+        typeSerializer.writeTypePrefix(jsonGenerator, writableTypeId);
+        serialize(contingency, jsonGenerator, serializerProvider);
+        typeSerializer.writeTypeSuffix(jsonGenerator, writableTypeId);
+
+    }
+}

--- a/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/json/RoundTripUtil.java
+++ b/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/json/RoundTripUtil.java
@@ -45,9 +45,9 @@ public final class RoundTripUtil {
             ObjectMapper objectMapper = createObjectMapper();
             objectMapper.registerModule(new Jdk8Module());
             objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-            ObjectWriter writer = objectMapper.writerWithDefaultPrettyPrinter();
             SimpleModule module = new CracImplJsonModule();
             objectMapper.registerModule(module);
+            ObjectWriter writer = objectMapper.writerWithDefaultPrettyPrinter();
             writer.writeValue(outputStream, object);
         } catch (IOException e) {
             throw new UncheckedIOException(e);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
exporting a crac with contingencies writes the whole network elements in the contingencies making the json impossible to import


**What is the new behavior (if this is a feature change)?**
the contingencies now only contain the network element ids


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
