### PR TITLE
Handling element name with timestamp filter on crac importer

### DIFF
--- a/data/crac-io/crac-io-api/src/main/java/com/farao_community/farao/data/crac_io_api/CracImporter.java
+++ b/data/crac-io/crac-io-api/src/main/java/com/farao_community/farao/data/crac_io_api/CracImporter.java
@@ -8,7 +8,10 @@
 package com.farao_community.farao.data.crac_io_api;
 
 import com.farao_community.farao.data.crac_api.Crac;
+import org.joda.time.DateTime;
+
 import java.io.InputStream;
+import java.util.Optional;
 
 /**
  * Interface for CRAC object import
@@ -18,7 +21,7 @@ import java.io.InputStream;
 
 public interface CracImporter {
 
-    Crac importCrac(InputStream inputStream);
+    Crac importCrac(InputStream inputStream, Optional<DateTime> timeStampFilter);
 
     boolean exists(String fileName, InputStream inputStream);
 }

--- a/data/crac-io/crac-io-api/src/main/java/com/farao_community/farao/data/crac_io_api/CracImporters.java
+++ b/data/crac-io/crac-io-api/src/main/java/com/farao_community/farao/data/crac_io_api/CracImporters.java
@@ -11,10 +11,12 @@ import com.farao_community.farao.commons.FaraoException;
 import com.farao_community.farao.data.crac_api.Crac;
 import com.google.common.base.Suppliers;
 import com.powsybl.commons.util.ServiceLoaderCache;
+import org.joda.time.DateTime;
 
 import java.io.*;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -29,8 +31,12 @@ public final class CracImporters {
     }
 
     public static Crac importCrac(Path cracPath) {
+        return importCrac(cracPath, Optional.empty());
+    }
+
+    public static Crac importCrac(Path cracPath, Optional<DateTime> timeStampFilter) {
         try (InputStream is = new FileInputStream(cracPath.toFile())) {
-            return importCrac(cracPath.getFileName().toString(), is);
+            return importCrac(cracPath.getFileName().toString(), is, timeStampFilter);
         } catch (FileNotFoundException e) {
             throw new FaraoException("File not found.");
         } catch (IOException e) {
@@ -46,6 +52,10 @@ public final class CracImporters {
     }
 
     public static Crac importCrac(String fileName, InputStream inputStream) {
+        return importCrac(fileName, inputStream, Optional.empty());
+    }
+
+    public static Crac importCrac(String fileName, InputStream inputStream, Optional<DateTime> timeStampFilter) {
         try {
             byte[] bytes = getBytesFromInputStream(inputStream);
 
@@ -53,7 +63,7 @@ public final class CracImporters {
             if (importer == null) {
                 throw new FaraoException("No importer found for this file");
             }
-            return importer.importCrac(new ByteArrayInputStream(bytes));
+            return importer.importCrac(new ByteArrayInputStream(bytes), timeStampFilter);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/data/crac-io/crac-io-api/src/test/java/com/farao_community/farao/data/crac_io_api/CracImporterMock.java
+++ b/data/crac-io/crac-io-api/src/test/java/com/farao_community/farao/data/crac_io_api/CracImporterMock.java
@@ -9,8 +9,10 @@ package com.farao_community.farao.data.crac_io_api;
 
 import com.farao_community.farao.data.crac_api.Crac;
 import com.google.auto.service.AutoService;
+import org.joda.time.DateTime;
 
 import java.io.InputStream;
+import java.util.Optional;
 
 /**
  * @author Viktor Terrier {@literal <viktor.terrier at rte-france.com>}
@@ -19,7 +21,7 @@ import java.io.InputStream;
 public class CracImporterMock implements CracImporter {
 
     @Override
-    public Crac importCrac(InputStream inputStream) {
+    public Crac importCrac(InputStream inputStream, Optional<DateTime> timeStampFilter) {
         return null;
     }
 

--- a/data/crac-io/crac-io-json/src/main/java/com/farao_community/farao/data/crac_io_json/JsonImport.java
+++ b/data/crac-io/crac-io-json/src/main/java/com/farao_community/farao/data/crac_io_json/JsonImport.java
@@ -17,8 +17,12 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.auto.service.AutoService;
 
 import java.io.*;
+import java.util.Optional;
 
 import org.apache.commons.io.FilenameUtils;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.powsybl.commons.json.JsonUtil.createObjectMapper;
 
@@ -30,9 +34,13 @@ import static com.powsybl.commons.json.JsonUtil.createObjectMapper;
 @AutoService(CracImporter.class)
 public class JsonImport implements CracImporter {
     private static final String JSON_EXTENSION = "json";
+    private static final Logger LOGGER = LoggerFactory.getLogger(CracImporter.class);
 
     @Override
-    public Crac importCrac(InputStream inputStream) {
+    public Crac importCrac(InputStream inputStream, Optional<DateTime> timeStampFilter) {
+        if (timeStampFilter.isPresent()) {
+            LOGGER.warn("Timestamp filtering is not implemented for json importer. The timestamp will be ignored.");
+        }
         try {
             ObjectMapper objectMapper = createObjectMapper();
             objectMapper.registerModule(new Jdk8Module());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
This allows the user to add a timestamp filter to the crac importer api, in order to filter out elements do not interest them for the given timestamp


**What is the current behavior?** *(You can also link to an open issue here)*
There is no possibility to add a timestamp filter input

**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
importCrac now has an additional argument. Users should use Optional.empty() if they do not need it.
