### PR TITLE
Added a new "in-between" level of loopflow approximations

### DIFF
--- a/data/crac/crac-loopflow-extension/src/main/java/com/farao_community/farao/data/crac_loopflow_extension/CnecLoopFlowExtension.java
+++ b/data/crac/crac-loopflow-extension/src/main/java/com/farao_community/farao/data/crac_loopflow_extension/CnecLoopFlowExtension.java
@@ -34,8 +34,6 @@ public class CnecLoopFlowExtension extends AbstractExtension<Cnec> {
 
     // ATTRIBUTES USED BY THE RAO to temporarily store some data about the loop-flows
     private double loopFlowConstraintInMW; // loop-flow upper bound, usually = max (Abs(inputThreshold), Abs(initial loopflow)) - frm
-    private double loopflowShift; // sum (ptdf * net position)
-    private boolean hasLoopflowShift; //has previous calculated loopflow shift value
 
     public CnecLoopFlowExtension(double inputThreshold, Unit inputThresholdUnit) {
         if (inputThresholdUnit.getPhysicalParameter() != PhysicalParameter.FLOW) {
@@ -46,8 +44,6 @@ public class CnecLoopFlowExtension extends AbstractExtension<Cnec> {
         this.inputThresholdUnit = inputThresholdUnit;
 
         this.loopFlowConstraintInMW = Double.NaN;
-        this.loopflowShift = Double.NaN;
-        this.hasLoopflowShift = false;
     }
 
     public double getInputThreshold() {
@@ -73,23 +69,6 @@ public class CnecLoopFlowExtension extends AbstractExtension<Cnec> {
      */
     public void setLoopFlowConstraintInMW(double loopFlowConstraint) {
         this.loopFlowConstraintInMW = loopFlowConstraint;
-    }
-
-    public double getLoopflowShift() {
-        return loopflowShift;
-    }
-
-    public void setLoopflowShift(double loopflowShift) {
-        this.loopflowShift = loopflowShift;
-        setHasLoopflowShift(true);
-    }
-
-    public boolean hasLoopflowShift() {
-        return hasLoopflowShift;
-    }
-
-    public void setHasLoopflowShift(boolean hasLoopflowShift) {
-        this.hasLoopflowShift = hasLoopflowShift;
     }
 
     public double getInputThreshold(Unit requestedUnit, Network network) {

--- a/data/crac/crac-loopflow-extension/src/test/java/com/farao_community/farao/data/crac_loopflow_extension/CnecLoopFlowExtensionTest.java
+++ b/data/crac/crac-loopflow-extension/src/test/java/com/farao_community/farao/data/crac_loopflow_extension/CnecLoopFlowExtensionTest.java
@@ -18,7 +18,6 @@ import org.junit.Test;
 
 import static java.lang.Math.sqrt;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com>}
@@ -51,11 +50,6 @@ public class CnecLoopFlowExtensionTest {
         Assert.assertEquals(200, cnecLoopFlowExtension.getLoopFlowConstraintInMW(), DOUBLE_TOLERANCE);
         Assert.assertEquals(100, cnecLoopFlowExtension.getInputThreshold(), DOUBLE_TOLERANCE);
         Assert.assertEquals(Unit.PERCENT_IMAX, cnecLoopFlowExtension.getInputThresholdUnit());
-
-        cnecLoopFlowExtension.setHasLoopflowShift(true);
-        cnecLoopFlowExtension.setLoopflowShift(1);
-        assertTrue(cnecLoopFlowExtension.hasLoopflowShift());
-        Assert.assertEquals(1, cnecLoopFlowExtension.getLoopflowShift(), DOUBLE_TOLERANCE);
     }
 
     @Test

--- a/data/crac/crac-result-extensions/src/main/java/com/farao_community/farao/data/crac_result_extensions/CnecResult.java
+++ b/data/crac/crac-result-extensions/src/main/java/com/farao_community/farao/data/crac_result_extensions/CnecResult.java
@@ -30,6 +30,7 @@ public class CnecResult implements Result {
 
     private double loopflowInMW; //loopflow value in MW
     private double loopflowThresholdInMW; //loopflow threshold in MW. Normally = max(Tso input, initial calculated lp)
+    private double commercialFlowInMW;
 
     private double absolutePtdfSum;
 
@@ -45,6 +46,7 @@ public class CnecResult implements Result {
         this.maxThresholdInA = Double.NaN;
         this.loopflowInMW = Double.NaN;
         this.loopflowThresholdInMW = Double.NaN;
+        this.commercialFlowInMW = Double.NaN;
         this.absolutePtdfSum = absolutePtdfSum;
     }
 
@@ -129,6 +131,14 @@ public class CnecResult implements Result {
 
     public void setLoopflowThresholdInMW(double loopflowThresholdInMW) {
         this.loopflowThresholdInMW = loopflowThresholdInMW;
+    }
+
+    public double getCommercialFlowInMW() {
+        return commercialFlowInMW;
+    }
+
+    public void setCommercialFlowInMW(double commercialFlowInMW) {
+        this.commercialFlowInMW = commercialFlowInMW;
     }
 
     public double getAbsolutePtdfSum() {

--- a/data/crac/crac-result-extensions/src/test/java/com.farao_community.farao.data.crac_result_extensions/CnecResultTest.java
+++ b/data/crac/crac-result-extensions/src/test/java/com.farao_community.farao.data.crac_result_extensions/CnecResultTest.java
@@ -69,5 +69,7 @@ public class CnecResultTest {
         assertEquals(2.0, cnecResult.getLoopflowInMW(), DOUBLE_TOLERANCE);
         cnecResult.setLoopflowThresholdInMW(2.0);
         assertEquals(2.0, cnecResult.getLoopflowThresholdInMW(), DOUBLE_TOLERANCE);
+        cnecResult.setCommercialFlowInMW(6.5);
+        assertEquals(6.5, cnecResult.getCommercialFlowInMW(), DOUBLE_TOLERANCE);
     }
 }

--- a/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
+++ b/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
@@ -79,7 +79,7 @@ public class LinearRao implements RaoProvider {
         }
 
         this.unit = raoParameters.getObjectiveFunction().getUnit();
-        SystematicSensitivityInterface systematicSensitivityInterface = RaoUtil.createSystematicSensitivityInterface(raoParameters, raoData);
+        SystematicSensitivityInterface systematicSensitivityInterface = RaoUtil.createSystematicSensitivityInterface(raoParameters, raoData, raoParameters.getLoopFlowApproximationLevel().shouldUpdatePtdfWithPstChange());
         IteratingLinearOptimizer iteratingLinearOptimizer = RaoUtil.createLinearOptimizer(raoParameters, systematicSensitivityInterface);
         return run(raoData, systematicSensitivityInterface, iteratingLinearOptimizer, new InitialSensitivityAnalysis(raoData, raoParameters), raoParameters);
     }

--- a/ra-optimisation/linear-rao/src/test/resources/LinearRaoParameters.json
+++ b/ra-optimisation/linear-rao/src/test/resources/LinearRaoParameters.json
@@ -6,7 +6,7 @@
   "pst-sensitivity-threshold" : 0.0,
   "sensitivity-fallback-over-cost" : 0.0,
   "rao-with-loop-flow-limitation" : false,
-  "loop-flow-approximation" : true,
+  "loop-flow-approximation" : "FIXED_PTDF",
   "loop-flow-constraint-adjustment-coefficient" : 0.0,
   "loop-flow-violation-cost" : 0.0,
   "loop-flow-countries" : [ ],

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/RaoParameters.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/RaoParameters.java
@@ -53,13 +53,27 @@ public class RaoParameters extends AbstractExtendable<RaoParameters> {
         }
     }
 
+    public enum LoopFlowApproximationLevel {
+        FIXED_PTDF, // compute PTDFs only once at beginning of RAO (best performance, worst accuracy)
+        UPDATE_PTDF_WITH_TOPO, // recompute PTDFs after every topological change in the network (worse performance, better accuracy for AC, best accuracy for DC)
+        UPDATE_PTDF_WITH_TOPO_AND_PST; // recompute PTDFs after every topological or PST change in the network (worst performance, best accuracy for AC)
+
+        public boolean shouldUpdatePtdfWithTopologicalChange() {
+            return !this.equals(FIXED_PTDF);
+        }
+
+        public boolean shouldUpdatePtdfWithPstChange() {
+            return this.equals(UPDATE_PTDF_WITH_TOPO_AND_PST);
+        }
+    }
+
     public static final ObjectiveFunction DEFAULT_OBJECTIVE_FUNCTION = ObjectiveFunction.MAX_MIN_MARGIN_IN_MEGAWATT;
     public static final int DEFAULT_MAX_ITERATIONS = 10;
     public static final double DEFAULT_FALLBACK_OVER_COST = 0;
     public static final boolean DEFAULT_RAO_WITH_LOOP_FLOW_LIMITATION = false; //loop flow is for CORE D2CC, default value set to false
     public static final boolean DEFAULT_SECURITY_ANALYSIS_WITHOUT_RAO = false;
     public static final double DEFAULT_PST_SENSITIVITY_THRESHOLD = 0.0;
-    public static final boolean DEFAULT_LOOP_FLOW_APPROXIMATION = true;
+    public static final LoopFlowApproximationLevel DEFAULT_LOOP_FLOW_APPROXIMATION_LEVEL = LoopFlowApproximationLevel.FIXED_PTDF;
     public static final double DEFAULT_LOOP_FLOW_CONSTRAINT_ADJUSTMENT_COEFFICIENT = 0.0;
     public static final double DEFAULT_LOOP_FLOW_VIOLATION_COST = 0.0;
     public static final double DEFAULT_PST_PENALTY_COST = 0.01;
@@ -75,7 +89,7 @@ public class RaoParameters extends AbstractExtendable<RaoParameters> {
     private double pstSensitivityThreshold = DEFAULT_PST_SENSITIVITY_THRESHOLD;
     private double fallbackOverCost = DEFAULT_FALLBACK_OVER_COST;
     private boolean raoWithLoopFlowLimitation = DEFAULT_RAO_WITH_LOOP_FLOW_LIMITATION;
-    private boolean loopFlowApproximation = DEFAULT_LOOP_FLOW_APPROXIMATION;
+    private LoopFlowApproximationLevel loopFlowApproximationLevel = DEFAULT_LOOP_FLOW_APPROXIMATION_LEVEL;
     private double loopFlowConstraintAdjustmentCoefficient = DEFAULT_LOOP_FLOW_CONSTRAINT_ADJUSTMENT_COEFFICIENT;
     private double loopFlowViolationCost = DEFAULT_LOOP_FLOW_VIOLATION_COST;
     private Set<Country> loopflowCountries = new HashSet<>(); //Empty by default
@@ -141,12 +155,12 @@ public class RaoParameters extends AbstractExtendable<RaoParameters> {
         return this;
     }
 
-    public boolean isLoopFlowApproximation() {
-        return loopFlowApproximation;
+    public LoopFlowApproximationLevel getLoopFlowApproximationLevel() {
+        return loopFlowApproximationLevel;
     }
 
-    public RaoParameters setLoopFlowApproximation(boolean loopFlowApproximation) {
-        this.loopFlowApproximation = loopFlowApproximation;
+    public RaoParameters setLoopFlowApproximationLevel(LoopFlowApproximationLevel loopFlowApproximation) {
+        this.loopFlowApproximationLevel = loopFlowApproximation;
         return this;
     }
 
@@ -282,7 +296,7 @@ public class RaoParameters extends AbstractExtendable<RaoParameters> {
                 parameters.setPstSensitivityThreshold(config.getDoubleProperty("pst-sensitivity-threshold", DEFAULT_PST_SENSITIVITY_THRESHOLD));
                 parameters.setFallbackOverCost(config.getDoubleProperty("sensitivity-fallback-over-cost", DEFAULT_FALLBACK_OVER_COST));
                 parameters.setRaoWithLoopFlowLimitation(config.getBooleanProperty("rao-with-loop-flow-limitation", DEFAULT_RAO_WITH_LOOP_FLOW_LIMITATION));
-                parameters.setLoopFlowApproximation(config.getBooleanProperty("loop-flow-approximation", DEFAULT_LOOP_FLOW_APPROXIMATION));
+                parameters.setLoopFlowApproximationLevel(config.getEnumProperty("loop-flow-approximation", LoopFlowApproximationLevel.class, DEFAULT_LOOP_FLOW_APPROXIMATION_LEVEL));
                 parameters.setLoopFlowConstraintAdjustmentCoefficient(config.getDoubleProperty("loop-flow-constraint-adjustment-coefficient", DEFAULT_LOOP_FLOW_CONSTRAINT_ADJUSTMENT_COEFFICIENT));
                 parameters.setLoopFlowViolationCost(config.getDoubleProperty("loop-flow-violation-cost", DEFAULT_LOOP_FLOW_VIOLATION_COST));
                 parameters.setLoopflowCountries(convertToCountrySet(config.getStringListProperty("loop-flow-countries", new ArrayList<>())));

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/RaoParametersDeserializer.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/RaoParametersDeserializer.java
@@ -72,8 +72,7 @@ public class RaoParametersDeserializer extends StdDeserializer<RaoParameters> {
                     parameters.setRaoWithLoopFlowLimitation(parser.getBooleanValue());
                     break;
                 case "loop-flow-approximation":
-                    parser.nextToken();
-                    parameters.setLoopFlowApproximation(parser.getBooleanValue());
+                    parameters.setLoopFlowApproximationLevel(stringToLoopFlowApproximationLevel(parser.nextTextValue()));
                     break;
                 case "loop-flow-constraint-adjustment-coefficient":
                     parser.nextToken();
@@ -138,7 +137,15 @@ public class RaoParametersDeserializer extends StdDeserializer<RaoParameters> {
         try {
             return RaoParameters.ObjectiveFunction.valueOf(string);
         } catch (IllegalArgumentException e) {
-            throw new FaraoException(String.format("Unknown objective function value : %s", string));
+            throw new FaraoException(String.format("Unknown objective function value: %s", string));
+        }
+    }
+
+    private RaoParameters.LoopFlowApproximationLevel stringToLoopFlowApproximationLevel(String string) {
+        try {
+            return RaoParameters.LoopFlowApproximationLevel.valueOf(string);
+        } catch (IllegalArgumentException e) {
+            throw new FaraoException(String.format("Unknown loopflow approximation level: %s", string));
         }
     }
 }

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/RaoParametersSerializer.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/RaoParametersSerializer.java
@@ -35,7 +35,7 @@ public class RaoParametersSerializer extends StdSerializer<RaoParameters> {
         jsonGenerator.writeNumberField("pst-sensitivity-threshold", parameters.getPstSensitivityThreshold());
         jsonGenerator.writeNumberField("sensitivity-fallback-over-cost", parameters.getFallbackOverCost());
         jsonGenerator.writeBooleanField("rao-with-loop-flow-limitation", parameters.isRaoWithLoopFlowLimitation());
-        jsonGenerator.writeBooleanField("loop-flow-approximation", parameters.isLoopFlowApproximation());
+        jsonGenerator.writeObjectField("loop-flow-approximation", parameters.getLoopFlowApproximationLevel());
         jsonGenerator.writeNumberField("loop-flow-constraint-adjustment-coefficient", parameters.getLoopFlowConstraintAdjustmentCoefficient());
         jsonGenerator.writeNumberField("loop-flow-violation-cost", parameters.getLoopFlowViolationCost());
         jsonGenerator.writeFieldName("loop-flow-countries");

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/RaoParametersTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/RaoParametersTest.java
@@ -112,6 +112,35 @@ public class RaoParametersTest {
         assertEquals(0.005, parameters.getPtdfSumLowerBound(), 1e-6);
     }
 
+    @Test
+    public void checkLoopFlowConfig() {
+        MapModuleConfig moduleConfig = platformCfg.createModuleConfig("rao-parameters");
+        moduleConfig.setStringProperty("loop-flow-approximation", "UPDATE_PTDF_WITH_TOPO");
+        moduleConfig.setStringProperty("loop-flow-constraint-adjustment-coefficient", Objects.toString(5.0));
+        moduleConfig.setStringProperty("loop-flow-violation-cost", Objects.toString(20.6));
+
+        RaoParameters parameters = new RaoParameters();
+        RaoParameters.load(parameters, platformCfg);
+
+        assertEquals(RaoParameters.LoopFlowApproximationLevel.UPDATE_PTDF_WITH_TOPO, parameters.getLoopFlowApproximationLevel());
+        assertEquals(5, parameters.getLoopFlowConstraintAdjustmentCoefficient(), 1e-6);
+        assertEquals(20.6, parameters.getLoopFlowViolationCost(), 1e-6);
+    }
+
+    @Test
+    public void testUpdatePtdfWithTopo() {
+        assertFalse(RaoParameters.LoopFlowApproximationLevel.FIXED_PTDF.shouldUpdatePtdfWithTopologicalChange());
+        assertTrue(RaoParameters.LoopFlowApproximationLevel.UPDATE_PTDF_WITH_TOPO.shouldUpdatePtdfWithTopologicalChange());
+        assertTrue(RaoParameters.LoopFlowApproximationLevel.UPDATE_PTDF_WITH_TOPO_AND_PST.shouldUpdatePtdfWithTopologicalChange());
+    }
+
+    @Test
+    public void testUpdatePtdfWithPst() {
+        assertFalse(RaoParameters.LoopFlowApproximationLevel.FIXED_PTDF.shouldUpdatePtdfWithPstChange());
+        assertFalse(RaoParameters.LoopFlowApproximationLevel.UPDATE_PTDF_WITH_TOPO.shouldUpdatePtdfWithPstChange());
+        assertTrue(RaoParameters.LoopFlowApproximationLevel.UPDATE_PTDF_WITH_TOPO_AND_PST.shouldUpdatePtdfWithPstChange());
+    }
+
     private static class DummyExtension extends AbstractExtension<RaoParameters> {
 
         @Override

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoParametersTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoParametersTest.java
@@ -6,6 +6,7 @@
  */
 package com.farao_community.farao.rao_api.json;
 
+import com.farao_community.farao.commons.FaraoException;
 import com.farao_community.farao.rao_api.RaoParameters;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -53,7 +54,7 @@ public class JsonRaoParametersTest extends AbstractConverterTest {
         parameters.setPstSensitivityThreshold(0.2);
         parameters.setFallbackOverCost(10);
         parameters.setRaoWithLoopFlowLimitation(true);
-        parameters.setLoopFlowApproximation(false);
+        parameters.setLoopFlowApproximationLevel(RaoParameters.LoopFlowApproximationLevel.UPDATE_PTDF_WITH_TOPO_AND_PST);
         parameters.setLoopFlowConstraintAdjustmentCoefficient(0.5);
         List<String> countries = new ArrayList<>();
         countries.add("BE");
@@ -91,6 +92,11 @@ public class JsonRaoParametersTest extends AbstractConverterTest {
             // should throw
             assertTrue(e.getMessage().contains("Unexpected field"));
         }
+    }
+
+    @Test(expected = FaraoException.class)
+    public void loopFlowApproximationLevelError() {
+        JsonRaoParameters.read(getClass().getResourceAsStream("/RaoParametersWithLoopFlowError.json"));
     }
 
     static class DummyExtension extends AbstractExtension<RaoParameters> {

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters.json
@@ -6,7 +6,7 @@
   "pst-sensitivity-threshold" : 0.0,
   "sensitivity-fallback-over-cost" : 0.0,
   "rao-with-loop-flow-limitation" : false,
-  "loop-flow-approximation" : true,
+  "loop-flow-approximation" : "FIXED_PTDF",
   "loop-flow-constraint-adjustment-coefficient" : 0.0,
   "loop-flow-violation-cost" : 0.0,
   "loop-flow-countries" : [ ],

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersSet.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersSet.json
@@ -6,7 +6,7 @@
   "pst-sensitivity-threshold" : 0.2,
   "sensitivity-fallback-over-cost" : 10.0,
   "rao-with-loop-flow-limitation" : true,
-  "loop-flow-approximation" : false,
+  "loop-flow-approximation" : "UPDATE_PTDF_WITH_TOPO_AND_PST",
   "loop-flow-constraint-adjustment-coefficient" : 0.5,
   "loop-flow-violation-cost" : 0.0,
   "loop-flow-countries" : [ "BE", "FR" ],

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersWithExtension.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersWithExtension.json
@@ -6,7 +6,7 @@
   "pst-sensitivity-threshold" : 0.0,
   "sensitivity-fallback-over-cost" : 0.0,
   "rao-with-loop-flow-limitation" : false,
-  "loop-flow-approximation" : true,
+  "loop-flow-approximation" : "FIXED_PTDF",
   "loop-flow-constraint-adjustment-coefficient" : 0.0,
   "loop-flow-violation-cost" : 0.0,
   "loop-flow-countries" : [ ],

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersWithFallback.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersWithFallback.json
@@ -6,7 +6,7 @@
   "pst-sensitivity-threshold" : 0.0,
   "sensitivity-fallback-over-cost" : 0.0,
   "rao-with-loop-flow-limitation" : false,
-  "loop-flow-approximation" : true,
+  "loop-flow-approximation" : "FIXED_PTDF",
   "loop-flow-constraint-adjustment-coefficient" : 0.0,
   "loop-flow-violation-cost" : 0.0,
   "loop-flow-countries" : [ ],

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersWithLoopFlowError.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersWithLoopFlowError.json
@@ -1,0 +1,18 @@
+{
+  "version" : "1.0",
+  "objective-function" : "MAX_MIN_MARGIN_IN_MEGAWATT",
+  "max-number-of-iterations" : 10,
+  "pst-penalty-cost" : 0.01,
+  "pst-sensitivity-threshold" : 0.0,
+  "sensitivity-fallback-over-cost" : 0.0,
+  "rao-with-loop-flow-limitation" : false,
+  "loop-flow-approximation" : "FIXED_PTDF_WRONG",
+  "loop-flow-constraint-adjustment-coefficient" : 0.0,
+  "loop-flow-violation-cost" : 0.0,
+  "loop-flow-countries" : [ ],
+  "mnec-acceptable-margin-diminution" : 50.0,
+  "mnec-violation-cost" : 10.0,
+  "mnec-constraint-adjustment-coefficient" : 0.0,
+  "negative-margin-objective-coefficient" : 1000.0,
+  "ptdf-sum-lower-bound" : 0.01
+}

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracResultManager.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracResultManager.java
@@ -165,9 +165,9 @@ public class CracResultManager {
     }
 
     public void copyCommercialFlowsBetweenVariants(String originVariant, String destinationVariant) {
-        raoData.getLoopflowCnecs().forEach(cnec -> {
-            cnec.getExtension(CnecResultExtension.class).getVariant(destinationVariant)
-                    .setCommercialFlowInMW(cnec.getExtension(CnecResultExtension.class).getVariant(originVariant).getCommercialFlowInMW());
-        });
+        raoData.getLoopflowCnecs().forEach(cnec ->
+                cnec.getExtension(CnecResultExtension.class).getVariant(destinationVariant)
+                        .setCommercialFlowInMW(cnec.getExtension(CnecResultExtension.class).getVariant(originVariant).getCommercialFlowInMW())
+        );
     }
 }

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracResultManager.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracResultManager.java
@@ -132,7 +132,6 @@ public class CracResultManager {
                 double initialLoopFlow = Math.abs(loopFlowResult.getLoopFlow(cnec));
 
                 cnecLoopFlowExtension.setLoopFlowConstraintInMW(Math.max(initialLoopFlow, loopFlowThreshold - cnec.getFrm()));
-                cnecLoopFlowExtension.setLoopflowShift(loopFlowResult.getCommercialFlow(cnec));
             }
         });
     }
@@ -143,6 +142,7 @@ public class CracResultManager {
             if (!Objects.isNull(cnec.getExtension(CnecLoopFlowExtension.class))) {
                 cnecResult.setLoopflowInMW(loopFlowResult.getLoopFlow(cnec));
                 cnecResult.setLoopflowThresholdInMW(cnec.getExtension(CnecLoopFlowExtension.class).getLoopFlowConstraintInMW());
+                cnecResult.setCommercialFlowInMW(loopFlowResult.getCommercialFlow(cnec));
             }
         });
     }
@@ -151,7 +151,7 @@ public class CracResultManager {
         raoData.getLoopflowCnecs().forEach(cnec -> {
             CnecResult cnecResult = cnec.getExtension(CnecResultExtension.class).getVariant(raoData.getWorkingVariantId());
             if (!Objects.isNull(cnec.getExtension(CnecLoopFlowExtension.class))) {
-                double loopFLow = raoData.getSystematicSensitivityResult().getReferenceFlow(cnec) - cnec.getExtension(CnecLoopFlowExtension.class).getLoopflowShift();
+                double loopFLow = raoData.getSystematicSensitivityResult().getReferenceFlow(cnec) - cnecResult.getCommercialFlowInMW();
                 cnecResult.setLoopflowInMW(loopFLow);
                 cnecResult.setLoopflowThresholdInMW(cnec.getExtension(CnecLoopFlowExtension.class).getLoopFlowConstraintInMW());
             }
@@ -162,5 +162,12 @@ public class CracResultManager {
         ptdfSums.entrySet().forEach(entry ->
                 entry.getKey().getExtension(CnecResultExtension.class).getVariant(raoData.getInitialVariantId()).setAbsolutePtdfSum(entry.getValue())
         );
+    }
+
+    public void copyCommercialFlowsBetweenVariants(String originVariant, String destinationVariant) {
+        raoData.getLoopflowCnecs().forEach(cnec -> {
+            cnec.getExtension(CnecResultExtension.class).getVariant(destinationVariant)
+                    .setCommercialFlowInMW(cnec.getExtension(CnecResultExtension.class).getVariant(originVariant).getCommercialFlowInMW());
+        });
     }
 }

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/InitialSensitivityAnalysis.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/InitialSensitivityAnalysis.java
@@ -85,7 +85,7 @@ public class InitialSensitivityAnalysis {
             .withRangeActionSensitivities(raoData.getAvailableRangeActions(), raoData.getCnecs());
 
         if (raoParameters.getObjectiveFunction().doesRequirePtdf()) {
-            builder.withPtdfSensitivities(raoData.getGlskProvider(), raoData.getCrac().getCnecs());
+            builder.withPtdfSensitivities(raoData.getGlskProvider(), raoData.getCnecs());
         } else if (raoParameters.isRaoWithLoopFlowLimitation()) {
             builder.withPtdfSensitivities(raoData.getGlskProvider(), raoData.getLoopflowCnecs());
         }

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/LoopFlowUtil.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/LoopFlowUtil.java
@@ -15,7 +15,8 @@ import com.farao_community.farao.loopflow_computation.LoopFlowResult;
  */
 public final class LoopFlowUtil {
 
-    private LoopFlowUtil() { }
+    private LoopFlowUtil() {
+    }
 
     public static void buildLoopFlowsWithLatestSensi(RaoData raoData, boolean isLoopFlowApproximation) {
         if (isLoopFlowApproximation) {

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoUtil.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoUtil.java
@@ -87,7 +87,7 @@ public final class RaoUtil {
         }
     }
 
-    public static SystematicSensitivityInterface createSystematicSensitivityInterface(RaoParameters raoParameters, RaoData raoData, Boolean withPtdfSensitivities) {
+    public static SystematicSensitivityInterface createSystematicSensitivityInterface(RaoParameters raoParameters, RaoData raoData, boolean withPtdfSensitivities) {
 
         SystematicSensitivityInterface.SystematicSensitivityInterfaceBuilder builder = SystematicSensitivityInterface
             .builder()
@@ -96,11 +96,7 @@ public final class RaoUtil {
             .withRangeActionSensitivities(raoData.getAvailableRangeActions(), raoData.getCnecs());
 
         if (raoParameters.isRaoWithLoopFlowLimitation() && withPtdfSensitivities) {
-
             builder.withPtdfSensitivities(raoData.getGlskProvider(), raoData.getLoopflowCnecs());
-
-            // We may want to have a different interface for the first run and the successive runs if we do not wish to
-            // compute the PTDFs at every iteration.
         }
 
         return builder.build();

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoUtil.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoUtil.java
@@ -87,7 +87,7 @@ public final class RaoUtil {
         }
     }
 
-    public static SystematicSensitivityInterface createSystematicSensitivityInterface(RaoParameters raoParameters, RaoData raoData, boolean withPtdfSensitivities) {
+    public static SystematicSensitivityInterface createSystematicSensitivityInterface(RaoParameters raoParameters, RaoData raoData, boolean withPtdfSensitivitiesForLoopFlows) {
 
         SystematicSensitivityInterface.SystematicSensitivityInterfaceBuilder builder = SystematicSensitivityInterface
             .builder()
@@ -95,7 +95,7 @@ public final class RaoUtil {
             .withFallbackParameters(raoParameters.getFallbackSensitivityAnalysisParameters())
             .withRangeActionSensitivities(raoData.getAvailableRangeActions(), raoData.getCnecs());
 
-        if (raoParameters.isRaoWithLoopFlowLimitation() && withPtdfSensitivities) {
+        if (raoParameters.isRaoWithLoopFlowLimitation() && withPtdfSensitivitiesForLoopFlows) {
             builder.withPtdfSensitivities(raoData.getGlskProvider(), raoData.getLoopflowCnecs());
         }
 
@@ -126,7 +126,7 @@ public final class RaoUtil {
     }
 
     private static MaxLoopFlowFiller createMaxLoopFlowFiller(RaoParameters raoParameters) {
-        return new MaxLoopFlowFiller(raoParameters.getLoopFlowConstraintAdjustmentCoefficient(), raoParameters.getLoopFlowViolationCost());
+        return new MaxLoopFlowFiller(raoParameters.getLoopFlowConstraintAdjustmentCoefficient(), raoParameters.getLoopFlowViolationCost(), raoParameters.getLoopFlowApproximationLevel());
     }
 
     private static IteratingLinearOptimizerParameters createIteratingParameters(RaoParameters raoParameters) {

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoUtil.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoUtil.java
@@ -87,7 +87,7 @@ public final class RaoUtil {
         }
     }
 
-    public static SystematicSensitivityInterface createSystematicSensitivityInterface(RaoParameters raoParameters, RaoData raoData) {
+    public static SystematicSensitivityInterface createSystematicSensitivityInterface(RaoParameters raoParameters, RaoData raoData, Boolean withPtdfSensitivities) {
 
         SystematicSensitivityInterface.SystematicSensitivityInterfaceBuilder builder = SystematicSensitivityInterface
             .builder()
@@ -95,7 +95,7 @@ public final class RaoUtil {
             .withFallbackParameters(raoParameters.getFallbackSensitivityAnalysisParameters())
             .withRangeActionSensitivities(raoData.getAvailableRangeActions(), raoData.getCnecs());
 
-        if (raoParameters.isRaoWithLoopFlowLimitation() && !raoParameters.isLoopFlowApproximation()) {
+        if (raoParameters.isRaoWithLoopFlowLimitation() && withPtdfSensitivities) {
 
             builder.withPtdfSensitivities(raoData.getGlskProvider(), raoData.getLoopflowCnecs());
 
@@ -130,8 +130,7 @@ public final class RaoUtil {
     }
 
     private static MaxLoopFlowFiller createMaxLoopFlowFiller(RaoParameters raoParameters) {
-        return new MaxLoopFlowFiller(raoParameters.isLoopFlowApproximation(),
-            raoParameters.getLoopFlowConstraintAdjustmentCoefficient(), raoParameters.getLoopFlowViolationCost(), raoParameters.getDefaultSensitivityAnalysisParameters());
+        return new MaxLoopFlowFiller(raoParameters.getLoopFlowConstraintAdjustmentCoefficient(), raoParameters.getLoopFlowViolationCost());
     }
 
     private static IteratingLinearOptimizerParameters createIteratingParameters(RaoParameters raoParameters) {
@@ -140,7 +139,7 @@ public final class RaoUtil {
 
     private static IteratingLinearOptimizerWithLoopFLowsParameters createIteratingLoopFlowsParameters(RaoParameters raoParameters) {
         return new IteratingLinearOptimizerWithLoopFLowsParameters(raoParameters.getMaxIterations(),
-                raoParameters.getFallbackOverCost(), raoParameters.isLoopFlowApproximation(), raoParameters.getLoopFlowViolationCost());
+                raoParameters.getFallbackOverCost(), raoParameters.getLoopFlowApproximationLevel(), raoParameters.getLoopFlowViolationCost());
     }
 
     public static ObjectiveFunctionEvaluator createObjectiveFunction(RaoParameters raoParameters) {

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxLoopFlowFiller.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxLoopFlowFiller.java
@@ -9,13 +9,11 @@ package com.farao_community.farao.rao_commons.linear_optimisation.fillers;
 import com.farao_community.farao.commons.FaraoException;
 import com.farao_community.farao.data.crac_api.Cnec;
 import com.farao_community.farao.data.crac_loopflow_extension.CnecLoopFlowExtension;
-import com.farao_community.farao.loopflow_computation.LoopFlowComputation;
-import com.farao_community.farao.loopflow_computation.LoopFlowResult;
+import com.farao_community.farao.data.crac_result_extensions.CnecResultExtension;
 import com.farao_community.farao.rao_commons.RaoData;
 import com.farao_community.farao.rao_commons.linear_optimisation.LinearProblem;
 import com.google.ortools.linearsolver.MPConstraint;
 import com.google.ortools.linearsolver.MPVariable;
-import com.powsybl.sensitivity.SensitivityAnalysisParameters;
 
 import java.util.Objects;
 
@@ -33,16 +31,12 @@ import java.util.Objects;
  */
 public class MaxLoopFlowFiller implements ProblemFiller {
 
-    private boolean isLoopFlowApproximation;
     private double loopFlowConstraintAdjustmentCoefficient;
     private double loopFlowViolationCost;
-    private SensitivityAnalysisParameters sensitivityAnalysisParameters;
 
-    public MaxLoopFlowFiller(boolean isLoopFlowApproximation, double loopFlowConstraintAdjustmentCoefficient, double loopFlowViolationCost, SensitivityAnalysisParameters sensitivityAnalysisParameters) {
-        this.isLoopFlowApproximation = isLoopFlowApproximation;
+    public MaxLoopFlowFiller(double loopFlowConstraintAdjustmentCoefficient, double loopFlowViolationCost) {
         this.loopFlowConstraintAdjustmentCoefficient = loopFlowConstraintAdjustmentCoefficient;
         this.loopFlowViolationCost = loopFlowViolationCost;
-        this.sensitivityAnalysisParameters = sensitivityAnalysisParameters;
     }
 
     @Override
@@ -59,35 +53,26 @@ public class MaxLoopFlowFiller implements ProblemFiller {
      * currentLoopflow = flowVariable - PTDF * NetPosition, where flowVariable a MPVariable
      * Constraint for loopflow in optimization is: - MaxLoopFlow <= currentLoopFlow <= MaxLoopFlow,
      * where MaxLoopFlow is calculated as
-     *     max(Input TSO loopflow limit, Loopflow value computed from initial network)
-     *
-     * let LoopFlowShift = PTDF * NetPosition, then
-     *     - MaxLoopFlow + LoopFlowShift <= flowVariable <= MaxLoopFlow + LoopFlowShift
-     *
+     * max(Input TSO loopflow limit, Loopflow value computed from initial network)
+     * <p>
+     * let CommercialFlow = PTDF * NetPosition, then
+     * - MaxLoopFlow + CommercialFlow <= flowVariable <= MaxLoopFlow + CommercialFlow
+     * <p>
      * Loopflow limit may be tuned by a "Loopflow adjustment coefficient":
-     *     MaxLoopFlow = Loopflow constraint - Loopflow adjustment coefficient
-     *
+     * MaxLoopFlow = Loopflow constraint - Loopflow adjustment coefficient
+     * <p>
      * An additional MPVariable "loopflowViolationVariable" may be added when "Loopflow violation cost" is not zero:
-     *     - (MaxLoopFlow + loopflowViolationVariable) <= currentLoopFlow <= MaxLoopFlow + loopflowViolationVariable
+     * - (MaxLoopFlow + loopflowViolationVariable) <= currentLoopFlow <= MaxLoopFlow + loopflowViolationVariable
      * equivalent to 2 constraints:
-     *     - MaxLoopFlow <= currentLoopFlow + loopflowViolationVariable
-     *     currentLoopFlow - loopflowViolationVariable <= MaxLoopFlow
+     * - MaxLoopFlow <= currentLoopFlow + loopflowViolationVariable
+     * currentLoopFlow - loopflowViolationVariable <= MaxLoopFlow
      * or:
-     *     - MaxLoopFlow + LoopFlowShift <= flowVariable + loopflowViolationVariable <= POSITIVE_INF
-     *     NEGATIVE_INF <= flowVariable - loopflowViolationVariable <= MaxLoopFlow + LoopFlowShift
+     * - MaxLoopFlow + CommercialFlow <= flowVariable + loopflowViolationVariable <= POSITIVE_INF
+     * NEGATIVE_INF <= flowVariable - loopflowViolationVariable <= MaxLoopFlow + CommercialFlow
      * and a "virtual cost" is added to objective function as "loopflowViolationVariable * Loopflow violation cost"
      */
     private void buildLoopFlowConstraintsAndUpdateObjectiveFunction(RaoData raoData, LinearProblem linearProblem) {
-
-        LoopFlowResult loopFlowResult = null;
-        //todo : do not compute loopFlow from scratch here : not necessary
-        if (!isLoopFlowApproximation) {
-            loopFlowResult = new LoopFlowComputation(raoData.getGlskProvider(), raoData.getReferenceProgram())
-                .calculateLoopFlows(raoData.getNetwork(), sensitivityAnalysisParameters, raoData.getLoopflowCnecs());
-        }
-
         for (Cnec cnec : raoData.getLoopflowCnecs()) {
-
             //get and update MapLoopFlowLimit with loopflowConstraintAdjustmentCoefficient
             double maxLoopFlowLimit = cnec.getExtension(CnecLoopFlowExtension.class).getLoopFlowConstraintInMW();
             if (maxLoopFlowLimit == Double.POSITIVE_INFINITY) {
@@ -96,14 +81,6 @@ public class MaxLoopFlowFiller implements ProblemFiller {
 
             maxLoopFlowLimit = Math.max(0.0, maxLoopFlowLimit - loopFlowConstraintAdjustmentCoefficient);
 
-            double commercialFlow;
-            //get commercial flow
-            if (!isLoopFlowApproximation) {
-                commercialFlow = loopFlowResult.getCommercialFlow(cnec);
-            } else {
-                commercialFlow = cnec.getExtension(CnecLoopFlowExtension.class).getLoopflowShift();
-            }
-
             //get MPVariable: flowVariable
             MPVariable flowVariable = linearProblem.getFlowVariable(cnec);
             if (Objects.isNull(flowVariable)) {
@@ -111,27 +88,28 @@ public class MaxLoopFlowFiller implements ProblemFiller {
             }
 
             MPVariable loopflowViolationVariable = linearProblem.addLoopflowViolationVariable(
-                0,
-                linearProblem.infinity(),
-                cnec
+                    0,
+                    linearProblem.infinity(),
+                    cnec
             );
 
-            // - MaxLoopFlow + LoopFlowShift <= flowVariable + loopflowViolationVariable <= POSITIVE_INF
+            double commercialFlow = cnec.getExtension(CnecResultExtension.class).getVariant(raoData.getWorkingVariantId()).getCommercialFlowInMW();
+            // - MaxLoopFlow + commercialFlow <= flowVariable + loopflowViolationVariable <= POSITIVE_INF
             MPConstraint positiveLoopflowViolationConstraint = linearProblem.addMaxLoopFlowConstraint(
-                -maxLoopFlowLimit + commercialFlow,
-                linearProblem.infinity(),
-                cnec,
-                LinearProblem.BoundExtension.LOWER_BOUND
+                    -maxLoopFlowLimit + commercialFlow,
+                    linearProblem.infinity(),
+                    cnec,
+                    LinearProblem.BoundExtension.LOWER_BOUND
             );
             positiveLoopflowViolationConstraint.setCoefficient(flowVariable, 1);
             positiveLoopflowViolationConstraint.setCoefficient(loopflowViolationVariable, 1);
 
-            // NEGATIVE_INF <= flowVariable - loopflowViolationVariable <= MaxLoopFlow + LoopFlowShift
+            // NEGATIVE_INF <= flowVariable - loopflowViolationVariable <= MaxLoopFlow + commercialFlow
             MPConstraint negativeLoopflowViolationConstraint = linearProblem.addMaxLoopFlowConstraint(
-                -linearProblem.infinity(),
-                maxLoopFlowLimit + commercialFlow,
-                cnec,
-                LinearProblem.BoundExtension.UPPER_BOUND
+                    -linearProblem.infinity(),
+                    maxLoopFlowLimit + commercialFlow,
+                    cnec,
+                    LinearProblem.BoundExtension.UPPER_BOUND
             );
             negativeLoopflowViolationConstraint.setCoefficient(flowVariable, 1);
             negativeLoopflowViolationConstraint.setCoefficient(loopflowViolationVariable, -1);

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizer.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizer.java
@@ -83,6 +83,8 @@ public class IteratingLinearOptimizer {
         String optimizedVariantId;
         for (int iteration = 1; iteration <= parameters.getMaxIterations(); iteration++) {
             optimizedVariantId = cracVariantManager.cloneWorkingVariant();
+            raoData.getCracResultManager().copyCommercialFlowsBetweenVariants(cracVariantManager.getWorkingVariantId(), optimizedVariantId);
+            //TODO : copy crac results from one variant to the next in CracVariantManager.cloneWorkingVariant() ?
             cracVariantManager.setWorkingVariant(optimizedVariantId);
             if (!optimize(iteration)
                     || !hasRemedialActionsChanged(optimizedVariantId, iteration)

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizerWithLoopFLowsParameters.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizerWithLoopFLowsParameters.java
@@ -7,6 +7,8 @@
 
 package com.farao_community.farao.rao_commons.linear_optimisation.iterating_linear_optimizer;
 
+import com.farao_community.farao.rao_api.RaoParameters;
+
 /**
  * @author Joris Mancini {@literal <joris.mancini at rte-france.com>}
  */
@@ -19,22 +21,22 @@ public class IteratingLinearOptimizerWithLoopFLowsParameters extends IteratingLi
      *  if "loopflowApproximation" is set to "true", loopflow computation tries to use previous saved ptdf and netposition.
      *  note: Loopflow = reference flow - ptdf * net position
      */
-    private boolean loopFlowApproximation;
+    private RaoParameters.LoopFlowApproximationLevel loopFlowApproximationLevel;
 
     private double loopFlowViolationCost;
 
-    public IteratingLinearOptimizerWithLoopFLowsParameters(int maxIterations, double fallbackOverCost, boolean loopFlowApproximation, double loopFlowViolationCost) {
+    public IteratingLinearOptimizerWithLoopFLowsParameters(int maxIterations, double fallbackOverCost, RaoParameters.LoopFlowApproximationLevel loopFlowApproximationLevel, double loopFlowViolationCost) {
         super(maxIterations, fallbackOverCost);
-        this.loopFlowApproximation = loopFlowApproximation;
+        this.loopFlowApproximationLevel = loopFlowApproximationLevel;
         this.loopFlowViolationCost = loopFlowViolationCost;
     }
 
-    public boolean isLoopflowApproximation() {
-        return loopFlowApproximation;
+    public RaoParameters.LoopFlowApproximationLevel getLoopflowApproximationLevel() {
+        return loopFlowApproximationLevel;
     }
 
-    public void setLoopFlowApproximation(boolean loopFlowApproximation) {
-        this.loopFlowApproximation = loopFlowApproximation;
+    public void setLoopFlowApproximationLevel(RaoParameters.LoopFlowApproximationLevel loopFlowApproximation) {
+        this.loopFlowApproximationLevel = loopFlowApproximation;
     }
 
     public double getLoopFlowViolationCost() {

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizerWithLoopFlows.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizerWithLoopFlows.java
@@ -7,10 +7,11 @@
 
 package com.farao_community.farao.rao_commons.linear_optimisation.iterating_linear_optimizer;
 
+import com.farao_community.farao.rao_api.RaoParameters;
 import com.farao_community.farao.rao_commons.LoopFlowUtil;
-import com.farao_community.farao.rao_commons.objective_function_evaluator.ObjectiveFunctionEvaluator;
 import com.farao_community.farao.rao_commons.linear_optimisation.LinearOptimizer;
 import com.farao_community.farao.rao_commons.linear_optimisation.fillers.ProblemFiller;
+import com.farao_community.farao.rao_commons.objective_function_evaluator.ObjectiveFunctionEvaluator;
 import com.farao_community.farao.sensitivity_analysis.SystematicSensitivityInterface;
 
 import java.util.List;
@@ -20,24 +21,21 @@ import java.util.List;
  */
 public class IteratingLinearOptimizerWithLoopFlows extends IteratingLinearOptimizer {
 
-    private boolean loopFlowApproximation;
+    private RaoParameters.LoopFlowApproximationLevel loopFlowApproximationLevel;
 
     public IteratingLinearOptimizerWithLoopFlows(List<ProblemFiller> fillers,
                                                  SystematicSensitivityInterface systematicSensitivityInterface,
                                                  ObjectiveFunctionEvaluator objectiveFunctionEvaluator,
                                                  IteratingLinearOptimizerWithLoopFLowsParameters parameters) {
         super(fillers, systematicSensitivityInterface, objectiveFunctionEvaluator, parameters);
-        loopFlowApproximation = parameters.isLoopflowApproximation();
+        loopFlowApproximationLevel = parameters.getLoopflowApproximationLevel();
         linearOptimizer = new LinearOptimizer(fillers);
     }
 
     @Override
     void runSensitivityAndUpdateResults() {
-
-        raoData.setSystematicSensitivityResult(
-            systematicSensitivityInterface.run(raoData.getNetwork(), objectiveFunctionEvaluator.getUnit()));
-
-        LoopFlowUtil.buildLoopFlowsWithLatestSensi(raoData, loopFlowApproximation);
+        raoData.setSystematicSensitivityResult(systematicSensitivityInterface.run(raoData.getNetwork(), objectiveFunctionEvaluator.getUnit()));
+        LoopFlowUtil.buildLoopFlowsWithLatestSensi(raoData, !loopFlowApproximationLevel.shouldUpdatePtdfWithPstChange());
 
         raoData.getCracResultManager().fillCnecResultWithFlows();
         raoData.getCracResultManager().fillCracResultWithCosts(objectiveFunctionEvaluator.getFunctionalCost(raoData), objectiveFunctionEvaluator.getVirtualCost(raoData));

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/CracResultManagerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/CracResultManagerTest.java
@@ -8,6 +8,7 @@
 package com.farao_community.farao.rao_commons;
 
 import com.farao_community.farao.commons.Unit;
+import com.farao_community.farao.data.crac_api.Cnec;
 import com.farao_community.farao.data.crac_api.Crac;
 import com.farao_community.farao.data.crac_impl.utils.CommonCracCreation;
 import com.farao_community.farao.data.crac_impl.utils.NetworkImportsUtil;
@@ -19,6 +20,8 @@ import com.powsybl.iidm.network.Network;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -89,5 +92,23 @@ public class CracResultManagerTest {
         assertEquals(47. - 45., raoData.getCrac().getCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(var).getLoopflowInMW(), DOUBLE_TOLERANCE);
         assertEquals(252., raoData.getCrac().getCnec("cnec1basecase").getExtension(CnecResultExtension.class).getVariant(var).getLoopflowThresholdInMW(), DOUBLE_TOLERANCE);
         assertEquals(100., raoData.getCrac().getCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(var).getLoopflowThresholdInMW(), DOUBLE_TOLERANCE);
+    }
+
+    @Test
+    public void testFillCnecResultsWithAbsolutePtdfSums() {
+        Map<Cnec, Double> ptdfSums = Map.of(raoData.getCrac().getCnec("cnec1basecase"), 0.5, raoData.getCrac().getCnec("cnec2basecase"), 1.3);
+        raoData.getCracResultManager().fillCnecResultsWithAbsolutePtdfSums(ptdfSums);
+        assertEquals(0.5, raoData.getCrac().getCnec("cnec1basecase").getExtension(CnecResultExtension.class).getVariant(raoData.getInitialVariantId()).getAbsolutePtdfSum(), DOUBLE_TOLERANCE);
+        assertEquals(1.3, raoData.getCrac().getCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(raoData.getInitialVariantId()).getAbsolutePtdfSum(), DOUBLE_TOLERANCE);
+    }
+
+    @Test
+    public void testCopyCommercialFlowsBetweenVariants() {
+        raoData.getCrac().getCnec("cnec1basecase").getExtension(CnecResultExtension.class).getVariant(raoData.getInitialVariantId()).setCommercialFlowInMW(150.6);
+        raoData.getCrac().getCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(raoData.getInitialVariantId()).setCommercialFlowInMW(653.7);
+        String var = raoData.getCracVariantManager().cloneWorkingVariant();
+        raoData.getCracResultManager().copyCommercialFlowsBetweenVariants(raoData.getInitialVariantId(), var);
+        assertEquals(150.6, raoData.getCrac().getCnec("cnec1basecase").getExtension(CnecResultExtension.class).getVariant(var).getCommercialFlowInMW(), DOUBLE_TOLERANCE);
+        assertEquals(653.7, raoData.getCrac().getCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(var).getCommercialFlowInMW(), DOUBLE_TOLERANCE);
     }
 }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/CracResultManagerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/CracResultManagerTest.java
@@ -56,8 +56,6 @@ public class CracResultManagerTest {
         raoData.getCracResultManager().fillCnecLoopFlowExtensionsWithInitialResults(loopFlowResult, raoData.getNetwork());
         assertEquals(252., raoData.getCrac().getCnec("cnec1basecase").getExtension(CnecLoopFlowExtension.class).getLoopFlowConstraintInMW(), DOUBLE_TOLERANCE);
         assertEquals(100., raoData.getCrac().getCnec("cnec2basecase").getExtension(CnecLoopFlowExtension.class).getLoopFlowConstraintInMW(), DOUBLE_TOLERANCE);
-        assertEquals(128., raoData.getCrac().getCnec("cnec1basecase").getExtension(CnecLoopFlowExtension.class).getLoopflowShift(), DOUBLE_TOLERANCE);
-        assertEquals(45., raoData.getCrac().getCnec("cnec2basecase").getExtension(CnecLoopFlowExtension.class).getLoopflowShift(), DOUBLE_TOLERANCE);
     }
 
     @Test
@@ -70,6 +68,8 @@ public class CracResultManagerTest {
         assertEquals(24, raoData.getCrac().getCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(var).getLoopflowInMW(), DOUBLE_TOLERANCE);
         assertEquals(252., raoData.getCrac().getCnec("cnec1basecase").getExtension(CnecResultExtension.class).getVariant(var).getLoopflowThresholdInMW(), DOUBLE_TOLERANCE);
         assertEquals(100., raoData.getCrac().getCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(var).getLoopflowThresholdInMW(), DOUBLE_TOLERANCE);
+        assertEquals(128., raoData.getCrac().getCnec("cnec1basecase").getExtension(CnecResultExtension.class).getVariant(var).getCommercialFlowInMW(), DOUBLE_TOLERANCE);
+        assertEquals(45., raoData.getCrac().getCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(var).getCommercialFlowInMW(), DOUBLE_TOLERANCE);
     }
 
     @Test
@@ -80,6 +80,7 @@ public class CracResultManagerTest {
         Mockito.when(sensiResults.getReferenceFlow(raoData.getCrac().getCnec("cnec2basecase"))).thenReturn(47.);
 
         raoData.getCracResultManager().fillCnecLoopFlowExtensionsWithInitialResults(loopFlowResult, raoData.getNetwork());
+        raoData.getCracResultManager().fillCnecResultsWithLoopFlows(loopFlowResult);
         raoData.setSystematicSensitivityResult(sensiResults);
         raoData.getCracResultManager().fillCnecResultsWithApproximatedLoopFlows();
         String var = raoData.getWorkingVariantId();

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoUtilTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoUtilTest.java
@@ -171,7 +171,7 @@ public class RaoUtilTest {
                 raoInput.getGlskProvider(),
                 raoInput.getBaseCracVariantId(),
                 raoParameters.getLoopflowCountries());
-        SystematicSensitivityInterface systematicSensitivityInterface = RaoUtil.createSystematicSensitivityInterface(raoParameters, raoData);
+        SystematicSensitivityInterface systematicSensitivityInterface = RaoUtil.createSystematicSensitivityInterface(raoParameters, raoData, false);
         assertNotNull(systematicSensitivityInterface);
     }
 
@@ -219,7 +219,7 @@ public class RaoUtilTest {
                 raoInput.getGlskProvider(),
                 raoInput.getBaseCracVariantId(),
                 raoParameters.getLoopflowCountries());
-        SystematicSensitivityInterface systematicSensitivityInterface = RaoUtil.createSystematicSensitivityInterface(raoParameters, raoData);
+        SystematicSensitivityInterface systematicSensitivityInterface = RaoUtil.createSystematicSensitivityInterface(raoParameters, raoData, true);
         assertNotNull(systematicSensitivityInterface);
     }
 }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxLoopFlowFillerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxLoopFlowFillerTest.java
@@ -8,6 +8,7 @@ package com.farao_community.farao.rao_commons.linear_optimisation.fillers;
 
 import com.farao_community.farao.commons.Unit;
 import com.farao_community.farao.data.crac_loopflow_extension.CnecLoopFlowExtension;
+import com.farao_community.farao.data.crac_result_extensions.CnecResultExtension;
 import com.farao_community.farao.rao_commons.linear_optimisation.LinearProblem;
 import com.google.ortools.linearsolver.MPConstraint;
 import com.google.ortools.linearsolver.MPVariable;
@@ -35,19 +36,16 @@ public class MaxLoopFlowFillerTest extends AbstractFillerTest {
 
     @Test
     public void testFill() {
-
         CnecLoopFlowExtension cnecLoopFlowExtension = new CnecLoopFlowExtension(0.0, Unit.PERCENT_IMAX);
         cnecLoopFlowExtension.setLoopFlowConstraintInMW(100.0);
-        cnecLoopFlowExtension.setLoopflowShift(49.0);
         cnec1.addExtension(CnecLoopFlowExtension.class, cnecLoopFlowExtension);
         initRaoData(crac.getPreventiveState());
+        cnec1.getExtension(CnecResultExtension.class).getVariant(raoData.getWorkingVariantId()).setCommercialFlowInMW(49.0);
 
-        boolean isLoopFlowApproximation = true; // currently cannot be tested without the loop-flow approximation, otherwise a sensitivity computation should be made
         double loopFlowConstraintAdjustmentCoefficient = 5.;
         double loopFlowViolationCost = 10.;
-        SensitivityAnalysisParameters sensitivityAnalysisParameters = new SensitivityAnalysisParameters();
 
-        MaxLoopFlowFiller maxLoopFlowFiller = new MaxLoopFlowFiller(isLoopFlowApproximation, loopFlowConstraintAdjustmentCoefficient, loopFlowViolationCost, sensitivityAnalysisParameters);
+        MaxLoopFlowFiller maxLoopFlowFiller = new MaxLoopFlowFiller(loopFlowConstraintAdjustmentCoefficient, loopFlowViolationCost);
 
         // build problem
         coreProblemFiller.fill(raoData, linearProblem);

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxLoopFlowFillerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxLoopFlowFillerTest.java
@@ -9,6 +9,7 @@ package com.farao_community.farao.rao_commons.linear_optimisation.fillers;
 import com.farao_community.farao.commons.Unit;
 import com.farao_community.farao.data.crac_loopflow_extension.CnecLoopFlowExtension;
 import com.farao_community.farao.data.crac_result_extensions.CnecResultExtension;
+import com.farao_community.farao.rao_api.RaoParameters;
 import com.farao_community.farao.rao_commons.linear_optimisation.LinearProblem;
 import com.google.ortools.linearsolver.MPConstraint;
 import com.google.ortools.linearsolver.MPVariable;
@@ -45,7 +46,7 @@ public class MaxLoopFlowFillerTest extends AbstractFillerTest {
         double loopFlowConstraintAdjustmentCoefficient = 5.;
         double loopFlowViolationCost = 10.;
 
-        MaxLoopFlowFiller maxLoopFlowFiller = new MaxLoopFlowFiller(loopFlowConstraintAdjustmentCoefficient, loopFlowViolationCost);
+        MaxLoopFlowFiller maxLoopFlowFiller = new MaxLoopFlowFiller(loopFlowConstraintAdjustmentCoefficient, loopFlowViolationCost, RaoParameters.LoopFlowApproximationLevel.FIXED_PTDF);
 
         // build problem
         coreProblemFiller.fill(raoData, linearProblem);
@@ -64,5 +65,69 @@ public class MaxLoopFlowFillerTest extends AbstractFillerTest {
         MPVariable flowVariable = linearProblem.getFlowVariable(cnec1);
         assertEquals(1, loopFlowConstraintUb.getCoefficient(flowVariable), 0.1);
         assertEquals(1, loopFlowConstraintLb.getCoefficient(flowVariable), 0.1);
+    }
+
+    @Test
+    public void testShouldUpdate() {
+        CnecLoopFlowExtension cnecLoopFlowExtension = new CnecLoopFlowExtension(0.0, Unit.PERCENT_IMAX);
+        cnecLoopFlowExtension.setLoopFlowConstraintInMW(100.0);
+        cnec1.addExtension(CnecLoopFlowExtension.class, cnecLoopFlowExtension);
+        initRaoData(crac.getPreventiveState());
+        cnec1.getExtension(CnecResultExtension.class).getVariant(raoData.getWorkingVariantId()).setCommercialFlowInMW(49.0);
+
+        double loopFlowConstraintAdjustmentCoefficient = 5.;
+        double loopFlowViolationCost = 10.;
+
+        MaxLoopFlowFiller maxLoopFlowFiller = new MaxLoopFlowFiller(loopFlowConstraintAdjustmentCoefficient, loopFlowViolationCost, RaoParameters.LoopFlowApproximationLevel.UPDATE_PTDF_WITH_TOPO_AND_PST);
+
+        // build problem
+        coreProblemFiller.fill(raoData, linearProblem);
+        maxLoopFlowFiller.fill(raoData, linearProblem);
+
+        // update rao data and filler
+        cnecLoopFlowExtension.setLoopFlowConstraintInMW(350.0);
+        cnec1.getExtension(CnecResultExtension.class).getVariant(raoData.getWorkingVariantId()).setCommercialFlowInMW(67.0);
+        maxLoopFlowFiller.update(raoData, linearProblem);
+
+        // check flow constraint for cnec1
+        MPConstraint loopFlowConstraintUb = linearProblem.getMaxLoopFlowConstraint(cnec1, LinearProblem.BoundExtension.UPPER_BOUND);
+        MPConstraint loopFlowConstraintLb = linearProblem.getMaxLoopFlowConstraint(cnec1, LinearProblem.BoundExtension.LOWER_BOUND);
+
+        assertEquals(-(350 - 5.) + 67.0, loopFlowConstraintLb.lb(), DOUBLE_TOLERANCE);
+        assertEquals((350 - 5.) + 67.0, loopFlowConstraintUb.ub(), DOUBLE_TOLERANCE);
+
+        MPVariable flowVariable = linearProblem.getFlowVariable(cnec1);
+        assertEquals(1, loopFlowConstraintUb.getCoefficient(flowVariable), 0.1);
+        assertEquals(1, loopFlowConstraintLb.getCoefficient(flowVariable), 0.1);
+    }
+
+    @Test
+    public void testShouldNotUpdate() {
+        CnecLoopFlowExtension cnecLoopFlowExtension = new CnecLoopFlowExtension(0.0, Unit.PERCENT_IMAX);
+        cnecLoopFlowExtension.setLoopFlowConstraintInMW(100.0);
+        cnec1.addExtension(CnecLoopFlowExtension.class, cnecLoopFlowExtension);
+        initRaoData(crac.getPreventiveState());
+        cnec1.getExtension(CnecResultExtension.class).getVariant(raoData.getWorkingVariantId()).setCommercialFlowInMW(49.0);
+
+        double loopFlowConstraintAdjustmentCoefficient = 5.;
+        double loopFlowViolationCost = 10.;
+
+        MaxLoopFlowFiller maxLoopFlowFiller = new MaxLoopFlowFiller(loopFlowConstraintAdjustmentCoefficient, loopFlowViolationCost, RaoParameters.LoopFlowApproximationLevel.UPDATE_PTDF_WITH_TOPO);
+
+        // build problem
+        coreProblemFiller.fill(raoData, linearProblem);
+        maxLoopFlowFiller.fill(raoData, linearProblem);
+
+        // update rao data and filler
+        cnecLoopFlowExtension.setLoopFlowConstraintInMW(350.0);
+        cnec1.getExtension(CnecResultExtension.class).getVariant(raoData.getWorkingVariantId()).setCommercialFlowInMW(67.0);
+        maxLoopFlowFiller.update(raoData, linearProblem);
+
+        // check flow constraint for cnec1
+        MPConstraint loopFlowConstraintUb = linearProblem.getMaxLoopFlowConstraint(cnec1, LinearProblem.BoundExtension.UPPER_BOUND);
+        MPConstraint loopFlowConstraintLb = linearProblem.getMaxLoopFlowConstraint(cnec1, LinearProblem.BoundExtension.LOWER_BOUND);
+
+        assertEquals(-(100 - 5.) + 49.0, loopFlowConstraintLb.lb(), DOUBLE_TOLERANCE);
+        assertEquals((100 - 5.) + 49.0, loopFlowConstraintUb.ub(), DOUBLE_TOLERANCE);
     }
 }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizerWithLoopFlowsParametersTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizerWithLoopFlowsParametersTest.java
@@ -7,6 +7,7 @@
 
 package com.farao_community.farao.rao_commons.linear_optimisation.iterating_linear_optimizer;
 
+import com.farao_community.farao.rao_api.RaoParameters;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -14,23 +15,23 @@ import static org.junit.Assert.*;
 /**
  * @author Joris Mancini {@literal <joris.mancini at rte-france.com>}
  */
-public class IteratingLinearOptimizerWithLoopFLowsParametersTest {
+public class IteratingLinearOptimizerWithLoopFlowsParametersTest {
 
     @Test
     public void isLoopflowApproximation() {
         IteratingLinearOptimizerWithLoopFLowsParameters parameters =
-            new IteratingLinearOptimizerWithLoopFLowsParameters(20, 12, false, 1.0);
-        assertFalse(parameters.isLoopflowApproximation());
+            new IteratingLinearOptimizerWithLoopFLowsParameters(20, 12, RaoParameters.LoopFlowApproximationLevel.UPDATE_PTDF_WITH_TOPO, 1.0);
+        assertEquals(RaoParameters.LoopFlowApproximationLevel.UPDATE_PTDF_WITH_TOPO, parameters.getLoopflowApproximationLevel());
         assertEquals(1.0, parameters.getLoopFlowViolationCost(), 0.1);
     }
 
     @Test
     public void setLoopFlowApproximation() {
         IteratingLinearOptimizerWithLoopFLowsParameters parameters =
-            new IteratingLinearOptimizerWithLoopFLowsParameters(20, 12, false, 1.0);
-        parameters.setLoopFlowApproximation(true);
+            new IteratingLinearOptimizerWithLoopFLowsParameters(20, 12, RaoParameters.LoopFlowApproximationLevel.FIXED_PTDF, 1.0);
+        parameters.setLoopFlowApproximationLevel(RaoParameters.LoopFlowApproximationLevel.UPDATE_PTDF_WITH_TOPO_AND_PST);
         parameters.setLoopFlowViolationCost(10.0);
-        assertTrue(parameters.isLoopflowApproximation());
+        assertEquals(RaoParameters.LoopFlowApproximationLevel.UPDATE_PTDF_WITH_TOPO_AND_PST, parameters.getLoopflowApproximationLevel());
         assertEquals(10.0, parameters.getLoopFlowViolationCost(), 0.1);
     }
 }

--- a/ra-optimisation/rao-commons/src/test/resources/RaoParametersWithBoundaries.json
+++ b/ra-optimisation/rao-commons/src/test/resources/RaoParametersWithBoundaries.json
@@ -6,7 +6,7 @@
   "pst-sensitivity-threshold" : 0.0,
   "sensitivity-fallback-over-cost" : 0.0,
   "rao-with-loop-flow-limitation" : false,
-  "loop-flow-approximation" : true,
+  "loop-flow-approximation" : "FIXED_PTDF",
   "loop-flow-constraint-adjustment-coefficient" : 0.0,
   "loop-flow-violation-cost" : 0.0,
   "sensitivity-parameters" : {

--- a/ra-optimisation/rao-commons/src/test/resources/RaoPtdfParameters.json
+++ b/ra-optimisation/rao-commons/src/test/resources/RaoPtdfParameters.json
@@ -6,7 +6,7 @@
   "pst-sensitivity-threshold" : 0.0,
   "sensitivity-fallback-over-cost" : 0.0,
   "rao-with-loop-flow-limitation" : false,
-  "loop-flow-approximation" : true,
+  "loop-flow-approximation" : "FIXED_PTDF",
   "loop-flow-constraint-adjustment-coefficient" : 0.0,
   "loop-flow-violation-cost" : 0.0,
   "loop-flow-countries" : [ ],

--- a/ra-optimisation/rao-commons/src/test/resources/RaoPtdfParametersUnknownField.json
+++ b/ra-optimisation/rao-commons/src/test/resources/RaoPtdfParametersUnknownField.json
@@ -6,7 +6,7 @@
   "pst-sensitivity-threshold" : 0.0,
   "sensitivity-fallback-over-cost" : 0.0,
   "rao-with-loop-flow-limitation" : false,
-  "loop-flow-approximation" : true,
+  "loop-flow-approximation" : "FIXED_PTDF",
   "loop-flow-constraint-adjustment-coefficient" : 0.0,
   "loop-flow-violation-cost" : 0.0,
   "mnec-acceptable-margin-diminution" : 50.0,

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
@@ -46,6 +46,9 @@ public class SearchTreeRaoProvider implements RaoProvider {
         return "1.0.0";
     }
 
+    public SearchTreeRaoProvider() {
+    }
+
     // Useful for tests
     SearchTreeRaoProvider(StateTree stateTree) {
         this.stateTree = stateTree;

--- a/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/LeafTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/LeafTest.java
@@ -103,7 +103,7 @@ public class LeafTest {
             PowerMockito.when(SystematicSensitivityInterface.builder()).thenAnswer(invocationOnMock -> sensitivityBuilder);
             PowerMockito.mockStatic(RaoUtil.class);
             PowerMockito.when(RaoUtil.createLinearOptimizer(Mockito.any(), Mockito.any())).thenAnswer(invocationOnMock -> iteratingLinearOptimizer);
-            PowerMockito.when(RaoUtil.createSystematicSensitivityInterface(Mockito.any(), Mockito.any())).thenAnswer(invocationOnMock -> systematicSensitivityInterface);
+            PowerMockito.when(RaoUtil.createSystematicSensitivityInterface(Mockito.any(), Mockito.any(), Mockito.any())).thenAnswer(invocationOnMock -> systematicSensitivityInterface);
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/LeafTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/LeafTest.java
@@ -35,8 +35,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.util.Set;
 
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.*;
 
 /**
  * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com>}
@@ -103,7 +102,7 @@ public class LeafTest {
             PowerMockito.when(SystematicSensitivityInterface.builder()).thenAnswer(invocationOnMock -> sensitivityBuilder);
             PowerMockito.mockStatic(RaoUtil.class);
             PowerMockito.when(RaoUtil.createLinearOptimizer(Mockito.any(), Mockito.any())).thenAnswer(invocationOnMock -> iteratingLinearOptimizer);
-            PowerMockito.when(RaoUtil.createSystematicSensitivityInterface(Mockito.any(), Mockito.any(), Mockito.any())).thenAnswer(invocationOnMock -> systematicSensitivityInterface);
+            PowerMockito.when(RaoUtil.createSystematicSensitivityInterface(Mockito.any(), Mockito.any(), anyBoolean())).thenAnswer(invocationOnMock -> systematicSensitivityInterface);
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/ra-optimisation/search-tree-rao/src/test/resources/RaoParametersWithoutSearchTreeParameters.json
+++ b/ra-optimisation/search-tree-rao/src/test/resources/RaoParametersWithoutSearchTreeParameters.json
@@ -6,7 +6,7 @@
   "pst-sensitivity-threshold" : 0.0,
   "sensitivity-fallback-over-cost" : 0.0,
   "rao-with-loop-flow-limitation" : false,
-  "loop-flow-approximation" : true,
+  "loop-flow-approximation" : "FIXED_PTDF",
   "loop-flow-constraint-adjustment-coefficient" : 0.0,
   "sensitivity-parameters": {
     "version": "1.0",

--- a/ra-optimisation/search-tree-rao/src/test/resources/SearchTreeRaoParameters.json
+++ b/ra-optimisation/search-tree-rao/src/test/resources/SearchTreeRaoParameters.json
@@ -6,7 +6,7 @@
   "pst-sensitivity-threshold" : 0.0,
   "sensitivity-fallback-over-cost" : 0.0,
   "rao-with-loop-flow-limitation" : false,
-  "loop-flow-approximation" : true,
+  "loop-flow-approximation" : "FIXED_PTDF",
   "loop-flow-constraint-adjustment-coefficient" : 0.0,
   "loop-flow-violation-cost" : 0.0,
   "loop-flow-countries" : [ ],

--- a/ra-optimisation/search-tree-rao/src/test/resources/SearchTreeRaoParametersError.json
+++ b/ra-optimisation/search-tree-rao/src/test/resources/SearchTreeRaoParametersError.json
@@ -6,7 +6,7 @@
   "pst-sensitivity-threshold" : 0.0,
   "sensitivity-fallback-over-cost" : 0.0,
   "rao-with-loop-flow-limitation" : false,
-  "loop-flow-approximation" : true,
+  "loop-flow-approximation" : "FIXED_PTDF",
   "loop-flow-constraint-adjustment-coefficient" : 0.0,
   "mnec-acceptable-margin-diminution" : 50.0,
   "mnec-violation-cost" : 10.0,

--- a/ra-optimisation/search-tree-rao/src/test/resources/parameters.json
+++ b/ra-optimisation/search-tree-rao/src/test/resources/parameters.json
@@ -6,7 +6,7 @@
   "pst-sensitivity-threshold" : 0.0,
   "sensitivity-fallback-over-cost" : 0.0,
   "rao-with-loop-flow-limitation" : false,
-  "loop-flow-approximation" : true,
+  "loop-flow-approximation" : "FIXED_PTDF",
   "loop-flow-constraint-adjustment-coefficient" : 0.0,
   "sensitivity-parameters": {
     "version": "1.0",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
New feature

**What is the current behavior?** *(You can also link to an open issue here)*
The loopflows have two levels of approximation:
1- no approximation (loopflow-approximation=false): PTDFs are computed after each topological and PST change
2- heavy approximation (loopflow-approximation=true): PTDFs are computed only once at the start of the RAO
Moreover, in case 1, sensitivities were unnecessarily computed once more in the linear problem filler

**What is the new behavior (if this is a feature change)?**
We now have 3 levels of LF approximations:
1- no approximation (loopflow-approximation=UPDATE_PTDF_WITH_TOPO_AND_PST): same as above, but optimized to avoid computing sensitivities inside the linear problem filler
2- "in-between" approximation (loopflow-approximation=UPDATE_PTDF_WITH_TOPO): PTDFs are recomputed only after topological actions change. This is an exact method for DC computations, as for DC PSTs do not change PTDFs.
3- heavy approximation (loopflow-approximation=FIXED_PTDF): same as old case 2

**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
Instead of setting loopflow-approximation=false/true in their configuration file, users should now use one of the three values: UPDATE_PTDF_WITH_TOPO_AND_PST / UPDATE_PTDF_WITH_TOPO / FIXED_PTDF