### PR TITLE
compute PTDF for loop-flows on preventive Cnecs only

### DIFF
--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoData.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoData.java
@@ -153,11 +153,13 @@ public final class RaoData {
     private void computeLoopflowCnecs() {
         //TODO: when we start computing loopflows for N-1 cnecs, adapt this part of code
         if (!loopflowCountries.isEmpty()) {
-            loopflowCnecs = crac.getCnecs(crac.getPreventiveState()).stream()
+            loopflowCnecs = perimeterCnecs.stream()
+                .filter(cnec -> cnec.getState().getContingency().isEmpty())
                 .filter(cnec -> !Objects.isNull(cnec.getExtension(CnecLoopFlowExtension.class)) && cnecIsInCountryList(cnec, network, loopflowCountries))
                 .collect(Collectors.toSet());
         } else {
-            loopflowCnecs = crac.getCnecs().stream()
+            loopflowCnecs = perimeterCnecs.stream()
+                .filter(cnec -> cnec.getState().getContingency().isEmpty())
                 .filter(cnec -> !Objects.isNull(cnec.getExtension(CnecLoopFlowExtension.class)))
                 .collect(Collectors.toSet());
         }


### PR DESCRIPTION
Small fix : 
- compute PTDF for loop-flows on preventive Cnecs only
- compute PTDF for loop-flows only for the Cnecs in the perimeter