### PR TITLE
add isRangeAction and isNetworkAction methods

### DIFF
--- a/data/crac/crac-api/src/main/java/com/farao_community/farao/data/crac_api/RemedialAction.java
+++ b/data/crac/crac-api/src/main/java/com/farao_community/farao/data/crac_api/RemedialAction.java
@@ -38,4 +38,8 @@ public interface RemedialAction<I extends RemedialAction<I>> extends Identifiabl
      */
     @JsonIgnore
     Set<NetworkElement> getNetworkElements();
+
+    boolean isRangeAction();
+
+    boolean isNetworkAction();
 }

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/remedial_action/network_action/AbstractNetworkAction.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/remedial_action/network_action/AbstractNetworkAction.java
@@ -31,4 +31,14 @@ public abstract class AbstractNetworkAction extends AbstractRemedialAction<Netwo
     public AbstractNetworkAction(String id) {
         super(id);
     }
+
+    @Override
+    public boolean isRangeAction() {
+        return false;
+    }
+
+    @Override
+    public boolean isNetworkAction() {
+        return true;
+    }
 }

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/remedial_action/range_action/AbstractRangeAction.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/remedial_action/range_action/AbstractRangeAction.java
@@ -44,6 +44,16 @@ public abstract class AbstractRangeAction extends AbstractRemedialAction<RangeAc
     }
 
     @Override
+    public boolean isRangeAction() {
+        return true;
+    }
+
+    @Override
+    public boolean isNetworkAction() {
+        return false;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/remedial_action/network_action/ComplexNetworkActionTest.java
+++ b/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/remedial_action/network_action/ComplexNetworkActionTest.java
@@ -54,6 +54,12 @@ public class ComplexNetworkActionTest {
     }
 
     @Test
+    public void isNetworkAction() {
+        assertTrue(complexNetworkAction.isNetworkAction());
+        assertFalse(complexNetworkAction.isRangeAction());
+    }
+
+    @Test
     public void getApplicableNetworkActions() {
 
         Set<NetworkAction> applicableNetworkActions = Collections.singleton(mockedNetworkAction);

--- a/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/remedial_action/range_action/AlignedRangeActionTest.java
+++ b/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/remedial_action/range_action/AlignedRangeActionTest.java
@@ -66,6 +66,12 @@ public class AlignedRangeActionTest {
     }
 
     @Test
+    public void isRangeAction() {
+        assertTrue(alignedRangeAction.isRangeAction());
+        assertFalse(alignedRangeAction.isNetworkAction());
+    }
+
+    @Test
     public void getRanges() {
         assertEquals(mockedRanges, alignedRangeAction.getRanges());
     }


### PR DESCRIPTION
Add two methods in crac-api: isRangeAction and isNetworkAction.
These methods are implemented in crac-impl.

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
