### PR TITLE
Corrected minimim and maximum PST angles when range is given in CRAC

### DIFF
--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/remedial_action/range_action/PstWithRange.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/remedial_action/range_action/PstWithRange.java
@@ -134,6 +134,7 @@ public final class PstWithRange extends AbstractElementaryRangeAction implements
         return Math.min(lowTapPositionRangeIntersection(network, range), highTapPositionRangeIntersection(network, range));
     }
 
+    // Max value allowed by a range (from Crac)
     @Override
     protected double getMaxValueWithRange(Network network, Range range) {
         return Math.max(lowTapPositionRangeIntersection(network, range), highTapPositionRangeIntersection(network, range));

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/remedial_action/range_action/PstWithRange.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/remedial_action/range_action/PstWithRange.java
@@ -131,12 +131,26 @@ public final class PstWithRange extends AbstractElementaryRangeAction implements
     // Min value allowed by a range (from Crac)
     @Override
     protected double getMinValueWithRange(Network network, Range range) {
-        double minValue = range.getMin();
-        return convertTapToAngle(Math.max(lowTapPosition, (int) getExtremumValueWithRange(range, getCurrentTapPosition(network), minValue)));
+        return Math.min(lowTapPositionRangeIntersection(network, range), highTapPositionRangeIntersection(network, range));
     }
 
     @Override
     protected double getMaxValueWithRange(Network network, Range range) {
+        return Math.max(lowTapPositionRangeIntersection(network, range), highTapPositionRangeIntersection(network, range));
+    }
+
+    /**
+    Maximum value between lowTapPosition and lower range bound
+     */
+    private double lowTapPositionRangeIntersection(Network network, Range range) {
+        double minValue = range.getMin();
+        return convertTapToAngle(Math.max(lowTapPosition, (int) getExtremumValueWithRange(range, getCurrentTapPosition(network), minValue)));
+    }
+
+    /**
+     Minimum value between highTapPosition and upper range bound
+     */
+    private double highTapPositionRangeIntersection(Network network, Range range) {
         double maxValue = range.getMax();
         return convertTapToAngle(Math.min(highTapPosition, (int) getExtremumValueWithRange(range, getCurrentTapPosition(network), maxValue)));
     }

--- a/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/remedial_action/range_action/PstWithRangeTest.java
+++ b/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/remedial_action/range_action/PstWithRangeTest.java
@@ -264,6 +264,7 @@ public class PstWithRangeTest extends AbstractElementaryRangeActionTest {
     @Test
     public void handleDecreasingAnglesMinMax() {
         // First test case where deltaU is negative
+        pst.addRange(new Range(-10.0, 10.0, RangeType.ABSOLUTE_FIXED, RangeDefinition.CENTERED_ON_ZERO));
         pst.synchronize(network);
         assertTrue("Failed to compute min and max tap values for PST with negative deltaU",
                 pst.getMinValue(network) <= pst.getMaxValue(network));
@@ -273,6 +274,7 @@ public class PstWithRangeTest extends AbstractElementaryRangeActionTest {
         String networkElementId2 = "BBE2AA1  BBE3AA1  1";
         NetworkElement networkElement2 = new NetworkElement(networkElementId2);
         PstWithRange pst2 = new PstWithRange("pst_range_id", networkElement2);
+        pst2.addRange(new Range(-10.0, 10.0, RangeType.ABSOLUTE_FIXED, RangeDefinition.CENTERED_ON_ZERO));
         pst2.synchronize(network2);
         assertTrue("Failed to compute min and max tap values for PST with positive deltaU",
                 pst2.getMinValue(network) <= pst2.getMaxValue(network));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug in PstWithRange


**What is the current behavior?** *(You can also link to an open issue here)*
For a PST with positive deltaU, when a range is given in the CRAC, its intersection with the range given in the network file behaves badly : upper and lower bounds of the intersection are inverted


**What is the new behavior (if this is a feature change)?**
The lower and upper bounds of the intersection are correctly computed
Tests have been added