### PR TITLE
Fix returned object on crac element adders

### DIFF
--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/ComplexContingencyAdder.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/ComplexContingencyAdder.java
@@ -38,7 +38,7 @@ public class ComplexContingencyAdder extends AbstractIdentifiableAdder<ComplexCo
         checkId();
         ComplexContingency contingency = new ComplexContingency(this.id, this.name, this.networkElements);
         parent.addContingency(contingency);
-        return contingency;
+        return parent.getContingency(contingency.getId());
     }
 
     @Override

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/InstantAdderImpl.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/InstantAdderImpl.java
@@ -38,8 +38,6 @@ public class InstantAdderImpl extends AbstractIdentifiableAdder<InstantAdderImpl
         if (this.seconds == null) {
             throw new FaraoException("Cannot add an instant without a number of seconds. Please use setSeconds.");
         }
-        Instant instant = new Instant(this.id, this.seconds);
-        parent.addInstant(instant);
-        return instant;
+        return parent.addInstant(id, seconds);
     }
 }

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnecAdder.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/SimpleCnecAdder.java
@@ -14,8 +14,9 @@ import com.farao_community.farao.data.crac_impl.threshold.ThresholdAdderImpl;
 
 import java.util.HashSet;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
+
+import static java.lang.String.format;
 
 /**
  * @author Peter Mitri {@literal <peter.mitri at rte-france.com>}
@@ -87,6 +88,9 @@ public class SimpleCnecAdder extends AbstractIdentifiableAdder<SimpleCnecAdder> 
     @Override
     public Cnec add() {
         checkId();
+        if (parent.getCnec(id) != null) {
+            throw new FaraoException(format("Cannot add a cnec with an already existing ID - %s.", id));
+        }
         if (this.networkElement == null) {
             throw new FaraoException("Cannot add a cnec without a network element. Please use newNetworkElement.");
         }
@@ -96,10 +100,9 @@ public class SimpleCnecAdder extends AbstractIdentifiableAdder<SimpleCnecAdder> 
         if (this.instant == null) {
             throw new FaraoException("Cannot add a cnec with no specified state instant. Please use setInstant.");
         }
-        SimpleState state = new SimpleState((this.contingency != null) ? Optional.of(this.contingency) : Optional.empty(), this.instant);
-        SimpleCnec cnec = new SimpleCnec(this.id, this.name, networkElement, thresholds, state, frm, optimized, monitored);
-        parent.addCnec(cnec);
-        return cnec;
+        parent.addNetworkElement(networkElement);
+        State state = parent.addState(contingency, instant);
+        return parent.addCnec(id, name, networkElement.getId(), thresholds, state.getId(), frm, optimized, monitored);
     }
 
     @Override


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Add method of some element adders is not returning the instance of the object present in the CRAC. When adding an object to the CRAC a copy is realized to ensure object consistency inside the CRAC then the correct object must be returned.
