### PR TITLE
management of FRM during computation

### DIFF
--- a/data/crac/crac-api/src/main/java/com/farao_community/farao/data/crac_api/CnecAdder.java
+++ b/data/crac/crac-api/src/main/java/com/farao_community/farao/data/crac_api/CnecAdder.java
@@ -46,6 +46,13 @@ public interface CnecAdder extends NetworkElementParent<CnecAdder> {
      */
     ThresholdAdder newThreshold();
 
+    /***
+     * Set the frm of the created cnec
+     * @param frm the value of the frm in Megawatts
+     * @return the {@code CnecAdder} instance
+     */
+    CnecAdder setFrm(double frm);
+
     /**
      * Add the new Cnec to the Crac
      * @return the created {@code Cnec} instance

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnec.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnec.java
@@ -43,6 +43,7 @@ public class SimpleCnec extends AbstractIdentifiable<Cnec> implements Cnec {
 
         this.networkElement = networkElement;
         this.thresholds = new HashSet<>();
+        thresholds.forEach(threshold -> threshold.setMargin(frm));
         thresholds.forEach(this::addThreshold);
         this.state = state;
         isSynchronized = false;
@@ -52,14 +53,7 @@ public class SimpleCnec extends AbstractIdentifiable<Cnec> implements Cnec {
     public SimpleCnec(String id, String name,
                       NetworkElement networkElement,
                       Set<AbstractThreshold> thresholds, State state) {
-        super(id, name);
-
-        this.networkElement = networkElement;
-        this.thresholds = new HashSet<>();
-        thresholds.forEach(this::addThreshold);
-        this.state = state;
-        isSynchronized = false;
-        this.frm = 0;
+        this(id, name, networkElement, thresholds, state, 0.0);
     }
 
     public SimpleCnec(String id, NetworkElement networkElement, Set<AbstractThreshold> thresholds, State state) {

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnec.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnec.java
@@ -43,7 +43,7 @@ public class SimpleCnec extends AbstractIdentifiable<Cnec> implements Cnec {
 
         this.networkElement = networkElement;
         this.thresholds = new HashSet<>();
-        thresholds.forEach(threshold -> threshold.setMargin(frm));
+        thresholds.forEach(threshold -> threshold.setMargin(frm, Unit.MEGAWATT));
         thresholds.forEach(this::addThreshold);
         this.state = state;
         isSynchronized = false;

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnecAdder.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnecAdder.java
@@ -27,6 +27,7 @@ public class SimpleCnecAdder extends AbstractIdentifiableAdder<SimpleCnecAdder> 
     private Set<AbstractThreshold> thresholds = new HashSet<>();
     private Instant instant;
     private Contingency contingency;
+    private double frm;
 
     public SimpleCnecAdder(SimpleCrac parent) {
         Objects.requireNonNull(parent);
@@ -64,6 +65,12 @@ public class SimpleCnecAdder extends AbstractIdentifiableAdder<SimpleCnecAdder> 
     }
 
     @Override
+    public CnecAdder setFrm(double frm) {
+        this.frm = frm;
+        return this;
+    }
+
+    @Override
     public Cnec add() {
         checkId();
         if (this.networkElement == null) {
@@ -76,7 +83,7 @@ public class SimpleCnecAdder extends AbstractIdentifiableAdder<SimpleCnecAdder> 
             throw new FaraoException("Cannot add a cnec with no specified state instant. Please use setInstant.");
         }
         SimpleState state = new SimpleState((this.contingency != null) ? Optional.of(this.contingency) : Optional.empty(), this.instant);
-        SimpleCnec cnec = new SimpleCnec(this.id, this.name, networkElement, thresholds, state);
+        SimpleCnec cnec = new SimpleCnec(this.id, this.name, networkElement, thresholds, state, frm);
         parent.addCnec(cnec);
         return cnec;
     }

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThreshold.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThreshold.java
@@ -34,9 +34,10 @@ public class AbsoluteFlowThreshold extends AbstractFlowThreshold {
         setMaxValue(maxValue);
     }
 
-    public AbsoluteFlowThreshold(Unit unit, NetworkElement networkElement, Side side, Direction direction, double maxValue) {
+    public AbsoluteFlowThreshold(Unit unit, NetworkElement networkElement, Side side, Direction direction, double maxValue, double frmInMw) {
         super(unit, networkElement, side, direction);
         setMaxValue(maxValue);
+        this.frmInMW = frmInMw;
     }
 
     private void setMaxValue(double maxValue) {
@@ -57,7 +58,7 @@ public class AbsoluteFlowThreshold extends AbstractFlowThreshold {
 
     @Override
     public AbstractThreshold copy() {
-        AbsoluteFlowThreshold copiedAbsoluteFlowThreshold = new AbsoluteFlowThreshold(unit, networkElement, side, direction, maxValue);
+        AbsoluteFlowThreshold copiedAbsoluteFlowThreshold = new AbsoluteFlowThreshold(unit, networkElement, side, direction, maxValue, frmInMW);
         if (isSynchronized()) {
             copiedAbsoluteFlowThreshold.isSynchronized = isSynchronized;
             copiedAbsoluteFlowThreshold.voltageLevel = voltageLevel;

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
@@ -137,8 +137,12 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
         this.side = side;
     }
 
-    public void setMargin(double frmInMW) {
-        this.frmInMW = frmInMW;
+    public void setMargin(double frmInMW, Unit unit) {
+        if (unit != Unit.MEGAWATT) {
+            throw new FaraoException("Unable to handle another margin than the FRM in Megawatts");
+        } else {
+            this.frmInMW = frmInMW;
+        }
     }
 
     /**

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
@@ -51,7 +51,7 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
     /**
      * Flow reliability margin of the Cnec associated to this threshold, in MEGAWATT
      */
-    private double frmInMW;
+    protected double frmInMW;
 
     protected boolean isSynchronized;
 
@@ -204,7 +204,9 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
             result = threshold.networkElement == null;
         }
         return result && unit.equals(threshold.unit)
