### PR TITLE
Compute initial sensitivity on curative CNECs

### DIFF
--- a/data/crac/crac-api/src/test/java/com/farao_community/farao/data/crac_api/CracFactoryTest.java
+++ b/data/crac/crac-api/src/test/java/com/farao_community/farao/data/crac_api/CracFactoryTest.java
@@ -44,7 +44,7 @@ public class CracFactoryTest {
         assertEquals(cf.getClass(), MockCracFactory1.class);
     }
 
-    // TO DO : test different default configs : empty (should throw),
+    // TODO : test different default configs : empty (should throw),
     // with MockCracFactory2, with wrong implem name (should throw)
     // (this is not yet possible with PowSyBl's TestPlatformConfigProvider)
 }

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/cnec/FlowCnecImpl.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/cnec/FlowCnecImpl.java
@@ -77,7 +77,6 @@ public class FlowCnecImpl extends AbstractBranchCnec implements BranchCnec {
     public Optional<Double> getLowerBound(Side side, Unit requestedUnit) {
         requestedUnit.checkPhysicalParameter(getPhysicalParameter());
         if (!bounds.isLowerBoundComputed(side, requestedUnit)) {
-            LOGGER.debug("Lower bound computed for {} in {}", getId(), requestedUnit);
             Set<BranchThreshold> limitingThresholds = thresholds.stream()
                     .filter(Threshold::limitsByMin)
                     .collect(Collectors.toSet());
@@ -104,7 +103,6 @@ public class FlowCnecImpl extends AbstractBranchCnec implements BranchCnec {
     public Optional<Double> getUpperBound(Side side, Unit requestedUnit) {
         requestedUnit.checkPhysicalParameter(getPhysicalParameter());
         if (!bounds.isUpperBoundComputed(side, requestedUnit)) {
-            LOGGER.debug("Upper bound computed for {} in {}", getId(), requestedUnit);
             Set<BranchThreshold> limitingThresholds = thresholds.stream()
                     .filter(Threshold::limitsByMax)
                     .collect(Collectors.toSet());

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/InitialSensitivityAnalysis.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/InitialSensitivityAnalysis.java
@@ -7,7 +7,10 @@
 package com.farao_community.farao.rao_commons;
 
 import com.farao_community.farao.commons.Unit;
+import com.farao_community.farao.commons.ZonalData;
+import com.farao_community.farao.data.crac_api.Crac;
 import com.farao_community.farao.data.crac_api.cnec.BranchCnec;
+import com.farao_community.farao.data.refprog.reference_program.ReferenceProgram;
 import com.farao_community.farao.loopflow_computation.LoopFlowComputation;
 import com.farao_community.farao.loopflow_computation.LoopFlowResult;
 import com.farao_community.farao.rao_api.RaoParameters;
@@ -15,6 +18,8 @@ import com.farao_community.farao.rao_commons.objective_function_evaluator.Object
 import com.farao_community.farao.sensitivity_analysis.SystematicSensitivityInterface;
 import com.farao_community.farao.sensitivity_analysis.SystematicSensitivityResult;
 import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.sensitivity.factors.variables.LinearGlsk;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +39,10 @@ public class InitialSensitivityAnalysis {
     private RaoData raoData;
     private RaoParameters raoParameters;
     private SystematicSensitivityInterface systematicSensitivityInterface;
+
+    public InitialSensitivityAnalysis(Network network, Crac crac, ReferenceProgram referenceProgram, ZonalData<LinearGlsk> glsk, RaoParameters raoParameters) {
+        this(new RaoData(network, crac, crac.getPreventiveState(), null, referenceProgram, glsk, null, raoParameters.getLoopflowCountries()), raoParameters);
+    }
 
     public InitialSensitivityAnalysis(RaoData raoData, RaoParameters raoParameters) {
         this.raoData = raoData;

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoData.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoData.java
@@ -143,9 +143,13 @@ public final class RaoData {
     }
 
     private void computePerimeterCnecs() {
-        Set<BranchCnec> cnecs = new HashSet<>();
-        perimeter.forEach(state -> cnecs.addAll(crac.getBranchCnecs(state)));
-        perimeterCnecs = cnecs;
+        if (perimeter != null) {
+            Set<BranchCnec> cnecs = new HashSet<>();
+            perimeter.forEach(state -> cnecs.addAll(crac.getBranchCnecs(state)));
+            perimeterCnecs = cnecs;
+        } else {
+            perimeterCnecs = crac.getBranchCnecs();
+        }
     }
 
     public Set<BranchCnec> getLoopflowCnecs() {

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoUtil.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoUtil.java
@@ -134,7 +134,7 @@ public final class RaoUtil {
             fillers.add(new MnecFiller(raoParameters.getObjectiveFunction().getUnit(), raoParameters.getMnecAcceptableMarginDiminution(), raoParameters.getMnecViolationCost(), raoParameters.getMnecConstraintAdjustmentCoefficient()));
         }
         if (raoParameters.isRaoWithLoopFlowLimitation()) {
-            // TO DO : add relative margins to IteratingLinearOptimizerWithLoopFlows
+            // TODO : add relative margins to IteratingLinearOptimizerWithLoopFlows
             // or merge IteratingLinearOptimizerWithLoopFlows with IteratingLinearOptimizer
             fillers.add(createMaxLoopFlowFiller(raoParameters));
             return new IteratingLinearOptimizerWithLoopFlows(fillers, systematicSensitivityInterface,

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoDataTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoDataTest.java
@@ -49,6 +49,12 @@ public class RaoDataTest {
     }
 
     @Test
+    public void testNoPerimeter() {
+        RaoData raoData = new RaoData(network, crac, crac.getPreventiveState(), null, null, null, null, new HashSet<>());
+        assertEquals(crac.getBranchCnecs().size(), raoData.getCnecs().size());
+    }
+
+    @Test
     public void variantIdsInitializationTest() {
         assertEquals(1, raoData.getCracVariantManager().getVariantIds().size());
         assertNotNull(crac.getExtension(CracResultExtension.class));

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/Leaf.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/Leaf.java
@@ -164,7 +164,7 @@ class Leaf {
                     LOGGER.debug("Evaluating leaf...");
                     new InitialSensitivityAnalysis(raoData, raoParameters).run();
                     status = Status.EVALUATED;
-                    // TO DO : in curative RAO, we don't need to recompute PTDFs if we already did it before preventive RAO for all CNECs
+                    // TODO : in curative RAO, we don't need to recompute PTDFs if we already did it before preventive RAO for all CNECs
                 } catch (FaraoException e) {
                     LOGGER.error(String.format("Fail to evaluate leaf: %s", e.getMessage()));
                     status = Status.ERROR;

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/Leaf.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/Leaf.java
@@ -151,30 +151,53 @@ class Leaf {
     }
 
     /**
+     * This method performs an initial sensitivity computation on the root leaf only if it has not been done previously.
+     * If the computation works fine status is updated to EVALUATED otherwise it is set to ERROR.
+     */
+    void evaluateRootLeaf(boolean shouldComputeInitialSensitivity) {
+        if (!isRoot()) {
+            throw new FaraoException("Method evaluateRootLeaf should only be called on root leaf.");
+        }
+        if (status.equals(Status.CREATED)) {
+            if (shouldComputeInitialSensitivity) {
+                try {
+                    LOGGER.debug("Evaluating leaf...");
+                    new InitialSensitivityAnalysis(raoData, raoParameters).run();
+                    status = Status.EVALUATED;
+                    // TO DO : in curative RAO, we don't need to recompute PTDFs if we already did it before preventive RAO for all CNECs
+                } catch (FaraoException e) {
+                    LOGGER.error(String.format("Fail to evaluate leaf: %s", e.getMessage()));
+                    status = Status.ERROR;
+                }
+            } else {
+                LOGGER.debug("Initial sensitivity analysis has been skipped");
+                status = Status.EVALUATED;
+            }
+        }
+    }
+
+    /**
      * This method performs a systematic sensitivity computation on the leaf only if it has not been done previously.
      * If the computation works fine status is updated to EVALUATED otherwise it is set to ERROR.
      */
     void evaluate() {
+        if (isRoot()) {
+            throw new FaraoException("Method evaluate should not be called on root leaf.");
+        }
         if (status.equals(Status.CREATED)) {
             try {
                 LOGGER.debug("Evaluating leaf...");
+                raoData.setSystematicSensitivityResult(systematicSensitivityInterface.run(raoData.getNetwork()));
 
-                if (isRoot()) {
-                    new InitialSensitivityAnalysis(raoData, raoParameters).run();
-                } else {
-
-                    raoData.setSystematicSensitivityResult(systematicSensitivityInterface.run(raoData.getNetwork()));
-
-                    if (raoParameters.isRaoWithLoopFlowLimitation()) {
-                        LoopFlowUtil.buildLoopFlowsWithLatestSensi(raoData,
-                                !raoParameters.getLoopFlowApproximationLevel().shouldUpdatePtdfWithTopologicalChange());
-                    }
-
-                    ObjectiveFunctionEvaluator objectiveFunctionEvaluator = RaoUtil.createObjectiveFunction(raoParameters);
-                    raoData.getCracResultManager().fillCnecResultWithFlows();
-                    raoData.getCracResultManager().fillCracResultWithCosts(
-                            objectiveFunctionEvaluator.getFunctionalCost(raoData), objectiveFunctionEvaluator.getVirtualCost(raoData));
+                if (raoParameters.isRaoWithLoopFlowLimitation()) {
+                    LoopFlowUtil.buildLoopFlowsWithLatestSensi(raoData,
+                            !raoParameters.getLoopFlowApproximationLevel().shouldUpdatePtdfWithTopologicalChange());
                 }
+
+                ObjectiveFunctionEvaluator objectiveFunctionEvaluator = RaoUtil.createObjectiveFunction(raoParameters);
+                raoData.getCracResultManager().fillCnecResultWithFlows();
+                raoData.getCracResultManager().fillCracResultWithCosts(
+                        objectiveFunctionEvaluator.getFunctionalCost(raoData), objectiveFunctionEvaluator.getVirtualCost(raoData));
 
                 status = Status.EVALUATED;
             } catch (FaraoException e) {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTree.java
@@ -65,7 +65,7 @@ public class SearchTree {
         this.treeParameters = treeParameters;
 
         LOGGER.info("Evaluate root leaf");
-        rootLeaf.evaluate();
+        rootLeaf.evaluateRootLeaf(treeParameters.getShouldComputeInitialSensitivity());
         LOGGER.debug("{}", rootLeaf);
         if (rootLeaf.getStatus().equals(Leaf.Status.ERROR)) {
             //TODO : improve error messages depending on leaf error (infeasible optimisation, time-out, ...)

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTree.java
@@ -66,6 +66,7 @@ public class SearchTree {
 
         LOGGER.info("Evaluate root leaf");
         rootLeaf.evaluateRootLeaf(treeParameters.getShouldComputeInitialSensitivity());
+        SearchTreeRaoLogger.logMostLimitingElementsResults(rootLeaf, raoParameters.getObjectiveFunction().getUnit(), relativePositiveMargins);
         LOGGER.debug("{}", rootLeaf);
         if (rootLeaf.getStatus().equals(Leaf.Status.ERROR)) {
             //TODO : improve error messages depending on leaf error (infeasible optimisation, time-out, ...)
@@ -85,6 +86,7 @@ public class SearchTree {
         iterateOnTree();
 
         //TODO: refactor output format
+        LOGGER.info("Search-tree RAO completed with status {}", optimalLeaf.getStatus());
         SearchTreeRaoLogger.logMostLimitingElementsResults(optimalLeaf, raoParameters.getObjectiveFunction().getUnit(), relativePositiveMargins);
         return CompletableFuture.completedFuture(buildOutput());
     }
@@ -103,9 +105,12 @@ public class SearchTree {
                 } else {
                     previousDepthOptimalLeaf.clearAllVariants();
                 }
+            } else {
+                LOGGER.debug("Objective function value has not improved");
             }
             LOGGER.info("Optimal leaf - {}", optimalLeaf);
             SearchTreeRaoLogger.logRangeActions(optimalLeaf, "Optimal leaf");
+            SearchTreeRaoLogger.logMostLimitingElementsResults(optimalLeaf, raoParameters.getObjectiveFunction().getUnit(), relativePositiveMargins);
             depth += 1;
         }
     }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
@@ -8,9 +8,15 @@
 package com.farao_community.farao.search_tree_rao;
 
 import com.farao_community.farao.commons.FaraoException;
-import com.farao_community.farao.data.crac_api.*;
+import com.farao_community.farao.data.crac_api.Crac;
+import com.farao_community.farao.data.crac_api.NetworkAction;
+import com.farao_community.farao.data.crac_api.RangeAction;
+import com.farao_community.farao.data.crac_api.State;
 import com.farao_community.farao.data.crac_result_extensions.*;
-import com.farao_community.farao.rao_api.*;
+import com.farao_community.farao.rao_api.RaoInput;
+import com.farao_community.farao.rao_api.RaoParameters;
+import com.farao_community.farao.rao_api.RaoProvider;
+import com.farao_community.farao.rao_api.RaoResult;
 import com.farao_community.farao.rao_commons.InitialSensitivityAnalysis;
 import com.farao_community.farao.rao_commons.RaoData;
 import com.farao_community.farao.rao_commons.RaoUtil;
@@ -21,7 +27,8 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -282,9 +289,10 @@ public class SearchTreeRaoProvider implements RaoProvider {
 
     private void deleteCurativeVariants(Crac crac, String postOptimVariantId) {
         ResultVariantManager resultVariantManager = crac.getExtension(ResultVariantManager.class);
-        resultVariantManager.getVariants().stream().
+        List<String> variantToDelete = resultVariantManager.getVariants().stream().
                 filter(name -> !name.equals(resultVariantManager.getInitialVariantId())).
                 filter(name -> !name.equals(postOptimVariantId)).
-                forEach(variantId -> crac.getExtension(ResultVariantManager.class).deleteVariant(variantId));
+                collect(Collectors.toList());
+        variantToDelete.forEach(variantId -> crac.getExtension(ResultVariantManager.class).deleteVariant(variantId));
     }
 }

--- a/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/TreeParametersTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/TreeParametersTest.java
@@ -9,7 +9,7 @@ package com.farao_community.farao.search_tree_rao;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 /**
  * @author Peter Mitri {@literal <peter.mitri at rte-france.com>}
@@ -36,14 +36,16 @@ public class TreeParametersTest {
     @Test
     public void testPreventive() {
         searchTreeRaoParameters.setPreventiveRaoStopCriterion(SearchTreeRaoParameters.PreventiveRaoStopCriterion.MIN_OBJECTIVE);
-        TreeParameters treeParameters = TreeParameters.buildForPreventivePerimeter(searchTreeRaoParameters);
+        TreeParameters treeParameters = TreeParameters.buildForPreventivePerimeter(searchTreeRaoParameters, true);
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
+        assertTrue(treeParameters.getShouldComputeInitialSensitivity());
         compareCommonParameters(treeParameters, searchTreeRaoParameters);
 
         searchTreeRaoParameters.setPreventiveRaoStopCriterion(SearchTreeRaoParameters.PreventiveRaoStopCriterion.SECURE);
-        treeParameters = TreeParameters.buildForPreventivePerimeter(searchTreeRaoParameters);
+        treeParameters = TreeParameters.buildForPreventivePerimeter(searchTreeRaoParameters, false);
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
         assertEquals(0, treeParameters.getTargetObjectiveValue(), 1e-6);
+        assertFalse(treeParameters.getShouldComputeInitialSensitivity());
         compareCommonParameters(treeParameters, searchTreeRaoParameters);
     }
 
@@ -98,7 +100,7 @@ public class TreeParametersTest {
     @Test
     public void testDefaultSearchTreeRaoParameters() {
         SearchTreeRaoParameters defaultParameters = new SearchTreeRaoParameters();
-        TreeParameters treeParameters = TreeParameters.buildForPreventivePerimeter(null);
+        TreeParameters treeParameters = TreeParameters.buildForPreventivePerimeter(null, true);
         compareCommonParameters(treeParameters, defaultParameters);
         treeParameters = TreeParameters.buildForCurativePerimeter(null, 0.);
         compareCommonParameters(treeParameters, defaultParameters);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*
No initial load flow is computed on CNECs of curative perimeters. Thus initial flows used for loopflow and MNEC constraints cannot be found in curative RAO.

**What is the new behavior (if this is a feature change)?**
The new version computes sensitivities for all CNECs before preventive RAO and stores the result in the initial variant.
In the preventive RAO, there's no more need to compute the initial sensitivity.
