### PR TITLE
Fix Json I/O that did not handle InjectionSetpoint network actions.

### DIFF
--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/json/CracImplJsonModule.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/json/CracImplJsonModule.java
@@ -15,12 +15,14 @@ import com.farao_community.farao.data.crac_impl.json.serializers.FlowCnecImplSer
 import com.farao_community.farao.data.crac_impl.json.serializers.SimpleCracSerializer;
 import com.farao_community.farao.data.crac_impl.json.serializers.SimpleStateSerializer;
 import com.farao_community.farao.data.crac_impl.json.serializers.network_action.ComplexNetworkActionSerializer;
+import com.farao_community.farao.data.crac_impl.json.serializers.network_action.InjectionSetPointSerializer;
 import com.farao_community.farao.data.crac_impl.json.serializers.network_action.PstSetPointSerializer;
 import com.farao_community.farao.data.crac_impl.json.serializers.network_action.TopologySerializer;
 import com.farao_community.farao.data.crac_impl.json.serializers.range_action.PstWithRangeSerializer;
 import com.farao_community.farao.data.crac_impl.json.serializers.usage_rule.FreeToUseSerializer;
 import com.farao_community.farao.data.crac_impl.json.serializers.usage_rule.OnStateSerializer;
 import com.farao_community.farao.data.crac_impl.remedial_action.network_action.ComplexNetworkAction;
+import com.farao_community.farao.data.crac_impl.remedial_action.network_action.InjectionSetpoint;
 import com.farao_community.farao.data.crac_impl.remedial_action.network_action.PstSetpoint;
 import com.farao_community.farao.data.crac_impl.remedial_action.network_action.Topology;
 import com.farao_community.farao.data.crac_impl.remedial_action.range_action.PstWithRange;
