### PR TITLE
Correct curative range actions initial setpoints

### DIFF
--- a/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/utils/CommonCracCreation.java
+++ b/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/utils/CommonCracCreation.java
@@ -123,6 +123,19 @@ public final class CommonCracCreation {
         return crac;
     }
 
+    public static SimpleCrac createWithCurativePstRange() {
+        SimpleCrac crac = create();
+
+        //NetworkElement
+        NetworkElement pstElement = new NetworkElement("BBE2AA1  BBE3AA1  1", "BBE2AA1  BBE3AA1  1 name");
+
+        PstWithRange pstWithRange = new PstWithRange("pst", pstElement);
+        pstWithRange.addUsageRule(new OnStateImpl(UsageMethod.AVAILABLE, crac.getState("Contingency FR1 FR3-curative")));
+        crac.addRangeAction(pstWithRange);
+
+        return crac;
+    }
+
     public static SimpleCrac createWithSwitch() {
         SimpleCrac crac = create();
 

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoData.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoData.java
@@ -82,12 +82,8 @@ public final class RaoData {
     }
 
     private void addRaoDataVariantManager(String cracVariantId) {
-        if (cracVariantId != null) {
-            cracVariantManager = new CracVariantManager(crac, cracVariantId);
-        } else {
-            cracVariantManager = new CracVariantManager(crac);
-            cracResultManager.fillRangeActionResultsWithNetworkValues();
-        }
+        cracVariantManager = new CracVariantManager(crac, cracVariantId);
+        cracResultManager.fillRangeActionResultsWithNetworkValues();
     }
 
     public static RaoData createOnPreventiveState(Network network, Crac crac) {

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoDataTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoDataTest.java
@@ -67,6 +67,18 @@ public class RaoDataTest {
     }
 
     @Test
+    public void curativeRangeActionsInitializationTest() {
+        Crac crac1 = CommonCracCreation.createWithCurativePstRange();
+        crac1.synchronize(network);
+        RaoData raoData1 = RaoData.createOnPreventiveState(network, crac1);
+        raoData1.getCracResultManager().fillRangeActionResultsWithNetworkValues();
+        RangeActionResult rangeActionResult = crac1.getRangeAction("pst").getExtension(RangeActionResultExtension.class).getVariant(raoData1.getWorkingVariantId());
+        assertNotNull(rangeActionResult);
+        Assert.assertEquals(0, rangeActionResult.getSetPoint("none-initial"), 0.1);
+        Assert.assertEquals(Integer.valueOf(0), ((PstRangeResult) rangeActionResult).getTap("none-initial"));
+    }
+
+    @Test
     public void differentIdsForTwoClonedVariants() {
         String clonedVariantId1 = raoData.getCracVariantManager().cloneWorkingVariant();
         String clonedVariantId2 = raoData.getCracVariantManager().cloneWorkingVariant();
@@ -169,5 +181,28 @@ public class RaoDataTest {
 
         Set<BranchCnec> loopflowCnecs = raoData.getLoopflowCnecs();
         assertEquals(1, loopflowCnecs.size());
+    }
+
+    @Test
+    public void testCreateFromExistingVariant() {
+        Crac crac1 = CommonCracCreation.createWithCurativePstRange();
+        crac1.synchronize(network);
+        RaoData preventiveRaoData = RaoData.createOnPreventiveState(network, crac1);
+        String variantId = preventiveRaoData.getInitialVariantId();
+        RaoData curativeRaoData = new RaoData(
+                network,
+                crac1,
+                crac1.getState("Contingency FR1 FR3", "curative"),
+                Set.of(crac1.getState("Contingency FR1 FR3", "curative")),
+                null,
+                null,
+                variantId,
+                new HashSet<>());
+        RangeActionResult rangeActionResult = curativeRaoData.getCrac().getRangeAction("pst").getExtension(RangeActionResultExtension.class).getVariant(curativeRaoData.getWorkingVariantId());
+        assertNotNull(rangeActionResult);
+        Assert.assertEquals(0, rangeActionResult.getSetPoint("none-initial"), 0.1);
+        Assert.assertEquals(0, rangeActionResult.getSetPoint("Contingency FR1 FR3-curative"), 0.1);
+        Assert.assertEquals(Integer.valueOf(0), ((PstRangeResult) rangeActionResult).getTap("none-initial"));
+        Assert.assertEquals(Integer.valueOf(0), ((PstRangeResult) rangeActionResult).getTap("Contingency FR1 FR3-curative"));
     }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
@@ -152,7 +152,7 @@ public class SearchTreeRaoProvider implements RaoProvider {
                             curativeResults.put(optimizedState, curativeResult);
                             networkPool.releaseUsedNetwork(networkClone);
                             LOGGER.info("Curative state {} has been optimized.", optimizedState.getId());
-                        } catch (InterruptedException | NotImplementedException | FaraoException e) {
+                        } catch (InterruptedException | NotImplementedException | FaraoException | NullPointerException e) {
                             LOGGER.error("Curative state {} could not be optimized.", optimizedState.getId());
                             Thread.currentThread().interrupt();
                         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
For curative range actions, the initial set point was not correctly initialized from the network file. This lead to NaN values in the curative RAO. Sometimes, it also lead to NullPointerException at results merge step and the whole RAO failed.

**What is the new behavior (if this is a feature change)?**
Now the initial setpoints for all curative range actions are correctly set for all states (including in the preventive state, where they will be the same before and after optimization)

