### PR TITLE
Fix root evaluation not switching back to initial variant

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/process/search_tree/Tree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/process/search_tree/Tree.java
@@ -18,7 +18,6 @@ import com.farao_community.farao.search_tree_rao.config.SearchTreeRaoParameters;
 import com.farao_community.farao.util.FaraoNetworkPool;
 import com.powsybl.iidm.network.Network;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -56,7 +55,7 @@ public final class Tree {
 
         Leaf rootLeaf = new Leaf();
         String initialNetworkVariant = network.getVariantManager().getWorkingVariantId();
-        String newNetworkVariant = RandomizedString.getRandomizedString(Collections.singleton(initialNetworkVariant));
+        String newNetworkVariant = RandomizedString.getRandomizedString(network.getVariantManager().getVariantIds());
         network.getVariantManager().cloneVariant(initialNetworkVariant, newNetworkVariant);
         rootLeaf.evaluate(network, crac, newNetworkVariant, parameters);
         network.getVariantManager().setWorkingVariant(initialNetworkVariant);

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/process/search_tree/Tree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/process/search_tree/Tree.java
@@ -7,6 +7,7 @@
 package com.farao_community.farao.search_tree_rao.process.search_tree;
 
 import com.farao_community.farao.commons.FaraoException;
+import com.farao_community.farao.commons.RandomizedString;
 import com.farao_community.farao.data.crac_api.Crac;
 import com.farao_community.farao.data.crac_api.NetworkAction;
 import com.farao_community.farao.data.crac_api.UsageMethod;
@@ -17,6 +18,7 @@ import com.farao_community.farao.search_tree_rao.config.SearchTreeRaoParameters;
 import com.farao_community.farao.util.FaraoNetworkPool;
 import com.powsybl.iidm.network.Network;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -53,7 +55,11 @@ public final class Tree {
         SearchTreeRaoParameters searchTreeRaoParameters = parameters.getExtensionByName("SearchTreeRaoParameters");
 
         Leaf rootLeaf = new Leaf();
-        rootLeaf.evaluate(network, crac, referenceNetworkVariant, parameters);
+        String initialNetworkVariant = network.getVariantManager().getWorkingVariantId();
+        String newNetworkVariant = RandomizedString.getRandomizedString(Collections.singleton(initialNetworkVariant));
+        network.getVariantManager().cloneVariant(initialNetworkVariant, newNetworkVariant);
+        rootLeaf.evaluate(network, crac, newNetworkVariant, parameters);
+        network.getVariantManager().setWorkingVariant(initialNetworkVariant);
         int depth = 0;
 
         if (rootLeaf.getStatus() == Leaf.Status.EVALUATION_ERROR) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
After evaluating the root we do not switch back to the initial variant. This means we start the next iterations with the optimized PSTs etc


**What is the new behavior (if this is a feature change)?**
We clone the initial variant and switch back to it after evaluating the root.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
