### PR TITLE
Correct a bad practice in IteratingLinearOptimizer

### DIFF
--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/LinearOptimizer.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/LinearOptimizer.java
@@ -139,6 +139,7 @@ public class LinearOptimizer {
         } catch (Exception e) {
             String errorMessage = "Solving of the linear problem failed.";
             LOGGER.error(errorMessage);
+            setSolverResultStatusString("ABNORMAL");
             throw new LinearOptimisationException(errorMessage, e);
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?** 
Code refactoring: I suggest to follow good practice of command query separation. 
```
optimize();
if (hasNotOptimized) {...} 
```
is better than
`if(!optimize()) {...}`

**Does this PR introduce a breaking change?**
No
