### PR TITLE
Add PowSyBl classic configuration in distribution dependencies

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -166,6 +166,12 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-config-classic</artifactId>
+            <version>${powsybl.core.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-ampl-converter</artifactId>
             <version>${powsybl.core.version}</version>
             <scope>runtime</scope>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Currently, there is no platform configuration dependency deployed in distribution package. itools script does not work then


**What is the new behavior (if this is a feature change)?**
Distribution package is complete

