### PR TITLE
Add a preoptim variant ID to identify preventive results in curative RAO

### DIFF
--- a/data/crac/crac-result-extensions/src/main/java/com/farao_community/farao/data/crac_result_extensions/ResultVariantManager.java
+++ b/data/crac/crac-result-extensions/src/main/java/com/farao_community/farao/data/crac_result_extensions/ResultVariantManager.java
@@ -34,6 +34,7 @@ public class ResultVariantManager extends AbstractExtension<Crac> {
 
     private Set<String> variants;
     private String initialVariantId;
+    private String preOptimVariantId;
 
     /**
      * Default constructor
@@ -71,6 +72,14 @@ public class ResultVariantManager extends AbstractExtension<Crac> {
             throw new FaraoException("Impossible to set initial variant twice.");
         }
         this.initialVariantId = initialVariantId;
+    }
+
+    public String getPreOptimVariantId() {
+        return preOptimVariantId;
+    }
+
+    public void setPreOptimVariantId(String preOptimVariantId) {
+        this.preOptimVariantId = preOptimVariantId;
     }
 
     /**

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracVariantManager.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracVariantManager.java
@@ -53,6 +53,7 @@ public class CracVariantManager {
             variantIds.add(cracVariantId);
             systematicSensitivityResultMap.put(cracVariantId, null);
             setWorkingVariant(cracVariantId);
+            resultVariantManager.setPreOptimVariantId(cracVariantId);
         } else { // Case no base CRAC variant is defined so a new CRAC variant must be created
             String variantId;
             if (resultVariantManager == null) {
@@ -60,6 +61,7 @@ public class CracVariantManager {
                 crac.addExtension(ResultVariantManager.class, resultVariantManager);
                 variantId = createVariantFromWorkingVariant(VariantType.INITIAL);
                 resultVariantManager.setInitialVariantId(variantId);
+                resultVariantManager.setPreOptimVariantId(variantId);
             } else {
                 variantId = createVariantFromWorkingVariant(VariantType.PRE_OPTIM);
             }

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/CoreProblemFiller.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/CoreProblemFiller.java
@@ -190,7 +190,7 @@ public class CoreProblemFiller implements ProblemFiller {
      * AV[r] >= initialSetPoint[r] - S[r]     (POSITIVE)
      */
     private void buildRangeActionConstraints(RaoData raoData, LinearProblem linearProblem) {
-        String preOptimVariantId = raoData.getCrac().getExtension(ResultVariantManager.class).getInitialVariantId();
+        String preOptimVariantId = raoData.getCrac().getExtension(ResultVariantManager.class).getPreOptimVariantId();
         raoData.getAvailableRangeActions().forEach(rangeAction -> {
             double initialSetPoint = rangeAction.getExtension(RangeActionResultExtension.class).getVariant(preOptimVariantId).getSetPoint(raoData.getOptimizedState().getId());
             MPConstraint varConstraintNegative = linearProblem.addAbsoluteRangeActionVariationConstraint(-initialSetPoint, linearProblem.infinity(), rangeAction, LinearProblem.AbsExtension.NEGATIVE);

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MnecFillerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MnecFillerTest.java
@@ -79,6 +79,7 @@ public class MnecFillerTest extends AbstractFillerTest {
         // fill the problem : the core filler is required
         mnecFiller = new MnecFiller(unit, 50, 10, 3.5);
         initRaoData(crac.getPreventiveState());
+        raoData.getCrac().getExtension(ResultVariantManager.class).setPreOptimVariantId(raoData.getInitialVariantId());
         coreProblemFiller.fill(raoData, linearProblem);
         mnecFiller.fill(raoData, linearProblem);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
In the RAO, the initial PST setpoint used to penalize PST variation is fetched from the initial variant. In the curative RAO, this initial variant does not exist, we should use preventive results instead.


**What is the new behavior (if this is a feature change)?**
A new "preOptimVariant" is added in order to differentiate initial variant from pre-optim variant 
pre-optim variant = initial variant in preventive RAO
pre-optim variant = preventive post-optim variant in curative RAO
