### PR TITLE
Fix cnec getMin/MaxThreshold behaviour

### DIFF
--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnec.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnec.java
@@ -149,13 +149,21 @@ public class SimpleCnec extends AbstractIdentifiable<Cnec> implements Cnec {
     @Override
     public Optional<Double> getMinThreshold(Unit requestedUnit) {
         requestedUnit.checkPhysicalParameter(getPhysicalParameter());
-        return Optional.of(thresholds.stream().map(threshold -> threshold.getMinThreshold(requestedUnit).orElse(Double.NEGATIVE_INFINITY)).max(Double::compare).orElse(Double.NEGATIVE_INFINITY));
+        if (thresholds.stream().anyMatch(t -> t.getMinThreshold(requestedUnit).isPresent())) {
+            return Optional.of(thresholds.stream().map(threshold -> threshold.getMinThreshold(requestedUnit).orElse(Double.NEGATIVE_INFINITY)).max(Double::compare).orElse(Double.NEGATIVE_INFINITY));
+        } else {
+            return Optional.empty();
+        }
     }
 
     @Override
     public Optional<Double> getMaxThreshold(Unit requestedUnit) {
         requestedUnit.checkPhysicalParameter(getPhysicalParameter());
-        return Optional.of(thresholds.stream().map(threshold -> threshold.getMaxThreshold(requestedUnit).orElse(Double.POSITIVE_INFINITY)).min(Double::compare).orElse(Double.POSITIVE_INFINITY));
+        if (thresholds.stream().anyMatch(t -> t.getMaxThreshold(requestedUnit).isPresent())) {
+            return Optional.of(thresholds.stream().map(threshold -> threshold.getMaxThreshold(requestedUnit).orElse(Double.POSITIVE_INFINITY)).min(Double::compare).orElse(Double.POSITIVE_INFINITY));
+        } else {
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/SimpleCnecAdderTest.java
+++ b/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/SimpleCnecAdderTest.java
@@ -125,7 +125,7 @@ public class SimpleCnecAdderTest {
         assertEquals(Optional.empty(), cnec2.getState().getContingency());
         assertEquals("neId2", cnec2.getNetworkElement().getName());
         assertEquals(500.0, cnec2.getMaxThreshold(Unit.MEGAWATT).get(), DOUBLE_TOLERANCE);
-        assertEquals(Double.NEGATIVE_INFINITY, cnec2.getMinThreshold(Unit.MEGAWATT).get(), DOUBLE_TOLERANCE);
+        assertFalse(cnec2.getMinThreshold(Unit.MEGAWATT).isPresent());
     }
 
     @Test

--- a/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/SimpleCnecTest.java
+++ b/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/SimpleCnecTest.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com>}
@@ -209,5 +210,37 @@ public class SimpleCnecTest {
 
         assertEquals(490, cnec.getMaxThreshold(Unit.MEGAWATT).get(), 0.1);
         assertEquals(-200, cnec.getMinThreshold(Unit.MEGAWATT).get(), 0.1);
+    }
+
+    @Test
+    public void unboundedCnecInOppositeDirection() {
+        State state = Mockito.mock(State.class);
+        AbsoluteFlowThreshold directThreshold = new AbsoluteFlowThreshold(Unit.MEGAWATT, Side.LEFT, Direction.DIRECT, 500);
+        AbsoluteFlowThreshold oppositeThreshold = new AbsoluteFlowThreshold(Unit.MEGAWATT, Side.LEFT, Direction.DIRECT, 200);
+
+        Set<AbstractThreshold> thresholds = new HashSet<>();
+        thresholds.add(directThreshold);
+        thresholds.add(oppositeThreshold);
+
+        Cnec cnec = new SimpleCnec("cnec1", new NetworkElement("FRANCE_BELGIUM_1"), thresholds, state);
+
+        assertEquals(200, cnec.getMaxThreshold(Unit.MEGAWATT).get(), 0.1);
+        assertFalse(cnec.getMinThreshold(Unit.MEGAWATT).isPresent());
+    }
+
+    @Test
+    public void unboundedCnecInDirectDirection() {
+        State state = Mockito.mock(State.class);
+        AbsoluteFlowThreshold directThreshold = new AbsoluteFlowThreshold(Unit.MEGAWATT, Side.LEFT, Direction.OPPOSITE, 500);
+        AbsoluteFlowThreshold oppositeThreshold = new AbsoluteFlowThreshold(Unit.MEGAWATT, Side.LEFT, Direction.OPPOSITE, 200);
+
+        Set<AbstractThreshold> thresholds = new HashSet<>();
+        thresholds.add(directThreshold);
+        thresholds.add(oppositeThreshold);
+
+        Cnec cnec = new SimpleCnec("cnec1", new NetworkElement("FRANCE_BELGIUM_1"), thresholds, state);
+
+        assertEquals(-200, cnec.getMinThreshold(Unit.MEGAWATT).get(), 0.1);
+        assertFalse(cnec.getMaxThreshold(Unit.MEGAWATT).isPresent());
     }
 }


### PR DESCRIPTION
getMin/MaxThreshold() returns Optional.empty() instead of Optional.of(infinity)