-            && side.equals(threshold.side) && direction.equals(threshold.direction);
+            && side.equals(threshold.side)
+                && direction.equals(threshold.direction)
+                && frmInMW == (threshold.frmInMW);
     }
 
     @Override
@@ -212,6 +214,7 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
         int result = unit.hashCode();
         result = 31 * result + side.hashCode();
         result = 31 * result + direction.hashCode();
+        result += frmInMW;
         return result;
     }
 }

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
@@ -16,8 +16,6 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.Network;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
@@ -34,8 +32,6 @@ import java.util.Optional;
         @JsonSubTypes.Type(value = RelativeFlowThreshold.class, name = "relative-flow-threshold")
     })
 public abstract class AbstractFlowThreshold extends AbstractThreshold {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbsoluteFlowThreshold.class);
 
     /**
      * Side of the network element which is monitored

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractFlowThreshold.java
@@ -48,6 +48,11 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
      */
     protected double voltageLevel;
 
+    /**
+     * Flow reliability margin of the Cnec associated to this threshold, in MEGAWATT
+     */
+    private double frmInMW;
+
     protected boolean isSynchronized;
 
     public AbstractFlowThreshold(Unit unit, NetworkElement networkElement, Side side, Direction direction) {
@@ -72,7 +77,9 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
         if (direction == Direction.DIRECT) {
             return Optional.empty();
         } else { // Direction.OPPOSITE and Direction.BOTH
-            return Optional.of(-convert(getAbsoluteMax(), unit, requestedUnit));
+            return Optional.of(
+                    convert(frmInMW, Unit.MEGAWATT, requestedUnit)
+                    - convert(getAbsoluteMax(), unit, requestedUnit));
         }
     }
 
@@ -81,7 +88,9 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
         if (direction == Direction.OPPOSITE) {
             return Optional.empty();
         } else { // Direction.DIRECT and Direction.BOTH
-            return Optional.of(convert(getAbsoluteMax(), unit, requestedUnit));
+            return Optional.of(
+                    convert(getAbsoluteMax(), unit, requestedUnit)
+                    - convert(frmInMW, Unit.MEGAWATT, requestedUnit));
         }
     }
 
