### PR TITLE
Filter out CNECs that are neither optimized nor monitored before RAO

### DIFF
--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoInput.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoInput.java
@@ -44,9 +44,19 @@ public final class RaoInput {
                 report.add(String.format("[REMOVED] Cnec %s with network element [%s] is not present in the network. It is removed from the Crac", cnec.getId(), cnec.getNetworkElement().getId()));
             }
         });
+        absentFromNetworkCnecs.forEach(cnec -> crac.getCnecs().remove(cnec));
+
+        // remove Cnecs that are neither optimized nor monitored
+        ArrayList<Cnec> unmonitoredCnecs = new ArrayList<>();
+        crac.getCnecs().forEach(cnec -> {
+            if (!cnec.isOptimized() && !cnec.isMonitored()) {
+                unmonitoredCnecs.add(cnec);
+                report.add(String.format("[REMOVED] Cnec %s with network element [%s] is neither optimized nor monitored. It is removed from the Crac", cnec.getId(), cnec.getNetworkElement().getId()));
+            }
+        });
+        unmonitoredCnecs.forEach(cnec -> crac.getCnecs().remove(cnec));
 
         // remove RangeAction whose NetworkElement is absent from the network
-        absentFromNetworkCnecs.forEach(cnec -> crac.getCnecs().remove(cnec));
         ArrayList<RangeAction> absentFromNetworkRangeActions = new ArrayList<>();
         for (RangeAction rangeAction: crac.getRangeActions()) {
             rangeAction.getNetworkElements().forEach(networkElement -> {

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoInputTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoInputTest.java
@@ -139,4 +139,35 @@ public class RaoInputTest {
         }
         assertEquals(6, removedCount);
     }
+
+    @Test
+    public void testRemoveUnmonitoredCnecs() {
+        CracFactory factory = CracFactory.find("SimpleCracFactory");
+        Crac crac = factory.create("test-crac");
+        Instant inst = crac.newInstant().setId("inst1").setSeconds(10).add();
+        crac.newCnec().setId("BBE1AA1  BBE2AA1  1").setOptimized(true).setMonitored(true)
+                .newNetworkElement().setId("BBE1AA1  BBE2AA1  1").add()
+                .newThreshold().setUnit(Unit.MEGAWATT).setMaxValue(0.0).setDirection(Direction.BOTH).setSide(Side.LEFT).add()
+                .setInstant(inst)
+                .add();
+        crac.newCnec().setId("BBE1AA1  BBE3AA1  1").setOptimized(true).setMonitored(false)
+                .newNetworkElement().setId("BBE1AA1  BBE3AA1  1").add()
+                .newThreshold().setUnit(Unit.MEGAWATT).setMaxValue(0.0).setDirection(Direction.BOTH).setSide(Side.LEFT).add()
+                .setInstant(inst)
+                .add();
+        crac.newCnec().setId("FFR1AA1  FFR2AA1  1").setOptimized(false).setMonitored(true)
+                .newNetworkElement().setId("FFR1AA1  FFR2AA1  1").add()
+                .newThreshold().setUnit(Unit.MEGAWATT).setMaxValue(0.0).setDirection(Direction.BOTH).setSide(Side.LEFT).add()
+                .setInstant(inst)
+                .add();
+        crac.newCnec().setId("FFR1AA1  FFR3AA1  1").setOptimized(false).setMonitored(false)
+                .newNetworkElement().setId("FFR1AA1  FFR3AA1  1").add()
+                .newThreshold().setUnit(Unit.MEGAWATT).setMaxValue(0.0).setDirection(Direction.BOTH).setSide(Side.LEFT).add()
+                .setInstant(inst)
+                .add();
+        List<String> qualityReport = RaoInput.cleanCrac(crac, network);
+        assertEquals(1, qualityReport.size());
+        assertEquals(3, crac.getCnecs().size());
+        assertNull(crac.getCnec("FFR1AA1  FFR3AA1  1"));
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature

**What is the current behavior?** *(You can also link to an open issue here)*
CNECs that are neither optimized nor monitored are not filtered out before RAO (we supposed they did not exist)

**What is the new behavior (if this is a feature change)?**
When cleaning CRAC, these CNECs are removed and reported

**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
We do not have to apply this filter during import anymore