### PR TITLE
Merge rao results

### DIFF
--- a/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/utils/CommonCracCreation.java
+++ b/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/utils/CommonCracCreation.java
@@ -46,8 +46,8 @@ public final class CommonCracCreation {
         Instant curative = new Instant("curative", 1200);
 
         //NetworkElement
-        NetworkElement monitoredElement1 = new NetworkElement("BBE2AA1  FFR3AA1  1", "BBE2AA1  FFR3AA1  1 name");
-        NetworkElement monitoredElement2 = new NetworkElement("FFR2AA1  DDE3AA1  1", "FFR2AA1  DDE3AA1  1 name");
+        NetworkElement monitoredElement1 = new NetworkElement("BBE2AA1  FFR3AA1  1");
+        NetworkElement monitoredElement2 = new NetworkElement("FFR2AA1  DDE3AA1  1");
 
         // State
         State stateBasecase = new SimpleState(Optional.empty(), basecase);

--- a/data/crac/crac-result-extensions/src/main/java/com/farao_community/farao/data/crac_result_extensions/NetworkActionResult.java
+++ b/data/crac/crac-result-extensions/src/main/java/com/farao_community/farao/data/crac_result_extensions/NetworkActionResult.java
@@ -35,7 +35,7 @@ public class NetworkActionResult implements Result {
     }
 
     public boolean isActivated(String stateId) {
-        return activationMap.getOrDefault(stateId, false);
+        return activationMap.get(stateId);
     }
 
     public void activate(String stateId) {

--- a/data/crac/crac-result-extensions/src/main/java/com/farao_community/farao/data/crac_result_extensions/PstRangeResult.java
+++ b/data/crac/crac-result-extensions/src/main/java/com/farao_community/farao/data/crac_result_extensions/PstRangeResult.java
@@ -38,8 +38,8 @@ public class PstRangeResult extends RangeActionResult {
         stateIds.forEach(state -> tapPerStates.put(state, null));
     }
 
-    public int getTap(String stateId) {
-        return tapPerStates.getOrDefault(stateId, null);
+    public Integer getTap(String stateId) {
+        return tapPerStates.get(stateId);
     }
 
     public void setTap(String stateId, int tap) {

--- a/data/crac/crac-result-extensions/src/test/java/com.farao_community.farao.data.crac_result_extensions/JsonResultTest.java
+++ b/data/crac/crac-result-extensions/src/test/java/com.farao_community.farao.data.crac_result_extensions/JsonResultTest.java
@@ -95,8 +95,8 @@ public class JsonResultTest {
         RangeActionResultExtension rangeActionResultExtension = simpleCrac.getRangeAction("pst1").getExtension(RangeActionResultExtension.class);
         double pstRangeSetPointVariant1 = 4.0;
         double pstRangeSetPointVariant2 = 14.0;
-        int pstRangeTapVariant1 = 2;
-        int pstRangeTapVariant2 = 6;
+        Integer pstRangeTapVariant1 = 2;
+        Integer pstRangeTapVariant2 = 6;
         rangeActionResultExtension.getVariant("variant1").setSetPoint(preventiveState.getId(), pstRangeSetPointVariant1);
         ((PstRangeResult) rangeActionResultExtension.getVariant("variant1")).setTap(preventiveState.getId(), pstRangeTapVariant1);
         rangeActionResultExtension.getVariant("variant2").setSetPoint(preventiveState.getId(), pstRangeSetPointVariant2);

--- a/data/crac/crac-result-extensions/src/test/java/com.farao_community.farao.data.crac_result_extensions/PstRangeResultTest.java
+++ b/data/crac/crac-result-extensions/src/test/java/com.farao_community.farao.data.crac_result_extensions/PstRangeResultTest.java
@@ -37,6 +37,6 @@ public class PstRangeResultTest {
         pstRangeResult.setTap(state.getId(), 5);
 
         assertEquals(3.2, pstRangeResult.getSetPoint(state.getId()), EPSILON);
-        assertEquals(5, pstRangeResult.getTap(state.getId()));
+        assertEquals(Integer.valueOf(5), pstRangeResult.getTap(state.getId()));
     }
 }

--- a/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
+++ b/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
@@ -132,7 +132,7 @@ public class LinearRao implements RaoProvider {
         // build RaoResult
         RaoResult raoResult = new RaoResult(RaoResult.Status.SUCCESS);
         raoResult.setPreOptimVariantId(raoData.getInitialVariantId());
-        raoResult.setPostOptimVariantIdForStateId(raoData.getOptimizedState().getId(), postOptimVariantId);
+        raoResult.setPostOptimVariantId(postOptimVariantId);
 
         // build extension
         LinearRaoResult resultExtension = new LinearRaoResult();
@@ -157,7 +157,7 @@ public class LinearRao implements RaoProvider {
         // build RaoResult
         RaoResult raoResult = new RaoResult(RaoResult.Status.FAILURE);
         raoResult.setPreOptimVariantId(raoData.getInitialVariantId());
-        raoResult.setPostOptimVariantIdForStateId(raoData.getOptimizedState().getId(), raoData.getInitialVariantId());
+        raoResult.setPostOptimVariantId(raoData.getInitialVariantId());
 
         // build extension
         LinearRaoResult resultExtension = new LinearRaoResult();

--- a/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/JsonLinearRaoResultTest.java
+++ b/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/JsonLinearRaoResultTest.java
@@ -14,7 +14,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Map;
 
 /**
  * @author Viktor Terrier {@literal <viktor.terrier at rte-france.com>}
@@ -27,7 +26,7 @@ public class JsonLinearRaoResultTest extends AbstractConverterTest {
     public void setUp() throws IOException {
         raoResult = new RaoResult(RaoResult.Status.SUCCESS);
         raoResult.setPreOptimVariantId("variant1");
-        raoResult.setPostOptimVariantIdPerStateId(Map.of("preventive", "variant2"));
+        raoResult.setPostOptimVariantId("variant2");
         super.setUp();
     }
 

--- a/ra-optimisation/linear-rao/src/test/resources/RaoResultDefaultSensi.json
+++ b/ra-optimisation/linear-rao/src/test/resources/RaoResultDefaultSensi.json
@@ -1,9 +1,7 @@
 {
   "status" : "SUCCESS",
   "preOptimVariantId" : "variant1",
-  "postOptimVariantIdPerStateId" : {
-    "preventive" : "variant2"
-  },
+  "postOptimVariantId" : "variant2",
   "extensions" : {
     "LinearRaoResult" : {
       "systematicSensitivityAnalysisParameters" : "DEFAULT"

--- a/ra-optimisation/linear-rao/src/test/resources/RaoResultFallbackSensi.json
+++ b/ra-optimisation/linear-rao/src/test/resources/RaoResultFallbackSensi.json
@@ -1,9 +1,7 @@
 {
   "status" : "SUCCESS",
   "preOptimVariantId" : "variant1",
-  "postOptimVariantIdPerStateId" : {
-    "preventive" : "variant2"
-  },
+  "postOptimVariantId" : "variant2",
   "extensions" : {
     "LinearRaoResult" : {
       "systematicSensitivityAnalysisParameters" : "FALLBACK"

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/RaoResult.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/RaoResult.java
@@ -12,9 +12,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.powsybl.commons.extensions.AbstractExtendable;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * RAO result API. This class will contain information about the RAO computation (computation status, logs, etc).
  *
@@ -33,12 +30,11 @@ public class RaoResult extends AbstractExtendable<RaoResult> {
 
     private String preOptimVariantId;
 
-    private Map<String, String> postOptimVariantIdPerStateId;
+    private String postOptimVariantId;
 
     @JsonCreator
     public RaoResult(@JsonProperty("status") Status status) {
         this.status = status;
-        postOptimVariantIdPerStateId = new HashMap<>();
     }
 
     public Status getStatus() {
@@ -62,19 +58,11 @@ public class RaoResult extends AbstractExtendable<RaoResult> {
         return preOptimVariantId;
     }
 
-    public void setPostOptimVariantIdPerStateId(Map<String, String> postOptimVariantIdPerStateId) {
-        this.postOptimVariantIdPerStateId = postOptimVariantIdPerStateId;
+    public String getPostOptimVariantId() {
+        return postOptimVariantId;
     }
 
-    public void setPostOptimVariantIdForStateId(String stateId, String postOptimVariantId) {
-        this.postOptimVariantIdPerStateId.put(stateId, postOptimVariantId);
-    }
-
-    public Map<String, String> getPostOptimVariantIdPerStateId() {
-        return postOptimVariantIdPerStateId;
-    }
-
-    public String getPostOptimVariantIdForStateId(String stateId) {
-        return postOptimVariantIdPerStateId.get(stateId);
+    public void setPostOptimVariantId(String postOptimVariantId) {
+        this.postOptimVariantId = postOptimVariantId;
     }
 }

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/RaoResultDeserializer.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/RaoResultDeserializer.java
@@ -11,7 +11,6 @@ import com.farao_community.farao.commons.FaraoException;
 import com.farao_community.farao.rao_api.RaoResult;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.powsybl.commons.extensions.Extension;
@@ -20,7 +19,6 @@ import com.powsybl.commons.json.JsonUtil;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 /**
  * @author Viktor Terrier {@literal <viktor.terrier at rte-france.com>}
@@ -53,10 +51,9 @@ public class RaoResultDeserializer extends StdDeserializer<RaoResult> {
                     raoResult.setPreOptimVariantId(parser.getValueAsString());
                     break;
 
-                case "postOptimVariantIdPerStateId":
+                case "postOptimVariantId":
                     parser.nextToken();
-                    raoResult.setPostOptimVariantIdPerStateId(parser.readValueAs(new TypeReference<Map<String, String>>() {
-                    }));
+                    raoResult.setPostOptimVariantId(parser.getValueAsString());
                     break;
 
                 case "extensions":

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/RaoResultSerializer.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/RaoResultSerializer.java
@@ -31,7 +31,7 @@ public class RaoResultSerializer extends StdSerializer<RaoResult> {
 
         jsonGenerator.writeStringField("status", raoResult.getStatus().toString());
         jsonGenerator.writeStringField("preOptimVariantId", raoResult.getPreOptimVariantId());
-        jsonGenerator.writeObjectField("postOptimVariantIdPerStateId", raoResult.getPostOptimVariantIdPerStateId());
+        jsonGenerator.writeStringField("postOptimVariantId", raoResult.getPostOptimVariantId());
 
         JsonUtil.writeExtensions(raoResult, jsonGenerator, serializerProvider, JsonRaoResult.getExtensionSerializers());
 

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/RaoResultTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/RaoResultTest.java
@@ -9,8 +9,6 @@ package com.farao_community.farao.rao_api;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Map;
-
 import static org.junit.Assert.*;
 
 /**
@@ -24,14 +22,14 @@ public class RaoResultTest {
     public void setUp() {
         raoResult = new RaoResult(RaoResult.Status.SUCCESS);
         raoResult.setPreOptimVariantId("preOptimVariant");
-        raoResult.setPostOptimVariantIdPerStateId(Map.of("preventive", "postOptimVariant"));
+        raoResult.setPostOptimVariantId("postOptimVariant");
     }
 
     @Test
     public void testGetters() {
         assertTrue(raoResult.isSuccessful());
         assertEquals("preOptimVariant", raoResult.getPreOptimVariantId());
-        assertEquals(Map.of("preventive", "postOptimVariant"), raoResult.getPostOptimVariantIdPerStateId());
+        assertEquals("postOptimVariant", raoResult.getPostOptimVariantId());
     }
 
 }

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoResultTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoResultTest.java
@@ -12,7 +12,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -27,7 +26,7 @@ public class JsonRaoResultTest extends AbstractConverterTest {
     public void setUp() throws IOException {
         raoResult = new RaoResult(RaoResult.Status.SUCCESS);
         raoResult.setPreOptimVariantId("variant1");
-        raoResult.setPostOptimVariantIdPerStateId(Map.of("preventive", "variant2"));
+        raoResult.setPostOptimVariantId("variant2");
         super.setUp();
     }
 
@@ -40,7 +39,7 @@ public class JsonRaoResultTest extends AbstractConverterTest {
     public void writeExtension() throws IOException {
         raoResult.setStatus(RaoResult.Status.FAILURE);
         raoResult.setPreOptimVariantId("var1");
-        raoResult.setPostOptimVariantIdPerStateId(Map.of("preventive", "var2"));
+        raoResult.setPostOptimVariantId("var2");
         writeTest(raoResult, JsonRaoResult::write, AbstractConverterTest::compareTxt, "/RaoResultFailure.json");
     }
 
@@ -49,6 +48,6 @@ public class JsonRaoResultTest extends AbstractConverterTest {
         RaoResult raoResult = JsonRaoResult.read(getClass().getResourceAsStream("/RaoResultFailure.json"));
         assertFalse(raoResult.isSuccessful());
         assertEquals("var1", raoResult.getPreOptimVariantId());
-        assertNotNull("var2", raoResult.getPostOptimVariantIdPerStateId());
+        assertNotNull("var2", raoResult.getPostOptimVariantId());
     }
 }

--- a/ra-optimisation/rao-api/src/test/resources/RaoResult.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoResult.json
@@ -1,7 +1,5 @@
 {
   "status" : "SUCCESS",
   "preOptimVariantId" : "variant1",
-  "postOptimVariantIdPerStateId" : {
-    "preventive" : "variant2"
-  }
+  "postOptimVariantId" : "variant2"
 }

--- a/ra-optimisation/rao-api/src/test/resources/RaoResultFailure.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoResultFailure.json
@@ -1,7 +1,5 @@
 {
   "status" : "FAILURE",
   "preOptimVariantId" : "var1",
-  "postOptimVariantIdPerStateId" : {
-    "preventive" : "var2"
-  }
+  "postOptimVariantId" : "var2"
 }

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracResultManager.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracResultManager.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 public class CracResultManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(CracResultManager.class);
 
-    private RaoData raoData;
+    private final RaoData raoData;
 
     CracResultManager(RaoData raoData) {
         this.raoData = raoData;

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracVariantManager.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracVariantManager.java
@@ -25,10 +25,10 @@ public class CracVariantManager {
     private static final String NO_WORKING_VARIANT = "No working variant is defined.";
     private static final String UNKNOWN_VARIANT = "Unknown variant %s";
 
-    private List<String> variantIds;
+    private final List<String> variantIds;
     private String workingVariantId;
-    private Crac crac;
-    private Map<String, SystematicSensitivityResult> systematicSensitivityResultMap;
+    private final Crac crac;
+    private final Map<String, SystematicSensitivityResult> systematicSensitivityResultMap;
 
     /**
      * This constructor creates a new data variant with a pre-optimisation prefix and set it as the working variant.

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoUtil.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoUtil.java
@@ -8,10 +8,7 @@
 package com.farao_community.farao.rao_commons;
 
 import com.farao_community.farao.commons.FaraoException;
-import com.farao_community.farao.data.crac_api.Contingency;
 import com.farao_community.farao.data.crac_api.Crac;
-import com.farao_community.farao.data.crac_api.State;
-import com.farao_community.farao.data.crac_api.UsageMethod;
 import com.farao_community.farao.data.refprog.reference_program.ReferenceProgramBuilder;
 import com.farao_community.farao.rao_api.RaoInput;
 import com.farao_community.farao.rao_api.RaoParameters;
@@ -156,36 +153,5 @@ public final class RaoUtil {
             default:
                 throw new NotImplementedException("Not implemented objective function");
         }
-    }
-
-    public static List<List<State>> createPerimeters(Crac crac, Network network, State startingState) {
-        List<List<State>> perimeters = new ArrayList<>();
-
-        if (startingState.equals(crac.getPreventiveState())) {
-            List<State> preventivePerimeter = new ArrayList<>();
-            preventivePerimeter.add(startingState);
-            perimeters.add(preventivePerimeter);
-
-            List<State> currentPerimeter;
-            for (Contingency contingency : crac.getContingencies()) {
-                currentPerimeter = preventivePerimeter;
-                for (State state : crac.getStates(contingency)) {
-                    if (anyAvailableRemedialAction(crac, network, state)) {
-                        currentPerimeter = new ArrayList<>();
-                        perimeters.add(currentPerimeter);
-                    }
-                    currentPerimeter.add(state);
-                }
-            }
-        } else {
-            throw new NotImplementedException("Cannot create perimeters if starting state is different from preventive state");
-        }
-
-        return perimeters;
-    }
-
-    private static boolean anyAvailableRemedialAction(Crac crac, Network network, State state) {
-        return !crac.getNetworkActions(network, state, UsageMethod.AVAILABLE).isEmpty() ||
-            !crac.getRangeActions(network, state, UsageMethod.AVAILABLE).isEmpty();
     }
 }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoDataTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoDataTest.java
@@ -62,7 +62,7 @@ public class RaoDataTest {
         RangeActionResult rangeActionResult = crac.getRangeAction("pst").getExtension(RangeActionResultExtension.class).getVariant(initialVariantId);
         raoData.getCracResultManager().fillRangeActionResultsWithNetworkValues();
         Assert.assertEquals(0, rangeActionResult.getSetPoint("none-initial"), 0.1);
-        Assert.assertEquals(0, ((PstRangeResult) rangeActionResult).getTap("none-initial"));
+        Assert.assertEquals(Integer.valueOf(0), ((PstRangeResult) rangeActionResult).getTap("none-initial"));
     }
 
     @Test

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/LinearOptimizerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/LinearOptimizerTest.java
@@ -181,7 +181,7 @@ public class LinearOptimizerTest {
         String preventiveState = raoData.getCrac().getPreventiveState().getId();
         RangeActionResultExtension pstRangeResultMap = raoData.getCrac().getRangeAction("idPstRa").getExtension(RangeActionResultExtension.class);
         PstRangeResult pstRangeResult = (PstRangeResult) pstRangeResultMap.getVariant(raoData.getWorkingVariantId());
-        Assert.assertEquals(-12, pstRangeResult.getTap(preventiveState));
+        Assert.assertEquals(Integer.valueOf(-12), pstRangeResult.getTap(preventiveState));
         Assert.assertEquals(0.39 - 5, pstRangeResult.getSetPoint(preventiveState), ANGLE_TAP_APPROX_TOLERANCE);
     }
 
@@ -197,7 +197,7 @@ public class LinearOptimizerTest {
         String preventiveState = raoData.getCrac().getPreventiveState().getId();
         RangeActionResultExtension pstRangeResultMap = raoData.getCrac().getRangeAction("idPstRa").getExtension(RangeActionResultExtension.class);
         PstRangeResult pstRangeResult = (PstRangeResult) pstRangeResultMap.getVariant(raoData.getWorkingVariantId());
-        Assert.assertEquals(14, pstRangeResult.getTap(preventiveState));
+        Assert.assertEquals(Integer.valueOf(14), pstRangeResult.getTap(preventiveState));
         Assert.assertEquals(0.39 + 5, pstRangeResult.getSetPoint(preventiveState), ANGLE_TAP_APPROX_TOLERANCE);
     }
 

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTree.java
@@ -37,8 +37,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @author Joris Mancini {@literal <joris.mancini at rte-france.com>}
  * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com>}
  */
-public class Tree {
-    static final Logger LOGGER = LoggerFactory.getLogger(Tree.class);
+public class SearchTree {
+    static final Logger LOGGER = LoggerFactory.getLogger(SearchTree.class);
 
     private RaoParameters raoParameters;
     private SearchTreeRaoParameters searchTreeRaoParameters;

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoLogger.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoLogger.java
@@ -51,29 +51,27 @@ final class SearchTreeRaoLogger {
                     .append(" , ");
         }
         String rangeActionsLog = rangeActionMsg.toString();
-        Tree.LOGGER.info(rangeActionsLog);
+        SearchTree.LOGGER.info(rangeActionsLog);
     }
 
     static void logMostLimitingElementsResults(Leaf leaf, Unit unit, boolean relativePositiveMargins) {
-        Map<String, String> variantIdPerStatedId = new HashMap<>();
-        leaf.getRaoData().getCnecs().forEach(cnec -> variantIdPerStatedId.putIfAbsent(cnec.getState().getId(), leaf.getBestVariantId()));
-        logMostLimitingElementsResults(leaf.getRaoData().getCnecs(), variantIdPerStatedId, unit, relativePositiveMargins);
+        logMostLimitingElementsResults(leaf.getRaoData().getCnecs(), leaf.getBestVariantId(), unit, relativePositiveMargins);
     }
 
-    static void logMostLimitingElementsResults(Set<Cnec> cnecs, Map<String, String> variantIdPerStatedId, Unit unit, boolean relativePositiveMargins) {
+    static void logMostLimitingElementsResults(Set<Cnec> cnecs, String variantId, Unit unit, boolean relativePositiveMargins) {
         List<Cnec> sortedCnecs = cnecs.stream().
                 filter(Cnec::isOptimized).
-                sorted(Comparator.comparingDouble(cnec -> computeCnecMargin(cnec, variantIdPerStatedId.get(cnec.getState().getId()), unit, relativePositiveMargins))).
+                sorted(Comparator.comparingDouble(cnec -> computeCnecMargin(cnec, variantId, unit, relativePositiveMargins))).
                 collect(Collectors.toList());
 
         for (int i = 0; i < Math.min(MAX_LOGS_LIMITING_ELEMENTS, sortedCnecs.size()); i++) {
             Cnec cnec = sortedCnecs.get(i);
             String cnecNetworkElementName = cnec.getNetworkElement().getName();
             String cnecStateId = cnec.getState().getId();
-            double cnecMargin = computeCnecMargin(cnec, variantIdPerStatedId.get(cnec.getState().getId()), unit, relativePositiveMargins);
+            double cnecMargin = computeCnecMargin(cnec, variantId, unit, relativePositiveMargins);
             String margin = new DecimalFormat("#0.00").format(cnecMargin);
             String isRelativeMargin = (relativePositiveMargins && cnecMargin > 0) ? "relative " : "";
-            Tree.LOGGER.info("Limiting element #{}: element {} at state {} with a {}margin of {} {}",
+            SearchTree.LOGGER.info("Limiting element #{}: element {} at state {} with a {}margin of {} {}",
                     i + 1,
                     cnecNetworkElementName,
                     cnecStateId,

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
@@ -179,13 +179,11 @@ public class SearchTreeRaoProvider implements RaoProvider {
         deleteCurativeVariants(crac, curativeRaoResults);
         return preventiveRaoResult;
     }
-    
+
     private void mergeRaoResultStatus(RaoResult preventiveRaoResult, Map<State, RaoResult> curativeRaoResults) {
-        curativeRaoResults.values().forEach(curativeRaoResult -> {
-            if (curativeRaoResult.getStatus().equals(RaoResult.Status.FAILURE)) {
-                preventiveRaoResult.setStatus(RaoResult.Status.FAILURE);
-            }
-        });
+        if (curativeRaoResults.values().stream().anyMatch(curativeRaoResult -> curativeRaoResult.getStatus().equals(RaoResult.Status.FAILURE))) {
+            preventiveRaoResult.setStatus(RaoResult.Status.FAILURE);
+        }
     }
 
     private void mergeCnecResults(Crac crac, RaoResult preventiveRaoResult, Map<State, RaoResult> curativeRaoResults) {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
@@ -211,7 +211,8 @@ public class SearchTreeRaoProvider implements RaoProvider {
                     RangeActionResult targetRaResult = rangeAction.getExtension(RangeActionResultExtension.class).getVariant(preventiveRaoResult.getPostOptimVariantId());
                     STATE_TREE.getPerimeter(optimizedState).forEach(state -> {
                         targetRaResult.setSetPoint(state.getId(), raResult.getSetPoint(state.getId()));
-                        if (raResult instanceof PstRangeResult && targetRaResult instanceof PstRangeResult) {
+                        if (raResult instanceof PstRangeResult && targetRaResult instanceof PstRangeResult
+                            && ((PstRangeResult) raResult).getTap(state.getId()) != null) {
                             ((PstRangeResult) targetRaResult).setTap(state.getId(), ((PstRangeResult) raResult).getTap(state.getId()));
                         }
                     });

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
@@ -46,6 +46,11 @@ public class SearchTreeRaoProvider implements RaoProvider {
         return "1.0.0";
     }
 
+    // Useful for tests
+    SearchTreeRaoProvider(StateTree stateTree) {
+        this.stateTree = stateTree;
+    }
+
     @Override
     public CompletableFuture<RaoResult> run(RaoInput raoInput, RaoParameters parameters) {
         RaoUtil.initData(raoInput, parameters);
@@ -172,7 +177,7 @@ public class SearchTreeRaoProvider implements RaoProvider {
         }
     }
 
-    private RaoResult mergeRaoResults(Crac crac, RaoResult preventiveRaoResult, Map<State, RaoResult> curativeRaoResults) {
+    RaoResult mergeRaoResults(Crac crac, RaoResult preventiveRaoResult, Map<State, RaoResult> curativeRaoResults) {
         mergeRaoResultStatus(preventiveRaoResult, curativeRaoResults);
         mergeCnecResults(crac, preventiveRaoResult, curativeRaoResults);
         mergeRemedialActionsResults(crac, preventiveRaoResult, curativeRaoResults);

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
@@ -34,6 +34,8 @@ public class SearchTreeRaoProvider implements RaoProvider {
     private static final String PREVENTIVE_STATE = "PreventiveState";
     private static final String CURATIVE_STATE = "CurativeState";
 
+    private static final StateTree STATE_TREE = new StateTree();
+
     @Override
     public String getName() {
         return SEARCH_TREE_RAO;
@@ -65,55 +67,53 @@ public class SearchTreeRaoProvider implements RaoProvider {
         network.getVariantManager().cloneVariant(network.getVariantManager().getWorkingVariantId(), PREVENTIVE_STATE);
         network.getVariantManager().setWorkingVariant(PREVENTIVE_STATE);
 
-        List<List<State>> perimeters = RaoUtil.createPerimeters(raoInput.getCrac(), network, raoInput.getCrac().getPreventiveState());
-        List<State> preventivePerimeter = perimeters.remove(0);
-        Map<String, String> postOptimVariantIdPerStateId = new HashMap<>();
+        STATE_TREE.createPerimeters(raoInput.getCrac(), raoInput.getNetwork(), raoInput.getCrac().getPreventiveState());
 
         RaoData preventiveRaoData = new RaoData(
-                raoInput.getNetwork(),
-                raoInput.getCrac(),
-                preventivePerimeter.get(0),
-                new HashSet<>(preventivePerimeter),
-                raoInput.getReferenceProgram(),
-                raoInput.getGlskProvider(),
-                raoInput.getBaseCracVariantId(),
-                parameters.getLoopflowCountries());
+            raoInput.getNetwork(),
+            raoInput.getCrac(),
+            raoInput.getCrac().getPreventiveState(),
+            STATE_TREE.getPerimeter(raoInput.getCrac().getPreventiveState()),
+            raoInput.getReferenceProgram(),
+            raoInput.getGlskProvider(),
+            raoInput.getBaseCracVariantId(),
+            parameters.getLoopflowCountries());
         RaoResult preventiveRaoResult = new Tree().run(preventiveRaoData, parameters).join();
-        preventivePerimeter.forEach(state -> postOptimVariantIdPerStateId.put(state.getId(), preventiveRaoResult.getPostOptimVariantIdForStateId(preventivePerimeter.get(0).getId())));
 
         LOGGER.info("Preventive perimeter has been optimized.");
 
-        applyPreventiveRemedialActions(raoInput.getNetwork(), raoInput.getCrac(),
-            preventiveRaoResult.getPostOptimVariantIdForStateId(raoInput.getCrac().getPreventiveState().getId()));
+        applyPreventiveRemedialActions(raoInput.getNetwork(), raoInput.getCrac(), preventiveRaoResult.getPostOptimVariantId());
 
-        List<RaoResult> curativeResults = new ArrayList<>();
+        Map<State, RaoResult> curativeResults = new HashMap<>();
         network.getVariantManager().setWorkingVariant(PREVENTIVE_STATE);
         network.getVariantManager().cloneVariant(PREVENTIVE_STATE, CURATIVE_STATE);
         network.getVariantManager().setWorkingVariant(CURATIVE_STATE);
         // For now only one curative computation at a time
         try (FaraoNetworkPool networkPool = new FaraoNetworkPool(network, CURATIVE_STATE, 1)) {
-            perimeters.forEach(perimeter ->
-                networkPool.submit(() -> {
-                    try {
-                        LOGGER.info("Optimizing curative state {}.", perimeter.get(0).getId());
-                        Network networkClone = networkPool.getAvailableNetwork();
-                        RaoData curativeRaoData = new RaoData(
+            STATE_TREE.getOptimizedStates().forEach(optimizedState -> {
+                if (!optimizedState.equals(raoInput.getCrac().getPreventiveState())) {
+                    networkPool.submit(() -> {
+                        try {
+                            LOGGER.info("Optimizing curative state {}.", optimizedState.getId());
+                            Network networkClone = networkPool.getAvailableNetwork();
+                            RaoData curativeRaoData = new RaoData(
                                 networkClone,
                                 raoInput.getCrac(),
-                                perimeter.get(0),
-                                new HashSet<>(perimeter),
+                                optimizedState,
+                                STATE_TREE.getPerimeter(optimizedState),
                                 raoInput.getReferenceProgram(),
                                 raoInput.getGlskProvider(),
-                                preventiveRaoResult.getPostOptimVariantIdForStateId(raoInput.getCrac().getPreventiveState().getId()),
+                                preventiveRaoResult.getPostOptimVariantId(),
                                 parameters.getLoopflowCountries());
-                        RaoResult curativeResult = new Tree().run(curativeRaoData, parameters).join();
-                        curativeResults.add(curativeResult);
-                        networkPool.releaseUsedNetwork(networkClone);
-                        perimeter.forEach(state -> postOptimVariantIdPerStateId.put(state.getId(), curativeResult.getPostOptimVariantIdForStateId(perimeter.get(0).getId())));
-                    } catch (InterruptedException | NotImplementedException | FaraoException e) {
-                        Thread.currentThread().interrupt();
-                    }
-                }));
+                            RaoResult curativeResult = new Tree().run(curativeRaoData, parameters).join();
+                            curativeResults.put(optimizedState, curativeResult);
+                            networkPool.releaseUsedNetwork(networkClone);
+                        } catch (InterruptedException | NotImplementedException | FaraoException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    });
+                }
+            });
             networkPool.shutdown();
             networkPool.awaitTermination(24, TimeUnit.HOURS);
         } catch (InterruptedException e) {
@@ -121,13 +121,14 @@ public class SearchTreeRaoProvider implements RaoProvider {
         }
 
         LOGGER.info("Merging preventive and curative RAO results.");
-        RaoResult mergedRaoResults = mergeRaoResults(preventiveRaoResult, curativeResults);
-        if (mergedRaoResults.isSuccessful()) {
+        RaoResult mergedRaoResults = mergeRaoResults(raoInput.getCrac(), preventiveRaoResult, curativeResults);
+        // For logs only
+        /*if (mergedRaoResults.isSuccessful()) {
             boolean relativePositiveMargins =
                     parameters.getObjectiveFunction().equals(RaoParameters.ObjectiveFunction.MAX_MIN_RELATIVE_MARGIN_IN_AMPERE) ||
                             parameters.getObjectiveFunction().equals(RaoParameters.ObjectiveFunction.MAX_MIN_RELATIVE_MARGIN_IN_MEGAWATT);
             SearchTreeRaoLogger.logMostLimitingElementsResults(raoInput.getCrac().getCnecs(), postOptimVariantIdPerStateId, parameters.getObjectiveFunction().getUnit(), relativePositiveMargins);
-        }
+        }*/
         return CompletableFuture.completedFuture(mergedRaoResults);
     }
 
@@ -171,12 +172,51 @@ public class SearchTreeRaoProvider implements RaoProvider {
         }
     }
 
-    private RaoResult mergeRaoResults(RaoResult preventiveRaoResult, List<RaoResult> curativeRaoResults) {
-        curativeRaoResults.forEach(curativeRaoResult -> {
+    private RaoResult mergeRaoResults(Crac crac, RaoResult preventiveRaoResult, Map<State, RaoResult> curativeRaoResults) {
+        curativeRaoResults.values().forEach(curativeRaoResult -> {
             if (curativeRaoResult.getStatus().equals(RaoResult.Status.FAILURE)) {
                 preventiveRaoResult.setStatus(RaoResult.Status.FAILURE);
             }
-            curativeRaoResult.getPostOptimVariantIdPerStateId().forEach(preventiveRaoResult::setPostOptimVariantIdForStateId);
+        });
+        crac.getCnecs().forEach(cnec -> {
+            State optimizedState = STATE_TREE.getOptimizedState(cnec.getState());
+            if (!optimizedState.equals(crac.getPreventiveState())) {
+                String optimizedVariantId = curativeRaoResults.get(optimizedState).getPostOptimVariantId();
+                CnecResult optimizedCnecResult = cnec.getExtension(CnecResultExtension.class).getVariant(optimizedVariantId);
+                CnecResult targetResult = cnec.getExtension(CnecResultExtension.class).getVariant(preventiveRaoResult.getPostOptimVariantId());
+                targetResult.setAbsolutePtdfSum(optimizedCnecResult.getAbsolutePtdfSum());
+                targetResult.setFlowInA(optimizedCnecResult.getFlowInA());
+                targetResult.setFlowInMW(optimizedCnecResult.getFlowInMW());
+                targetResult.setLoopflowInMW(optimizedCnecResult.getLoopflowInMW());
+                targetResult.setLoopflowThresholdInMW(optimizedCnecResult.getLoopflowThresholdInMW());
+                targetResult.setMaxThresholdInA(optimizedCnecResult.getMaxThresholdInA());
+                targetResult.setMaxThresholdInMW(optimizedCnecResult.getMaxThresholdInMW());
+                targetResult.setMinThresholdInA(optimizedCnecResult.getMinThresholdInA());
+                targetResult.setMinThresholdInMW(optimizedCnecResult.getMinThresholdInMW());
+            }
+        });
+
+        STATE_TREE.getOptimizedStates().forEach(optimizedState -> {
+            if (!optimizedState.equals(crac.getPreventiveState())) {
+                String optimizedVariantId = curativeRaoResults.get(optimizedState).getPostOptimVariantId();
+                crac.getNetworkActions().forEach(networkAction -> {
+                    NetworkActionResult naResult = networkAction.getExtension(NetworkActionResultExtension.class).getVariant(optimizedVariantId);
+                    NetworkActionResult targetNaResult = networkAction.getExtension(NetworkActionResultExtension.class).getVariant(preventiveRaoResult.getPostOptimVariantId());
+                    if (naResult.isActivated(optimizedState.getId())) {
+                        targetNaResult.activate(optimizedState.getId());
+                    }
+                });
+                crac.getRangeActions().forEach(rangeAction -> {
+                    RangeActionResult raResult = rangeAction.getExtension(RangeActionResultExtension.class).getVariant(optimizedVariantId);
+                    RangeActionResult targetRaResult = rangeAction.getExtension(RangeActionResultExtension.class).getVariant(preventiveRaoResult.getPostOptimVariantId());
+                    STATE_TREE.getPerimeter(optimizedState).forEach(state -> {
+                        targetRaResult.setSetPoint(state.getId(), raResult.getSetPoint(state.getId()));
+                        if (raResult instanceof PstRangeResult && targetRaResult instanceof PstRangeResult) {
+                            ((PstRangeResult) targetRaResult).setTap(state.getId(), ((PstRangeResult) raResult).getTap(state.getId()));
+                        }
+                    });
+                });
+            }
         });
         return preventiveRaoResult;
     }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/StateTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/StateTree.java
@@ -24,19 +24,7 @@ public class StateTree {
     Map<State, State> optimizedStatePerState = new HashMap<>();
     Map<State, Set<State>> perimeterPerOptimizedState = new HashMap<>();
 
-    public State getOptimizedState(State state) {
-        return optimizedStatePerState.get(state);
-    }
-
-    public Set<State> getOptimizedStates() {
-        return new HashSet<>(optimizedStatePerState.values());
-    }
-
-    public Set<State> getPerimeter(State optimizedState) {
-        return perimeterPerOptimizedState.get(optimizedState);
-    }
-
-    public void createPerimeters(Crac crac, Network network, State startingState) {
+    public StateTree(Crac crac, Network network, State startingState) {
         List<List<State>> perimeters = new ArrayList<>();
 
         if (startingState.equals(crac.getPreventiveState())) {
@@ -63,6 +51,18 @@ public class StateTree {
             perimeterPerOptimizedState.put(states.get(0), new HashSet<>(states));
             states.forEach(state -> optimizedStatePerState.put(state, states.get(0)));
         });
+    }
+
+    public State getOptimizedState(State state) {
+        return optimizedStatePerState.get(state);
+    }
+
+    public Set<State> getOptimizedStates() {
+        return new HashSet<>(optimizedStatePerState.values());
+    }
+
+    public Set<State> getPerimeter(State optimizedState) {
+        return perimeterPerOptimizedState.get(optimizedState);
     }
 
     private static boolean anyAvailableRemedialAction(Crac crac, Network network, State state) {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/StateTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/StateTree.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.farao_community.farao.search_tree_rao;
+
+import com.farao_community.farao.data.crac_api.Contingency;
+import com.farao_community.farao.data.crac_api.Crac;
+import com.farao_community.farao.data.crac_api.State;
+import com.farao_community.farao.data.crac_api.UsageMethod;
+import com.powsybl.iidm.network.Network;
+import org.apache.commons.lang3.NotImplementedException;
+
+import java.util.*;
+
+/**
+ * @author Joris Mancini {@literal <joris.mancini at rte-france.com>}
+ */
+public class StateTree {
+
+    Map<State, State> optimizedStatePerState = new HashMap<>();
+    Map<State, Set<State>> perimeterPerOptimizedState = new HashMap<>();
+
+    public State getOptimizedState(State state) {
+        return optimizedStatePerState.get(state);
+    }
+
+    public Set<State> getOptimizedStates() {
+        return new HashSet<>(optimizedStatePerState.values());
+    }
+
+    public Set<State> getPerimeter(State optimizedState) {
+        return perimeterPerOptimizedState.get(optimizedState);
+    }
+
+    public void createPerimeters(Crac crac, Network network, State startingState) {
+        List<List<State>> perimeters = new ArrayList<>();
+
+        if (startingState.equals(crac.getPreventiveState())) {
+            List<State> preventivePerimeter = new ArrayList<>();
+            preventivePerimeter.add(startingState);
+            perimeters.add(preventivePerimeter);
+
+            List<State> currentPerimeter;
+            for (Contingency contingency : crac.getContingencies()) {
+                currentPerimeter = preventivePerimeter;
+                for (State state : crac.getStates(contingency)) {
+                    if (anyAvailableRemedialAction(crac, network, state)) {
+                        currentPerimeter = new ArrayList<>();
+                        perimeters.add(currentPerimeter);
+                    }
+                    currentPerimeter.add(state);
+                }
+            }
+        } else {
+            throw new NotImplementedException("Cannot create perimeters if starting state is different from preventive state");
+        }
+
+        perimeters.forEach(states -> {
+            perimeterPerOptimizedState.put(states.get(0), new HashSet<>(states));
+            states.forEach(state -> optimizedStatePerState.put(state, states.get(0)));
+        });
+    }
+
+    private static boolean anyAvailableRemedialAction(Crac crac, Network network, State state) {
+        return !crac.getNetworkActions(network, state, UsageMethod.AVAILABLE).isEmpty() ||
+            !crac.getRangeActions(network, state, UsageMethod.AVAILABLE).isEmpty();
+    }
+}

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/Tree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/Tree.java
@@ -221,7 +221,7 @@ public class Tree {
     private RaoResult buildOutput() {
         RaoResult raoResult = new RaoResult(optimalLeaf.getStatus().equals(Leaf.Status.ERROR) ? RaoResult.Status.FAILURE : RaoResult.Status.SUCCESS);
         raoResult.setPreOptimVariantId(rootLeaf.getInitialVariantId());
-        raoResult.setPostOptimVariantIdForStateId(optimalLeaf.getRaoData().getOptimizedState().getId(), optimalLeaf.getBestVariantId());
+        raoResult.setPostOptimVariantId(optimalLeaf.getBestVariantId());
         return raoResult;
     }
 }

--- a/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/PerimetersTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/PerimetersTest.java
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-package com.farao_community.farao.rao_commons;
+package com.farao_community.farao.search_tree_rao;
 
 import com.farao_community.farao.commons.Unit;
 import com.farao_community.farao.data.crac_api.*;
@@ -17,8 +17,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.util.List;
-
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -28,6 +26,7 @@ public class PerimetersTest {
 
     private SimpleCrac crac;
     private Network network;
+    private StateTree stateTree;
 
     @Before
     public void setUp() {
@@ -88,13 +87,15 @@ public class PerimetersTest {
             .newNetworkElement().setId("ne1").add()
             .newThreshold().setSide(Side.LEFT).setUnit(Unit.AMPERE).setMaxValue(200.).setDirection(Direction.BOTH).add()
             .add();
+
+        stateTree = new StateTree();
     }
 
     @Test
     public void testCreatePerimetersWithNoRemedialActions() {
-        List<List<State>> perimeters = RaoUtil.createPerimeters(crac, network, crac.getPreventiveState());
-        assertEquals(1, perimeters.size());
-        assertEquals(7, perimeters.get(0).size());
+        stateTree.createPerimeters(crac, network, crac.getPreventiveState());
+        assertEquals(1, stateTree.getOptimizedStates().size());
+        assertEquals(7, stateTree.getPerimeter(crac.getPreventiveState()).size());
     }
 
     @Test
@@ -102,10 +103,10 @@ public class PerimetersTest {
         PstRange pstRange = new PstWithRange("pst-ra", crac.addNetworkElement(new NetworkElement("pst1")));
         pstRange.addUsageRule(new OnState(UsageMethod.AVAILABLE, crac.getState("contingency-1", "Outage")));
         crac.addRangeAction(pstRange);
-        List<List<State>> perimeters = RaoUtil.createPerimeters(crac, network, crac.getPreventiveState());
-        assertEquals(2, perimeters.size());
-        assertEquals(5, perimeters.get(0).size());
-        assertEquals(2, perimeters.get(1).size());
+        stateTree.createPerimeters(crac, network, crac.getPreventiveState());
+        assertEquals(2, stateTree.getOptimizedStates().size());
+        assertEquals(5, stateTree.getPerimeter(crac.getPreventiveState()).size());
+        assertEquals(2, stateTree.getPerimeter(crac.getState("contingency-1", "Outage")).size());
     }
 
     @Test
@@ -113,10 +114,10 @@ public class PerimetersTest {
         PstRange pstRange = new PstWithRange("pst-ra", crac.addNetworkElement(new NetworkElement("pst1")));
         pstRange.addUsageRule(new OnState(UsageMethod.AVAILABLE, crac.getState("contingency-1", "Curative")));
         crac.addRangeAction(pstRange);
-        List<List<State>> perimeters = RaoUtil.createPerimeters(crac, network, crac.getPreventiveState());
-        assertEquals(2, perimeters.size());
-        assertEquals(6, perimeters.get(0).size());
-        assertEquals(1, perimeters.get(1).size());
+        stateTree.createPerimeters(crac, network, crac.getPreventiveState());
+        assertEquals(2, stateTree.getOptimizedStates().size());
+        assertEquals(6, stateTree.getPerimeter(crac.getPreventiveState()).size());
+        assertEquals(1, stateTree.getPerimeter(crac.getState("contingency-1", "Curative")).size());
     }
 
     @Test
@@ -127,9 +128,9 @@ public class PerimetersTest {
         PstRange pstRange2 = new PstWithRange("pst-ra2", crac.addNetworkElement(new NetworkElement("pst1")));
         pstRange2.addUsageRule(new OnState(UsageMethod.AVAILABLE, crac.getState("contingency-2", "Outage")));
         crac.addRangeAction(pstRange2);
-        List<List<State>> perimeters = RaoUtil.createPerimeters(crac, network, crac.getPreventiveState());
-        assertEquals(3, perimeters.size());
-        assertEquals(4, perimeters.get(0).size());
+        stateTree.createPerimeters(crac, network, crac.getPreventiveState());
+        assertEquals(3, stateTree.getOptimizedStates().size());
+        assertEquals(4, stateTree.getPerimeter(crac.getPreventiveState()).size());
     }
 
     @Test
@@ -140,8 +141,8 @@ public class PerimetersTest {
         PstRange pstRange2 = new PstWithRange("pst-ra2", crac.addNetworkElement(new NetworkElement("pst1")));
         pstRange2.addUsageRule(new OnState(UsageMethod.AVAILABLE, crac.getState("contingency-2", "Outage")));
         crac.addRangeAction(pstRange2);
-        List<List<State>> perimeters = RaoUtil.createPerimeters(crac, network, crac.getPreventiveState());
-        assertEquals(3, perimeters.size());
-        assertEquals(5, perimeters.get(0).size());
+        stateTree.createPerimeters(crac, network, crac.getPreventiveState());
+        assertEquals(3, stateTree.getOptimizedStates().size());
+        assertEquals(5, stateTree.getPerimeter(crac.getPreventiveState()).size());
     }
 }

--- a/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/PerimetersTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/PerimetersTest.java
@@ -87,13 +87,11 @@ public class PerimetersTest {
             .newNetworkElement().setId("ne1").add()
             .newThreshold().setSide(Side.LEFT).setUnit(Unit.AMPERE).setMaxValue(200.).setDirection(Direction.BOTH).add()
             .add();
-
-        stateTree = new StateTree();
     }
 
     @Test
     public void testCreatePerimetersWithNoRemedialActions() {
-        stateTree.createPerimeters(crac, network, crac.getPreventiveState());
+        stateTree = new StateTree(crac, network, crac.getPreventiveState());
         assertEquals(1, stateTree.getOptimizedStates().size());
         assertEquals(7, stateTree.getPerimeter(crac.getPreventiveState()).size());
     }
@@ -103,7 +101,7 @@ public class PerimetersTest {
         PstRange pstRange = new PstWithRange("pst-ra", crac.addNetworkElement(new NetworkElement("pst1")));
         pstRange.addUsageRule(new OnState(UsageMethod.AVAILABLE, crac.getState("contingency-1", "Outage")));
         crac.addRangeAction(pstRange);
-        stateTree.createPerimeters(crac, network, crac.getPreventiveState());
+        stateTree = new StateTree(crac, network, crac.getPreventiveState());
         assertEquals(2, stateTree.getOptimizedStates().size());
         assertEquals(5, stateTree.getPerimeter(crac.getPreventiveState()).size());
         assertEquals(2, stateTree.getPerimeter(crac.getState("contingency-1", "Outage")).size());
@@ -114,7 +112,7 @@ public class PerimetersTest {
         PstRange pstRange = new PstWithRange("pst-ra", crac.addNetworkElement(new NetworkElement("pst1")));
         pstRange.addUsageRule(new OnState(UsageMethod.AVAILABLE, crac.getState("contingency-1", "Curative")));
         crac.addRangeAction(pstRange);
-        stateTree.createPerimeters(crac, network, crac.getPreventiveState());
+        stateTree = new StateTree(crac, network, crac.getPreventiveState());
         assertEquals(2, stateTree.getOptimizedStates().size());
         assertEquals(6, stateTree.getPerimeter(crac.getPreventiveState()).size());
         assertEquals(1, stateTree.getPerimeter(crac.getState("contingency-1", "Curative")).size());
@@ -128,7 +126,7 @@ public class PerimetersTest {
         PstRange pstRange2 = new PstWithRange("pst-ra2", crac.addNetworkElement(new NetworkElement("pst1")));
         pstRange2.addUsageRule(new OnState(UsageMethod.AVAILABLE, crac.getState("contingency-2", "Outage")));
         crac.addRangeAction(pstRange2);
-        stateTree.createPerimeters(crac, network, crac.getPreventiveState());
+        stateTree = new StateTree(crac, network, crac.getPreventiveState());
         assertEquals(3, stateTree.getOptimizedStates().size());
         assertEquals(4, stateTree.getPerimeter(crac.getPreventiveState()).size());
     }
@@ -141,7 +139,7 @@ public class PerimetersTest {
         PstRange pstRange2 = new PstWithRange("pst-ra2", crac.addNetworkElement(new NetworkElement("pst1")));
         pstRange2.addUsageRule(new OnState(UsageMethod.AVAILABLE, crac.getState("contingency-2", "Outage")));
         crac.addRangeAction(pstRange2);
-        stateTree.createPerimeters(crac, network, crac.getPreventiveState());
+        stateTree = new StateTree(crac, network, crac.getPreventiveState());
         assertEquals(3, stateTree.getOptimizedStates().size());
         assertEquals(5, stateTree.getPerimeter(crac.getPreventiveState()).size());
     }

--- a/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/SearchTreeRaoProviderTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/SearchTreeRaoProviderTest.java
@@ -21,7 +21,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,7 +45,7 @@ public class SearchTreeRaoProviderTest {
 
         crac.addNetworkAction(new Topology("open BE2-FR3", "open BE2-FR3", "FR",
             List.of(new OnState(UsageMethod.AVAILABLE, curativeState)),
-            crac.addNetworkElement("BBE2AA1  FFR3AA1  1"), ActionType.OPEN));
+            crac.getNetworkElement("BBE2AA1  FFR3AA1  1"), ActionType.OPEN));
 
         ResultVariantManager resultVariantManager = new ResultVariantManager();
         crac.addExtension(ResultVariantManager.class, resultVariantManager);

--- a/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/SearchTreeRaoProviderTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/SearchTreeRaoProviderTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.farao_community.farao.search_tree_rao;
+
+import com.farao_community.farao.data.crac_api.ActionType;
+import com.farao_community.farao.data.crac_api.Crac;
+import com.farao_community.farao.data.crac_api.State;
+import com.farao_community.farao.data.crac_api.UsageMethod;
+import com.farao_community.farao.data.crac_impl.SimpleCrac;
+import com.farao_community.farao.data.crac_impl.remedial_action.network_action.Topology;
+import com.farao_community.farao.data.crac_impl.usage_rule.OnState;
+import com.farao_community.farao.data.crac_impl.utils.CommonCracCreation;
+import com.farao_community.farao.data.crac_result_extensions.*;
+import com.farao_community.farao.rao_api.RaoResult;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Joris Mancini {@literal <joris.mancini at rte-france.com>}
+ */
+public class SearchTreeRaoProviderTest {
+
+    private SimpleCrac crac;
+    private String initialVariantId;
+    private String postOptimPrevVariantId;
+    private String postOptimCurVariantId;
+
+    @Before
+    public void setUp() {
+        crac = CommonCracCreation.createWithPstRange();
+
+        State curativeState = crac.getState("Contingency FR1 FR3", "curative");
+
+        crac.addNetworkAction(new Topology("open BE2-FR3", "open BE2-FR3", "FR",
+            List.of(new OnState(UsageMethod.AVAILABLE, curativeState)),
+            crac.addNetworkElement("BBE2AA1  FFR3AA1  1"), ActionType.OPEN));
+
+        ResultVariantManager resultVariantManager = new ResultVariantManager();
+        crac.addExtension(ResultVariantManager.class, resultVariantManager);
+        initialVariantId = resultVariantManager.createNewUniqueVariantId("initial");
+        postOptimPrevVariantId = resultVariantManager.createNewUniqueVariantId("postOptim-prev");
+        postOptimCurVariantId = resultVariantManager.createNewUniqueVariantId("postOptim-cur");
+        resultVariantManager.setInitialVariantId(initialVariantId);
+
+        crac.getCnec("cnec1basecase").getExtension(CnecResultExtension.class).getVariant(initialVariantId).setFlowInMW(600);
+        crac.getCnec("cnec1basecase").getExtension(CnecResultExtension.class).getVariant(postOptimPrevVariantId).setFlowInMW(300);
+
+        crac.getCnec("cnec1stateCurativeContingency1").getExtension(CnecResultExtension.class)
+            .getVariant(postOptimPrevVariantId).setFlowInMW(400);
+        crac.getCnec("cnec1stateCurativeContingency1").getExtension(CnecResultExtension.class)
+            .getVariant(postOptimCurVariantId).setFlowInMW(200);
+
+        ((PstRangeResult) crac.getRangeAction("pst").getExtension(RangeActionResultExtension.class)
+            .getVariant(initialVariantId)).setTap(crac.getPreventiveState().getId(), 0);
+        ((PstRangeResult) crac.getRangeAction("pst").getExtension(RangeActionResultExtension.class)
+            .getVariant(postOptimPrevVariantId)).setTap(crac.getPreventiveState().getId(), 5);
+        ((PstRangeResult) crac.getRangeAction("pst").getExtension(RangeActionResultExtension.class)
+            .getVariant(postOptimCurVariantId)).setTap(curativeState.getId(), -10);
+
+        crac.getNetworkAction("open BE2-FR3").getExtension(NetworkActionResultExtension.class)
+            .getVariant(postOptimCurVariantId).activate(curativeState.getId());
+    }
+
+    /* Creates simple state tree with :
+     *  - preventive perimeter being {preventive state (optimized), curative state after FR1-FR2co}
+     *  - a curative perimeer being {curative state after FR1-FR3co (optimized)}
+     */
+    private StateTree mockedStateTree(Crac crac) {
+        State curativeState = crac.getState("Contingency FR1 FR3", "curative");
+        StateTree stateTree = Mockito.mock(StateTree.class);
+        Mockito.when(stateTree.getOptimizedState(crac.getPreventiveState())).thenReturn(crac.getPreventiveState());
+        Mockito.when(stateTree.getOptimizedState(crac.getState("Contingency FR1 FR2", "curative"))).thenReturn(crac.getPreventiveState());
+        Mockito.when(stateTree.getOptimizedState(curativeState)).thenReturn(curativeState);
+        Mockito.when(stateTree.getOptimizedStates()).thenReturn(Set.of(crac.getPreventiveState(), curativeState));
+        Mockito.when(stateTree.getPerimeter(crac.getPreventiveState())).thenReturn(Set.of(crac.getPreventiveState(), crac.getState("Contingency FR1 FR2", "curative")));
+        Mockito.when(stateTree.getPerimeter(curativeState)).thenReturn(Set.of(curativeState));
+        return stateTree;
+    }
+
+    @Test
+    public void mergeRaoResults() {
+
+        RaoResult preventiveRaoResult = new RaoResult(RaoResult.Status.SUCCESS);
+        preventiveRaoResult.setPreOptimVariantId(initialVariantId);
+        preventiveRaoResult.setPostOptimVariantId(postOptimPrevVariantId);
+
+        RaoResult curativeRaoResult = new RaoResult(RaoResult.Status.SUCCESS);
+        curativeRaoResult.setPreOptimVariantId(postOptimPrevVariantId);
+        curativeRaoResult.setPostOptimVariantId(postOptimCurVariantId);
+
+        StateTree stateTree = mockedStateTree(crac);
+
+        State curativeState = crac.getState("Contingency FR1 FR3", "curative");
+        RaoResult mergedRaoResult = new SearchTreeRaoProvider(stateTree).mergeRaoResults(crac, preventiveRaoResult,
+            Map.of(curativeState, curativeRaoResult));
+
+        assertEquals(RaoResult.Status.SUCCESS, mergedRaoResult.getStatus());
+        assertEquals(postOptimPrevVariantId, mergedRaoResult.getPostOptimVariantId());
+        assertEquals(300, crac.getCnec("cnec1basecase").getExtension(CnecResultExtension.class)
+            .getVariant(postOptimPrevVariantId).getFlowInMW(), 0.1);
+        assertEquals(200, crac.getCnec("cnec1stateCurativeContingency1").getExtension(CnecResultExtension.class)
+            .getVariant(postOptimPrevVariantId).getFlowInMW(), 0.1);
+        assertEquals(Integer.valueOf(5), ((PstRangeResult) crac.getRangeAction("pst").getExtension(RangeActionResultExtension.class)
+            .getVariant(postOptimPrevVariantId)).getTap(crac.getPreventiveState().getId()));
+        assertEquals(Integer.valueOf(-10), ((PstRangeResult) crac.getRangeAction("pst").getExtension(RangeActionResultExtension.class)
+            .getVariant(postOptimPrevVariantId)).getTap(curativeState.getId()));
+        assertTrue(crac.getNetworkAction("open BE2-FR3").getExtension(NetworkActionResultExtension.class)
+            .getVariant(postOptimPrevVariantId).isActivated(curativeState.getId()));
+        assertEquals(2, crac.getExtension(ResultVariantManager.class).getVariants().size());
+    }
+
+    @Test
+    public void mergeRaoResultsWithFailure() {
+
+        RaoResult preventiveRaoResult = new RaoResult(RaoResult.Status.SUCCESS);
+        preventiveRaoResult.setPreOptimVariantId(initialVariantId);
+        preventiveRaoResult.setPostOptimVariantId(postOptimPrevVariantId);
+
+        RaoResult curativeRaoResult = new RaoResult(RaoResult.Status.FAILURE);
+        curativeRaoResult.setPreOptimVariantId(postOptimPrevVariantId);
+        curativeRaoResult.setPostOptimVariantId(postOptimCurVariantId);
+
+        StateTree stateTree = mockedStateTree(crac);
+
+        State curativeState = crac.getState("Contingency FR1 FR3", "curative");
+        RaoResult mergedRaoResult = new SearchTreeRaoProvider(stateTree).mergeRaoResults(crac, preventiveRaoResult,
+            Map.of(curativeState, curativeRaoResult));
+
+        assertEquals(RaoResult.Status.FAILURE, mergedRaoResult.getStatus());
+    }
+}

--- a/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/SearchTreeTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/SearchTreeTest.java
@@ -46,11 +46,11 @@ import static org.mockito.Mockito.when;
  * @author Joris Mancini {@literal <joris.mancini at rte-france.com>}
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({NativeLibraryLoader.class, SearchTreeRaoLogger.class, SystematicSensitivityInterface.class, Leaf.class, Tree.class})
+@PrepareForTest({NativeLibraryLoader.class, SearchTreeRaoLogger.class, SystematicSensitivityInterface.class, Leaf.class, SearchTree.class})
 @PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
-public class TreeTest {
+public class SearchTreeTest {
 
-    private Tree tree;
+    private SearchTree searchTree;
     private RaoParameters raoParameters;
     private SystematicSensitivityInterface systematicSensitivityInterface;
     private IteratingLinearOptimizer iteratingLinearOptimizer;
@@ -59,7 +59,7 @@ public class TreeTest {
 
     @Before
     public void setUp() {
-        tree = new Tree();
+        searchTree = new SearchTree();
         network = NetworkImportsUtil.import12NodesNetwork();
         String variantId = network.getVariantManager().getWorkingVariantId();
         RaoUtil.initNetwork(network, variantId);
@@ -105,7 +105,7 @@ public class TreeTest {
         when(mockLeaf.getBestCost()).thenReturn(0.);
         PowerMockito.doNothing().when(mockLeaf).evaluate();
 
-        RaoResult result = tree.run(raoData, raoParameters).join();
+        RaoResult result = searchTree.run(raoData, raoParameters).join();
         assertNotNull(result);
         assertEquals(RaoResult.Status.SUCCESS, result.getStatus());
     }
@@ -114,9 +114,9 @@ public class TreeTest {
     public void optimizeNextLeafAndUpdate() throws Exception {
         NetworkAction networkAction = Mockito.mock(NetworkAction.class);
         FaraoNetworkPool faraoNetworkPool = Mockito.mock(FaraoNetworkPool.class);
-        tree.initParameters(raoParameters);
-        tree.initLeaves(raoData);
+        searchTree.initParameters(raoParameters);
+        searchTree.initLeaves(raoData);
         Mockito.doThrow(new NotImplementedException("")).when(networkAction).apply(network);
-        tree.optimizeNextLeafAndUpdate(networkAction, network, faraoNetworkPool);
+        searchTree.optimizeNextLeafAndUpdate(networkAction, network, faraoNetworkPool);
     }
 }

--- a/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/mock/RaoRunnerMock.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/mock/RaoRunnerMock.java
@@ -11,8 +11,6 @@ import com.farao_community.farao.data.crac_result_extensions.CracResultExtension
 import com.farao_community.farao.data.crac_result_extensions.ResultVariantManager;
 import com.farao_community.farao.rao_api.*;
 
-import java.util.Map;
-
 /**
  * @author Philippe Edwards {@literal <philippe.edwards at rte-france.com>}
  */
@@ -36,7 +34,7 @@ public class RaoRunnerMock extends Rao.Runner {
 
         RaoResult raoResult = new RaoResult(RaoResult.Status.SUCCESS);
         raoResult.setPreOptimVariantId(preOpt);
-        raoResult.setPostOptimVariantIdPerStateId(Map.of(raoInput.getOptimizedState().getId(), postOpt));
+        raoResult.setPostOptimVariantId(postOpt);
         return raoResult;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
To complete development on curative there was a temporary solution on results storage. Now we're back where RaoResult has only one post-optim result variant. The results of curative perimeters are merged into this one


**What is the current behavior?** *(You can also link to an open issue here)*
Multiple post-optim variants are returned according to optimized state


**What is the new behavior (if this is a feature change)?**
Only one post-optim result variant gathering the resuts for all perimeters optimizations
