### PR TITLE
aligned PSTs - added a setter for groupId to help import them

### DIFF
--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/remedial_action/range_action/AbstractRangeAction.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/remedial_action/range_action/AbstractRangeAction.java
@@ -95,6 +95,10 @@ public abstract class AbstractRangeAction extends AbstractRemedialAction<RangeAc
         return Optional.ofNullable(groupId);
     }
 
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
     public final List<Range> getRanges() {
         return ranges;
     }

--- a/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/remedial_action/range_action/AbstractRangeActionTest.java
+++ b/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/remedial_action/range_action/AbstractRangeActionTest.java
@@ -62,4 +62,12 @@ abstract public class AbstractRangeActionTest extends AbstractRemedialActionTest
         assertNotEquals(pst.hashCode(), pstDifferent.hashCode());
         assertNotEquals(pst, pstDifferent);
     }
+
+    @Test
+    public void testGroupId() {
+        AbstractRangeAction pst = new PstWithRange("pst_range_id", new NetworkElement("neID"));
+        pst.setGroupId("groupId");
+        assertTrue(pst.getGroupId().isPresent());
+        assertEquals("groupId", pst.getGroupId().get());
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
aligned PSTs can not be imported from CBCORAs


**What is the new behavior (if this is a feature change)?**
They are now correctly imported


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
