### PR TITLE
[fix github CI] add jaxb dependency

### DIFF
--- a/data/crac-io/crac-io-cne/pom.xml
+++ b/data/crac-io/crac-io-cne/pom.xml
@@ -36,6 +36,7 @@
     </build>
 
     <dependencies>
+        <!--Compile-->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>farao-crac-api</artifactId>

--- a/data/crac-io/crac-io-cne/pom.xml
+++ b/data/crac-io/crac-io-cne/pom.xml
@@ -48,22 +48,29 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>farao-util</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <!--Compile-->
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>farao-crac-io-api</artifactId>
             <version>${project.version}</version>
-            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>farao-util</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>farao-crac-result-extensions</artifactId>
             <version>${project.version}</version>
-            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+
+        <!--Runtime-->
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <!--Test-->

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,8 @@
         <jackson.version>2.11.2</jackson.version>
         <java.version>11</java.version>
         <javax.validation.version>2.0.1.Final</javax.validation.version>
+        <jaxb-api.version>2.4.0-b180830.0359</jaxb-api.version>
+        <jaxb-runtime.version>2.4.0-b180830.0438</jaxb-runtime.version>
         <jimfs.version>1.1</jimfs.version>
         <jgrapht.core.version>1.4.0</jgrapht.core.version>
         <junit.version>4.13.1</junit.version>
@@ -480,6 +482,11 @@
                 <version>${jgrapht.core.version}</version>
             </dependency>
             <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb-api.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
@@ -504,6 +511,12 @@
                 <groupId>com.rte-france.powsybl</groupId>
                 <artifactId>powsybl-hades2-integration</artifactId>
                 <version>${powsybl.hades2.version}</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${jaxb-runtime.version}</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Fix github CI

JAXB is apparently removed from java 11 and therefore need to be explicitly given in maven dependencies : https://stackoverflow.com/questions/52502189/java-11-package-javax-xml-bind-does-not-exist

I used the same version/dependencies than the ones used in powsybl-core java 11 profile :
https://github.com/powsybl/powsybl-core/blob/master/pom.xml