### PR TITLE
limit relative impact coef between 0 and 1

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoParameters.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoParameters.java
@@ -8,12 +8,15 @@ package com.farao_community.farao.search_tree_rao;
 
 import com.farao_community.farao.rao_api.RaoParameters;
 import com.powsybl.commons.extensions.AbstractExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Joris Mancini {@literal <joris.mancini at rte-france.com>}
  * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com>}
  */
 public class SearchTreeRaoParameters extends AbstractExtension<RaoParameters> {
+    static final Logger LOGGER = LoggerFactory.getLogger(SearchTreeRaoParameters.class);
 
     public enum StopCriterion {
         POSITIVE_MARGIN,
@@ -57,7 +60,15 @@ public class SearchTreeRaoParameters extends AbstractExtension<RaoParameters> {
     }
 
     public void setRelativeNetworkActionMinimumImpactThreshold(double relativeNetworkActionMinimumImpactThreshold) {
-        this.relativeNetworkActionMinimumImpactThreshold = relativeNetworkActionMinimumImpactThreshold;
+        if (relativeNetworkActionMinimumImpactThreshold < 0) {
+            LOGGER.warn("The value {} provided for relative network action minimum impact threshold is smaller than 0. It will be set to 0.", relativeNetworkActionMinimumImpactThreshold);
+            this.relativeNetworkActionMinimumImpactThreshold = 0;
+        } else if (relativeNetworkActionMinimumImpactThreshold > 1) {
+            LOGGER.warn("The value {} provided for relative network action minimum impact threshold is greater than 1. It will be set to 1.", relativeNetworkActionMinimumImpactThreshold);
+            this.relativeNetworkActionMinimumImpactThreshold = 1;
+        } else {
+            this.relativeNetworkActionMinimumImpactThreshold = relativeNetworkActionMinimumImpactThreshold;
+        }
     }
 
     public double getAbsoluteNetworkActionMinimumImpactThreshold() {

--- a/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/SearchTreeRaoParametersTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/SearchTreeRaoParametersTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -32,5 +33,14 @@ public class SearchTreeRaoParametersTest {
     public void testExtensionRecognition() {
         assertTrue(parameters.getExtensionByName("SearchTreeRaoParameters") instanceof SearchTreeRaoParameters);
         assertNotNull(parameters.getExtension(SearchTreeRaoParameters.class));
+    }
+
+    @Test
+    public void testRelativeNetworkActionMinimumImpactThresholdBounds() {
+        SearchTreeRaoParameters params = new SearchTreeRaoParameters();
+        params.setRelativeNetworkActionMinimumImpactThreshold(-0.5);
+        assertEquals(0, params.getRelativeNetworkActionMinimumImpactThreshold(), 1e-6);
+        params.setRelativeNetworkActionMinimumImpactThreshold(1.1);
+        assertEquals(1, params.getRelativeNetworkActionMinimumImpactThreshold(), 1e-6);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
The minimum relative impact in search tree can be greater than 1 (100%) and smaller than 0


**What is the new behavior (if this is a feature change)?**
The parameter is bound between 0 and 1