@@ -126,6 +135,10 @@ public abstract class AbstractFlowThreshold extends AbstractThreshold {
 
     public void setSide(Side side) {
         this.side = side;
+    }
+
+    public void setMargin(double frmInMW) {
+        this.frmInMW = frmInMW;
     }
 
     /**

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractThreshold.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractThreshold.java
@@ -105,5 +105,5 @@ public abstract class AbstractThreshold implements Synchronizable {
     @Override
     public abstract int hashCode();
 
-    public abstract void setMargin(double margin);
+    public abstract void setMargin(double margin, Unit unit);
 }

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractThreshold.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/AbstractThreshold.java
@@ -104,4 +104,6 @@ public abstract class AbstractThreshold implements Synchronizable {
 
     @Override
     public abstract int hashCode();
+
+    public abstract void setMargin(double margin);
 }

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThreshold.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/RelativeFlowThreshold.java
@@ -41,9 +41,10 @@ public class RelativeFlowThreshold extends AbstractFlowThreshold {
         initPercentageOfMax(percentageOfMax);
     }
 
-    public RelativeFlowThreshold(NetworkElement networkElement, Side side, Direction direction, double percentageOfMax) {
+    public RelativeFlowThreshold(NetworkElement networkElement, Side side, Direction direction, double percentageOfMax, double frmInMw) {
         super(Unit.AMPERE, networkElement, side, direction);
         initPercentageOfMax(percentageOfMax);
+        this.frmInMW = frmInMw;
     }
 
     private void initPercentageOfMax(double percentageOfMax) {
@@ -82,7 +83,7 @@ public class RelativeFlowThreshold extends AbstractFlowThreshold {
 
     @Override
     public AbstractThreshold copy() {
-        RelativeFlowThreshold copiedRelativeFlowThreshold = new RelativeFlowThreshold(networkElement, side, direction, percentageOfMax);
+        RelativeFlowThreshold copiedRelativeFlowThreshold = new RelativeFlowThreshold(networkElement, side, direction, percentageOfMax, frmInMW);
         if (isSynchronized()) {
             copiedRelativeFlowThreshold.isSynchronized = isSynchronized;
             copiedRelativeFlowThreshold.voltageLevel = voltageLevel;

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/VoltageThreshold.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/VoltageThreshold.java
@@ -99,7 +99,7 @@ public class VoltageThreshold extends AbstractThreshold {
     }
 
     @Override
-    public void setMargin(double margin) {
+    public void setMargin(double margin, Unit unit) {
         // do nothing for the moment
     }
 }

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/VoltageThreshold.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/threshold/VoltageThreshold.java
@@ -97,4 +97,9 @@ public class VoltageThreshold extends AbstractThreshold {
         result = 31 * result + (int) maxValue * 100;
         return result;
     }
+
+    @Override
+    public void setMargin(double margin) {
+        // do nothing for the moment
+    }
 }

--- a/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/SimpleCnecAdderTest.java
+++ b/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/SimpleCnecAdderTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 
 import java.util.Optional;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Peter Mitri {@literal <peter.mitri at rte-france.com>}
@@ -125,6 +125,22 @@ public class SimpleCnecAdderTest {
         assertEquals("neId2", cnec2.getNetworkElement().getName());
         assertEquals(500.0, cnec2.getMaxThreshold(Unit.MEGAWATT).get(), DOUBLE_TOLERANCE);
         assertEquals(Double.NEGATIVE_INFINITY, cnec2.getMinThreshold(Unit.MEGAWATT).get(), DOUBLE_TOLERANCE);
+    }
+
+    @Test
+    public void testFrmHandling() {
+        double maxValueInMw = 100.0;
+        double frmInMw = 5.0;
+        CnecAdder cnecAdder = crac.newCnec();
+        Cnec cnec = cnecAdder.setId("Cnec ID")
+                .setInstant(instant1)
+                .setContingency(contingency1)
+                .newNetworkElement().setId("Network Element ID").add()
+                .newThreshold().setUnit(Unit.MEGAWATT).setDirection(Direction.BOTH).setSide(Side.LEFT).setMaxValue(maxValueInMw).add()
+                .setFrm(frmInMw)
+                .add();
+        assertEquals(maxValueInMw - frmInMw, cnec.getMaxThreshold(Unit.MEGAWATT).orElseThrow(FaraoException::new), 0.0);
+        assertEquals(frmInMw - maxValueInMw, cnec.getMinThreshold(Unit.MEGAWATT).orElseThrow(FaraoException::new), 0.0);
     }
 
 }

--- a/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/json/CracImportExportTest.java
+++ b/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/json/CracImportExportTest.java
@@ -63,9 +63,8 @@ public class CracImportExportTest {
         AbsoluteFlowThreshold absoluteFlowThreshold = new AbsoluteFlowThreshold(Unit.MEGAWATT, Side.LEFT, Direction.DIRECT, 500.0);
         Set<AbstractThreshold> thresholdSet = new HashSet<>();
         thresholdSet.add(absoluteFlowThreshold);
-        simpleCrac.addCnec("cnec3prevId","cnec3prevName", "neId2", thresholdSet, preventiveState.getId(), positiveFrmMw);
-        simpleCrac.addCnec("cnec4prevId","cnec4prevName", "neId2", thresholdSet, preventiveState.getId(), 0.0);
-
+        simpleCrac.addCnec("cnec3prevId", "cnec3prevName", "neId2", thresholdSet, preventiveState.getId(), positiveFrmMw);
+        simpleCrac.addCnec("cnec4prevId", "cnec4prevName", "neId2", thresholdSet, preventiveState.getId(), 0.0);
 
         List<UsageRule> usageRules = new ArrayList<>();
         usageRules.add(new FreeToUse(UsageMethod.AVAILABLE, preventiveState));

--- a/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/json/CracImportExportTest.java
+++ b/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/json/CracImportExportTest.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.farao_community.farao.data.crac_impl.json.RoundTripUtil.roundTrip;
+import static junit.framework.Assert.assertTrue;
 import static junit.framework.TestCase.assertEquals;
 
 /**
@@ -57,6 +58,14 @@ public class CracImportExportTest {
 
         simpleCrac.addCnec("cnec2prev", "neId2", thresholds, preventiveState.getId());
         simpleCrac.addCnec("cnec1cur", "neId1", Collections.singleton(new AbsoluteFlowThreshold(Unit.AMPERE, Side.LEFT, Direction.OPPOSITE, 800)), postContingencyState.getId());
+
+        double positiveFrmMw = 20.0;
+        AbsoluteFlowThreshold absoluteFlowThreshold = new AbsoluteFlowThreshold(Unit.MEGAWATT, Side.LEFT, Direction.DIRECT, 500.0);
+        Set<AbstractThreshold> thresholdSet = new HashSet<>();
+        thresholdSet.add(absoluteFlowThreshold);
+        simpleCrac.addCnec("cnec3prevId","cnec3prevName", "neId2", thresholdSet, preventiveState.getId(), positiveFrmMw);
+        simpleCrac.addCnec("cnec4prevId","cnec4prevName", "neId2", thresholdSet, preventiveState.getId(), 0.0);
+
 
         List<UsageRule> usageRules = new ArrayList<>();
         usageRules.add(new FreeToUse(UsageMethod.AVAILABLE, preventiveState));
@@ -119,8 +128,10 @@ public class CracImportExportTest {
         assertEquals(5, crac.getNetworkElements().size());
         assertEquals(2, crac.getInstants().size());
         assertEquals(2, crac.getContingencies().size());
-        assertEquals(3, crac.getCnecs().size());
+        assertEquals(5, crac.getCnecs().size());
         assertEquals(2, crac.getRangeActions().size());
         assertEquals(2, crac.getNetworkActions().size());
+        assertTrue(crac.getCnec("cnec4prevId").getMaxThreshold(Unit.MEGAWATT).get()
+                > crac.getCnec("cnec3prevId").getMaxThreshold(Unit.MEGAWATT).get());
     }
 }

--- a/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
+++ b/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/threshold/AbsoluteFlowThresholdTest.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ */
+
+package com.farao_community.farao.data.crac_impl.threshold;
+
+import com.farao_community.farao.commons.FaraoException;
+import com.farao_community.farao.data.crac_api.Direction;
+import com.farao_community.farao.data.crac_api.Side;
+import com.farao_community.farao.data.crac_api.Unit;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Alexandre Montigny {@literal <alexandre.montigny at rte-france.com>}
+ */
+public class AbsoluteFlowThresholdTest {
+
+    private AbsoluteFlowThreshold absoluteFlowThreshold;
+
+    @Before
+    public void setUp() throws Exception {
+        absoluteFlowThreshold = new AbsoluteFlowThreshold(
+                Unit.AMPERE,
+                Side.LEFT,
+                Direction.BOTH,
+                1000.0
+        );
+    }
+
+    @Test
+    public void setMargin() {
+        try {
+            absoluteFlowThreshold.setMargin(2.0, Unit.AMPERE);
+            fail();
+        } catch (FaraoException e) {
+            // should throw because the frm can only be defined in Megawatt
+        }
+        assertEquals(0.0, absoluteFlowThreshold.frmInMW, 0.0);
+        double targetFrmInMw = 2.0;
+        absoluteFlowThreshold.setMargin(targetFrmInMw, Unit.MEGAWATT);
+        assertEquals(targetFrmInMw, absoluteFlowThreshold.frmInMW, 0.0);
+    }
+}


### PR DESCRIPTION
Add an attribute to AbstractFlowThreshold which contains its Cnec's frm in MEGAWATT
A setMargin method has been added at AbstractThreshold level
Adaptation of the methods getMinThreshold and getMaxThreshold of AbstractFlowThreshold to take into account this new attribute
Adaptation of the method copy of AbsoluteFlowThreshold and RelativeFlowThreshold

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