@@ -40,6 +42,7 @@ public class CracImplJsonModule extends SimpleModule {
         this.addSerializer(OnStateImpl.class, new OnStateSerializer());
         this.addSerializer(ComplexNetworkAction.class, new ComplexNetworkActionSerializer());
         this.addSerializer(PstSetpoint.class, new PstSetPointSerializer());
+        this.addSerializer(InjectionSetpoint.class, new InjectionSetPointSerializer());
         this.addSerializer(Topology.class, new TopologySerializer());
         this.addSerializer(PstSetpoint.class, new PstSetPointSerializer());
         this.addSerializer(ComplexNetworkAction.class, new ComplexNetworkActionSerializer());

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/json/JsonSerializationNames.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/json/JsonSerializationNames.java
@@ -72,6 +72,7 @@ public final class JsonSerializationNames {
 
     public static final String TOPOLOGY_TYPE = "topology";
     public static final String PST_SETPOINT_TYPE = "pst-setpoint";
+    public static final String INJECTION_SETPOINT_TYPE = "injection-setpoint";
     public static final String COMPLEX_NETWORK_ACTION_TYPE = "complex-network-action";
 
     public static final String FREE_TO_USE_TYPE = "free-to-use";

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/json/deserializers/NetworkActionDeserializer.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/json/deserializers/NetworkActionDeserializer.java
@@ -11,10 +11,7 @@ import com.farao_community.farao.commons.FaraoException;
 import com.farao_community.farao.data.crac_api.*;
 import com.farao_community.farao.data.crac_api.usage_rule.UsageRule;
 import com.farao_community.farao.data.crac_impl.SimpleCrac;
-import com.farao_community.farao.data.crac_impl.remedial_action.network_action.AbstractElementaryNetworkAction;
-import com.farao_community.farao.data.crac_impl.remedial_action.network_action.ComplexNetworkAction;
-import com.farao_community.farao.data.crac_impl.remedial_action.network_action.PstSetpoint;
-import com.farao_community.farao.data.crac_impl.remedial_action.network_action.Topology;
+import com.farao_community.farao.data.crac_impl.remedial_action.network_action.*;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -58,8 +55,8 @@ final class NetworkActionDeserializer {
             String type = jsonParser.nextTextValue();
             switch (type) {
                 case TOPOLOGY_TYPE:
-
                 case PST_SETPOINT_TYPE:
+                case INJECTION_SETPOINT_TYPE:
 
                     networkAction = deserializeSingleNetworkAction(jsonParser, simpleCrac, deserializationContext, type);
                     break;
@@ -156,6 +153,10 @@ final class NetworkActionDeserializer {
         switch (type) {
             case TOPOLOGY_TYPE:
                 networkAction = new Topology(id, name, operator, usageRules, ne, actionType);
+                break;
+
+            case INJECTION_SETPOINT_TYPE:
+                networkAction = new InjectionSetpoint(id, name, operator, usageRules, ne, setPoint);
                 break;
 
             case PST_SETPOINT_TYPE:

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/json/serializers/network_action/InjectionSetPointSerializer.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/json/serializers/network_action/InjectionSetPointSerializer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.farao_community.farao.data.crac_impl.json.serializers.network_action;
+
+import com.farao_community.farao.data.crac_api.ExtensionsHandler;
+import com.farao_community.farao.data.crac_impl.remedial_action.network_action.InjectionSetpoint;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.powsybl.commons.json.JsonUtil;
+
+import java.io.IOException;
+
+import static com.farao_community.farao.data.crac_impl.json.JsonSerializationNames.SETPOINT;
+
+/**
+ * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
+ */
+public class InjectionSetPointSerializer extends NetworkActionSerializer<InjectionSetpoint> {
+    @Override
+    public void serialize(InjectionSetpoint remedialAction, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        super.serialize(remedialAction, jsonGenerator, serializerProvider);
+        jsonGenerator.writeNumberField(SETPOINT, remedialAction.getSetpoint());
+        JsonUtil.writeExtensions(remedialAction, jsonGenerator, serializerProvider, ExtensionsHandler.getExtensionsSerializers());
+    }
+}

--- a/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/json/CracImportExportTest.java
+++ b/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/json/CracImportExportTest.java
@@ -15,10 +15,7 @@ import com.farao_community.farao.data.crac_api.threshold.BranchThresholdRule;
 import com.farao_community.farao.data.crac_impl.*;
 import com.farao_community.farao.data.crac_impl.range_domain.Range;
 import com.farao_community.farao.data.crac_impl.range_domain.RangeType;
-import com.farao_community.farao.data.crac_impl.remedial_action.network_action.AbstractElementaryNetworkAction;
-import com.farao_community.farao.data.crac_impl.remedial_action.network_action.ComplexNetworkAction;
-import com.farao_community.farao.data.crac_impl.remedial_action.network_action.PstSetpoint;
-import com.farao_community.farao.data.crac_impl.remedial_action.network_action.Topology;
+import com.farao_community.farao.data.crac_impl.remedial_action.network_action.*;
 import com.farao_community.farao.data.crac_impl.remedial_action.range_action.PstWithRange;
 import com.farao_community.farao.data.crac_impl.threshold.*;
 import com.farao_community.farao.data.crac_impl.usage_rule.FreeToUseImpl;
@@ -74,6 +71,7 @@ public class CracImportExportTest {
         usageRules.add(new OnStateImpl(UsageMethod.FORCED, postContingencyState));
 
         simpleCrac.addNetworkElement(new NetworkElement("pst"));
+        simpleCrac.addNetworkElement(new NetworkElement("injection"));
         simpleCrac.addNetworkAction(new PstSetpoint("pstSetpointId", "pstSetpointName", "RTE", usageRules, simpleCrac.getNetworkElement("pst"), 15, CENTERED_ON_ZERO));
 
         Set<AbstractElementaryNetworkAction> elementaryNetworkActions = new HashSet<>();
@@ -105,6 +103,16 @@ public class CracImportExportTest {
         );
         simpleCrac.addNetworkAction(complexNetworkAction);
 
+        InjectionSetpoint injectionSetpoint = new InjectionSetpoint(
+                "injectionSetpointId",
+                "injectioSetpointName",
+                "RTE",
+                new ArrayList<>(),
+                simpleCrac.getNetworkElement("injection"),
+                150
+        );
+        simpleCrac.addNetworkAction(injectionSetpoint);
+
         simpleCrac.addRangeAction(new PstWithRange(
                 "pstRangeId",
                 "pstRangeName",
@@ -130,16 +138,17 @@ public class CracImportExportTest {
 
         Crac crac = roundTrip(simpleCrac, SimpleCrac.class);
 
-        assertEquals(5, crac.getNetworkElements().size());
+        assertEquals(6, crac.getNetworkElements().size());
         assertEquals(2, crac.getInstants().size());
         assertEquals(2, crac.getContingencies().size());
         assertEquals(5, crac.getBranchCnecs().size());
         assertEquals(2, crac.getRangeActions().size());
-        assertEquals(2, crac.getNetworkActions().size());
+        assertEquals(3, crac.getNetworkActions().size());
         assertEquals(4, crac.getBranchCnec("cnec2prev").getThresholds().size());
         assertFalse(crac.getBranchCnec("cnec3prevId").isOptimized());
         assertTrue(crac.getBranchCnec("cnec4prevId").isMonitored());
         assertTrue(crac.getNetworkAction("pstSetpointId") instanceof PstSetpoint);
+        assertTrue(crac.getNetworkAction("injectionSetpointId") instanceof InjectionSetpoint);
         assertEquals("1", crac.getRangeAction("pstRangeId2").getGroupId().orElseThrow());
         assertTrue(crac.getRangeAction("pstRangeId").getGroupId().isEmpty());
         assertEquals(CENTERED_ON_ZERO, ((PstSetpoint) crac.getNetworkAction("pstSetpointId")).getRangeDefinition());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Currently, InjectionSetpoint network actions Are not handled correctly both in Json exporter and Json importer of the CRAC, preventing the user to do a correct roundtrip of a CRAC file that contains InjectionSetpoint network actions.


**What is the new behavior (if this is a feature change)?**
InjectionSetpoint network actions are now handled correctly.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No
