### PR TITLE
Fix RAO results merging after curative optimization

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoLogger.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoLogger.java
@@ -71,13 +71,15 @@ final class SearchTreeRaoLogger {
             double cnecMargin = computeCnecMargin(cnec, variantId, unit, relativePositiveMargins);
             String margin = new DecimalFormat("#0.00").format(cnecMargin);
             String isRelativeMargin = (relativePositiveMargins && cnecMargin > 0) ? "relative " : "";
-            SearchTree.LOGGER.info("Limiting element #{}: element {} at state {} with a {}margin of {} {}",
+            String ptdfIfRelative = (relativePositiveMargins && cnecMargin > 0) ? format("(PTDF %f)", cnec.getExtension(CnecResultExtension.class).getVariant(variantId).getAbsolutePtdfSum()) : "";
+            SearchTree.LOGGER.info("Limiting element #{}: element {} at state {} with a {}margin of {} {} {}",
                     i + 1,
                     cnecNetworkElementName,
                     cnecStateId,
                     isRelativeMargin,
                     margin,
-                    unit);
+                    unit,
+                    ptdfIfRelative);
         }
     }
 

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
@@ -241,10 +241,9 @@ public class SearchTreeRaoProvider implements RaoProvider {
     }
 
     private void deleteCurativeVariants(Crac crac, String preventivePostOptimVariantId, Map<State, RaoResult> curativeRaoResults) {
-        curativeRaoResults.values().stream().map(RaoResult::getPostOptimVariantId).forEach(variantId -> {
-            if (!variantId.equals(preventivePostOptimVariantId)) {
-                crac.getExtension(ResultVariantManager.class).deleteVariant(variantId);
-            }
-        });
+        curativeRaoResults.values().stream()
+            .map(RaoResult::getPostOptimVariantId)
+            .filter(variantId -> !variantId.equals(preventivePostOptimVariantId))
+            .forEach(variantId -> crac.getExtension(ResultVariantManager.class).deleteVariant(variantId));
     }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
@@ -184,7 +184,7 @@ public class SearchTreeRaoProvider implements RaoProvider {
         mergeRaoResultStatus(preventiveRaoResult, curativeRaoResults);
         mergeCnecResults(crac, preventiveRaoResult, curativeRaoResults);
         mergeRemedialActionsResults(crac, preventiveRaoResult, curativeRaoResults);
-        deleteCurativeVariants(crac, curativeRaoResults);
+        deleteCurativeVariants(crac, preventiveRaoResult.getPostOptimVariantId(), curativeRaoResults);
         return preventiveRaoResult;
     }
 
@@ -240,8 +240,11 @@ public class SearchTreeRaoProvider implements RaoProvider {
         });
     }
 
-    private void deleteCurativeVariants(Crac crac, Map<State, RaoResult> curativeRaoResults) {
-        curativeRaoResults.values().stream().map(RaoResult::getPostOptimVariantId).forEach(variantId ->
-            crac.getExtension(ResultVariantManager.class).deleteVariant(variantId));
+    private void deleteCurativeVariants(Crac crac, String preventivePostOptimVariantId, Map<State, RaoResult> curativeRaoResults) {
+        curativeRaoResults.values().stream().map(RaoResult::getPostOptimVariantId).forEach(variantId -> {
+            if (!variantId.equals(preventivePostOptimVariantId)) {
+                crac.getExtension(ResultVariantManager.class).deleteVariant(variantId);
+            }
+        });
     }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
@@ -210,6 +210,7 @@ public class SearchTreeRaoProvider implements RaoProvider {
                 targetResult.setMaxThresholdInMW(optimizedCnecResult.getMaxThresholdInMW());
                 targetResult.setMinThresholdInA(optimizedCnecResult.getMinThresholdInA());
                 targetResult.setMinThresholdInMW(optimizedCnecResult.getMinThresholdInMW());
+                targetResult.setAbsolutePtdfSum(optimizedCnecResult.getAbsolutePtdfSum());
             }
         });
     }

--- a/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/SearchTreeRaoProviderTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/SearchTreeRaoProviderTest.java
@@ -91,7 +91,6 @@ public class SearchTreeRaoProviderTest {
 
     @Test
     public void mergeRaoResults() {
-
         RaoResult preventiveRaoResult = new RaoResult(RaoResult.Status.SUCCESS);
         preventiveRaoResult.setPreOptimVariantId(initialVariantId);
         preventiveRaoResult.setPostOptimVariantId(postOptimPrevVariantId);
@@ -139,5 +138,25 @@ public class SearchTreeRaoProviderTest {
             Map.of(curativeState, curativeRaoResult));
 
         assertEquals(RaoResult.Status.FAILURE, mergedRaoResult.getStatus());
+    }
+
+    @Test
+    public void mergeRaoResultsWithNoOptimizationInCurative() {
+
+        RaoResult preventiveRaoResult = new RaoResult(RaoResult.Status.SUCCESS);
+        preventiveRaoResult.setPreOptimVariantId(initialVariantId);
+        preventiveRaoResult.setPostOptimVariantId(postOptimPrevVariantId);
+
+        RaoResult curativeRaoResult = new RaoResult(RaoResult.Status.SUCCESS);
+        curativeRaoResult.setPreOptimVariantId(postOptimPrevVariantId);
+        curativeRaoResult.setPostOptimVariantId(postOptimPrevVariantId);
+
+        StateTree stateTree = mockedStateTree(crac);
+
+        State curativeState = crac.getState("Contingency FR1 FR3", "curative");
+        new SearchTreeRaoProvider(stateTree).mergeRaoResults(crac, preventiveRaoResult,
+            Map.of(curativeState, curativeRaoResult));
+
+        assertNotNull(crac.getExtension(CracResultExtension.class).getVariant(postOptimPrevVariantId));
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix on merging rao results after curative optimization. Variant eleting + copy CnecResult from curative variant to preventive variant


**What is the current behavior?** *(You can also link to an open issue here)*
It's deleting the post-optim curative variant even if it's the same as the preventive post-optim variant. Then no optimized results are stored in output. It happens when no remedial actions are selected during curative optimization.


**What is the new behavior (if this is a feature change)?**
Delete this post-optim curative variant only if it's different from the preventive one.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No
