### PR TITLE
Skip PTDF computation in curative initial sensitivity analysis

### DIFF
--- a/data/crac/crac-result-extensions/src/main/java/com/farao_community/farao/data/crac_result_extensions/ResultVariantManager.java
+++ b/data/crac/crac-result-extensions/src/main/java/com/farao_community/farao/data/crac_result_extensions/ResultVariantManager.java
@@ -74,11 +74,11 @@ public class ResultVariantManager extends AbstractExtension<Crac> {
         this.initialVariantId = initialVariantId;
     }
 
-    public String getPreOptimVariantId() {
+    public String getPrePerimeterVariantId() {
         return preOptimVariantId;
     }
 
-    public void setPreOptimVariantId(String preOptimVariantId) {
+    public void setPrePerimeterVariantId(String preOptimVariantId) {
         this.preOptimVariantId = preOptimVariantId;
     }
 

--- a/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
+++ b/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
@@ -66,7 +66,7 @@ public class LinearRao implements RaoProvider {
                 raoInput.getReferenceProgram(),
                 raoInput.getGlskProvider(),
                 raoInput.getBaseCracVariantId(),
-                raoParameters.getLoopflowCountries());
+                raoParameters);
 
         return run(raoData, raoParameters);
     }
@@ -81,7 +81,7 @@ public class LinearRao implements RaoProvider {
         this.unit = raoParameters.getObjectiveFunction().getUnit();
         SystematicSensitivityInterface systematicSensitivityInterface = RaoUtil.createSystematicSensitivityInterface(raoParameters, raoData, raoParameters.getLoopFlowApproximationLevel().shouldUpdatePtdfWithPstChange());
         IteratingLinearOptimizer iteratingLinearOptimizer = RaoUtil.createLinearOptimizer(raoParameters, systematicSensitivityInterface);
-        return run(raoData, systematicSensitivityInterface, iteratingLinearOptimizer, new InitialSensitivityAnalysis(raoData, raoParameters), raoParameters);
+        return run(raoData, systematicSensitivityInterface, iteratingLinearOptimizer, new InitialSensitivityAnalysis(raoData), raoParameters);
     }
 
     // This method is useful for testing to be able to mock systematicSensitivityComputation
@@ -98,7 +98,7 @@ public class LinearRao implements RaoProvider {
         StringBuilder skipReason = new StringBuilder();
         if (skipOptim(raoParameters, raoData, skipReason)) {
             LOGGER.warn(format("Linear optimization is skipped. Cause: %s", skipReason));
-            return CompletableFuture.completedFuture(buildSuccessfulRaoResultAndClearVariants(raoData, raoData.getInitialVariantId(), systematicSensitivityInterface));
+            return CompletableFuture.completedFuture(buildSuccessfulRaoResultAndClearVariants(raoData, raoData.getPreOptimVariantId(), systematicSensitivityInterface));
         }
 
         String bestVariantId = iteratingLinearOptimizer.optimize(raoData);
@@ -131,7 +131,7 @@ public class LinearRao implements RaoProvider {
     private RaoResult buildSuccessfulRaoResultAndClearVariants(RaoData raoData, String postOptimVariantId, SystematicSensitivityInterface systematicSensitivityInterface) {
         // build RaoResult
         RaoResult raoResult = new RaoResult(RaoResult.Status.SUCCESS);
-        raoResult.setPreOptimVariantId(raoData.getInitialVariantId());
+        raoResult.setPreOptimVariantId(raoData.getPreOptimVariantId());
         raoResult.setPostOptimVariantId(postOptimVariantId);
 
         // build extension
@@ -146,7 +146,7 @@ public class LinearRao implements RaoProvider {
             minMargin, unit, raoData.getCracResult(postOptimVariantId).getNetworkSecurityStatus(),
             objFunctionValue));
 
-        raoData.getCracVariantManager().clearWithKeepingCracResults(Arrays.asList(raoData.getInitialVariantId(), postOptimVariantId));
+        raoData.getCracVariantManager().clearWithKeepingCracResults(Arrays.asList(raoData.getPreOptimVariantId(), postOptimVariantId));
         return raoResult;
     }
 
@@ -156,8 +156,8 @@ public class LinearRao implements RaoProvider {
     private RaoResult buildFailedRaoResultAndClearVariants(RaoData raoData, Exception e) {
         // build RaoResult
         RaoResult raoResult = new RaoResult(RaoResult.Status.FAILURE);
-        raoResult.setPreOptimVariantId(raoData.getInitialVariantId());
-        raoResult.setPostOptimVariantId(raoData.getInitialVariantId());
+        raoResult.setPreOptimVariantId(raoData.getPreOptimVariantId());
+        raoResult.setPostOptimVariantId(raoData.getPreOptimVariantId());
 
         // build extension
         LinearRaoResult resultExtension = new LinearRaoResult();
@@ -165,7 +165,7 @@ public class LinearRao implements RaoProvider {
         resultExtension.setErrorMessage(e.getMessage());
         raoResult.addExtension(LinearRaoResult.class, resultExtension);
 
-        raoData.getCracVariantManager().clearWithKeepingCracResults(Collections.singletonList(raoData.getInitialVariantId()));
+        raoData.getCracVariantManager().clearWithKeepingCracResults(Collections.singletonList(raoData.getPreOptimVariantId()));
 
         return raoResult;
     }

--- a/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
+++ b/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
@@ -67,7 +67,6 @@ public class LinearRao implements RaoProvider {
                 raoInput.getGlskProvider(),
                 raoInput.getBaseCracVariantId(),
                 raoParameters);
-
         return run(raoData, raoParameters);
     }
 

--- a/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
+++ b/ra-optimisation/linear-rao/src/main/java/com/farao_community/farao/linear_rao/LinearRao.java
@@ -90,6 +90,7 @@ public class LinearRao implements RaoProvider {
         try {
             initialSensitivityAnalysis.run();
         } catch (SensitivityAnalysisException e) {
+            LOGGER.error("Initial sensitivity analysis failed :", e);
             return CompletableFuture.completedFuture(buildFailedRaoResultAndClearVariants(raoData, e));
         }
 

--- a/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/LinearRaoTest.java
+++ b/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/LinearRaoTest.java
@@ -29,6 +29,8 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.Collections;
+
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
@@ -60,7 +62,7 @@ public class LinearRaoTest {
         crac = CracImporters.importCrac("small-crac.json", getClass().getResourceAsStream("/small-crac.json"));
         network = NetworkImportsUtil.import12NodesNetwork();
         crac.synchronize(network);
-        raoData = Mockito.spy(RaoData.createOnPreventiveState(network, crac));
+        raoData = Mockito.spy(new RaoData(network, crac, crac.getPreventiveState(), Collections.singleton(crac.getPreventiveState()), null, null, null, new RaoParameters()));
         CracResultManager spiedCracResultManager = Mockito.spy(raoData.getCracResultManager());
         Mockito.when(raoData.getCracResultManager()).thenReturn(spiedCracResultManager);
         Mockito.doNothing().when(spiedCracResultManager).fillCnecResultWithFlows();

--- a/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/LinearRaoTest.java
+++ b/ra-optimisation/linear-rao/src/test/java/com/farao_community/farao/linear_rao/LinearRaoTest.java
@@ -100,7 +100,7 @@ public class LinearRaoTest {
 
     @Test(expected = LinearOptimisationException.class)
     public void runLinearRaoWithLinearOptimisationError() {
-        Mockito.doNothing().when(initialSensitivityAnalysis).run();
+        Mockito.when(initialSensitivityAnalysis.run()).thenReturn(null);
         Mockito.when(iteratingLinearOptimizer.optimize(any())).thenThrow(new LinearOptimisationException("error with optim"));
         linearRao.run(raoData, systematicSensitivityInterface, iteratingLinearOptimizer, initialSensitivityAnalysis, raoParameters).join();
     }

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracResultManager.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracResultManager.java
@@ -8,6 +8,7 @@
 package com.farao_community.farao.rao_commons;
 
 import com.farao_community.farao.commons.Unit;
+import com.farao_community.farao.data.crac_api.Contingency;
 import com.farao_community.farao.data.crac_api.PstRange;
 import com.farao_community.farao.data.crac_api.RangeAction;
 import com.farao_community.farao.data.crac_api.State;
@@ -20,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -127,11 +129,12 @@ public class CracResultManager {
      * This method returns a set of State which are equal or after a given state.
      */
     private Set<State> getStatesAfter(State referenceState) {
-        if (referenceState.getContingency().isEmpty()) {
+        Optional<Contingency> referenceContingency = referenceState.getContingency();
+        if (referenceContingency.isEmpty()) {
             return raoData.getCrac().getStates();
         } else {
             return  raoData.getCrac().
-                getStates(referenceState.getContingency().get()).stream().
+                getStates(referenceContingency.get()).stream().
                 filter(state -> state.getInstant().getSeconds() >= referenceState.getInstant().getSeconds())
                 .collect(Collectors.toSet());
         }

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracResultManager.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracResultManager.java
@@ -10,6 +10,7 @@ package com.farao_community.farao.rao_commons;
 import com.farao_community.farao.commons.Unit;
 import com.farao_community.farao.data.crac_api.PstRange;
 import com.farao_community.farao.data.crac_api.RangeAction;
+import com.farao_community.farao.data.crac_api.State;
 import com.farao_community.farao.data.crac_loopflow_extension.CnecLoopFlowExtension;
 import com.farao_community.farao.data.crac_result_extensions.*;
 import com.farao_community.farao.loopflow_computation.LoopFlowResult;
@@ -19,6 +20,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Joris Mancini {@literal <joris.mancini at rte-france.com>}
@@ -37,13 +40,16 @@ public class CracResultManager {
      * with values in network of the working variant.
      */
     public void fillRangeActionResultsWithNetworkValues() {
+        Set<State> statesAfterOptimizedState = getStatesAfter(raoData.getOptimizedState());
         for (RangeAction rangeAction : raoData.getCrac().getRangeActions()) {
-            double valueInNetwork = rangeAction.getCurrentValue(raoData.getNetwork());
+            double setPointValueInNetwork = rangeAction.getCurrentValue(raoData.getNetwork());
             RangeActionResultExtension rangeActionResultMap = rangeAction.getExtension(RangeActionResultExtension.class);
             RangeActionResult rangeActionResult = rangeActionResultMap.getVariant(raoData.getWorkingVariantId());
-            rangeActionResult.setSetPoint(raoData.getOptimizedState().getId(), valueInNetwork);
+            statesAfterOptimizedState.forEach(state -> rangeActionResult.setSetPoint(state.getId(), setPointValueInNetwork));
             if (rangeAction instanceof PstRange) {
-                ((PstRangeResult) rangeActionResult).setTap(raoData.getOptimizedState().getId(), ((PstRange) rangeAction).computeTapPosition(valueInNetwork));
+                PstRangeResult pstRangeResult = (PstRangeResult) rangeActionResult;
+                int tapValueInNetwork = ((PstRange) rangeAction).computeTapPosition(setPointValueInNetwork);
+                statesAfterOptimizedState.forEach(state -> pstRangeResult.setTap(state.getId(), tapValueInNetwork));
             }
         }
     }
@@ -85,6 +91,8 @@ public class CracResultManager {
             LOGGER.debug(String.format("Expected minimum margin: %.2f", linearProblem.getMinimumMarginVariable().solutionValue()));
             LOGGER.debug(String.format("Expected optimisation criterion: %.2f", linearProblem.getObjective().value()));
         }
+        Set<State> statesAfterOptimizedState = getStatesAfter(raoData.getOptimizedState());
+
         for (RangeAction rangeAction : raoData.getCrac().getRangeActions()) {
             if (rangeAction instanceof PstRange) {
                 RangeActionResultExtension pstRangeResultMap = rangeAction.getExtension(RangeActionResultExtension.class);
@@ -105,10 +113,27 @@ public class CracResultManager {
                     approximatedPostOptimTap = ((PstRangeResult) pstRangeResultMap.getVariant(raoData.getPreOptimVariantId())).getTap(raoData.getOptimizedState().getId());
                     approximatedPostOptimAngle = pstRangeResultMap.getVariant(raoData.getPreOptimVariantId()).getSetPoint(raoData.getOptimizedState().getId());
                 }
+
                 PstRangeResult pstRangeResult = (PstRangeResult) pstRangeResultMap.getVariant(raoData.getWorkingVariantId());
-                pstRangeResult.setSetPoint(raoData.getOptimizedState().getId(), approximatedPostOptimAngle);
-                pstRangeResult.setTap(raoData.getOptimizedState().getId(), approximatedPostOptimTap);
+                statesAfterOptimizedState.forEach(state -> {
+                    pstRangeResult.setSetPoint(state.getId(), approximatedPostOptimAngle);
+                    pstRangeResult.setTap(state.getId(), approximatedPostOptimTap);
+                });
             }
+        }
+    }
+
+    /**
+     * This method returns a set of State which are equal or after a given state.
+     */
+    private Set<State> getStatesAfter(State referenceState) {
+        if (referenceState.getContingency().isEmpty()) {
+            return raoData.getCrac().getStates();
+        } else {
+            return  raoData.getCrac().
+                getStates(referenceState.getContingency().get()).stream().
+                filter(state -> state.getInstant().getSeconds() >= referenceState.getInstant().getSeconds())
+                .collect(Collectors.toSet());
         }
     }
 

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracResultManager.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracResultManager.java
@@ -8,7 +8,6 @@
 package com.farao_community.farao.rao_commons;
 
 import com.farao_community.farao.commons.Unit;
-import com.farao_community.farao.data.crac_api.cnec.BranchCnec;
 import com.farao_community.farao.data.crac_api.PstRange;
 import com.farao_community.farao.data.crac_api.RangeAction;
 import com.farao_community.farao.data.crac_loopflow_extension.CnecLoopFlowExtension;
@@ -19,7 +18,6 @@ import com.powsybl.iidm.network.TwoWindingsTransformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -104,8 +102,8 @@ public class CracResultManager {
                     LOGGER.debug("Range action {} has been set to tap {}", pstRange.getName(), approximatedPostOptimTap);
                 } else {
                     // For range actions that are not available in the perimeter, copy their setpoint from the initial variant
-                    approximatedPostOptimTap = ((PstRangeResult) pstRangeResultMap.getVariant(raoData.getInitialVariantId())).getTap(raoData.getOptimizedState().getId());
-                    approximatedPostOptimAngle = pstRangeResultMap.getVariant(raoData.getInitialVariantId()).getSetPoint(raoData.getOptimizedState().getId());
+                    approximatedPostOptimTap = ((PstRangeResult) pstRangeResultMap.getVariant(raoData.getPreOptimVariantId())).getTap(raoData.getOptimizedState().getId());
+                    approximatedPostOptimAngle = pstRangeResultMap.getVariant(raoData.getPreOptimVariantId()).getSetPoint(raoData.getOptimizedState().getId());
                 }
                 PstRangeResult pstRangeResult = (PstRangeResult) pstRangeResultMap.getVariant(raoData.getWorkingVariantId());
                 pstRangeResult.setSetPoint(raoData.getOptimizedState().getId(), approximatedPostOptimAngle);
@@ -163,10 +161,6 @@ public class CracResultManager {
                 cnecResult.setLoopflowThresholdInMW(cnec.getExtension(CnecLoopFlowExtension.class).getLoopFlowConstraintInMW());
             }
         });
-    }
-
-    public void fillCnecResultsWithAbsolutePtdfSums(Map<BranchCnec, Double> ptdfSums) {
-        ptdfSums.forEach((key, value) -> key.getExtension(CnecResultExtension.class).getVariant(raoData.getInitialVariantId()).setAbsolutePtdfSum(value));
     }
 
     public void copyCommercialFlowsBetweenVariants(String originVariant, String destinationVariant) {

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracResultManager.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracResultManager.java
@@ -184,4 +184,16 @@ public class CracResultManager {
                         .setCommercialFlowInMW(cnec.getExtension(CnecResultExtension.class).getVariant(originVariant).getCommercialFlowInMW())
         );
     }
+
+    /**
+     * This method copies absolute PTDF sums from a variant's CNEC result extension to another variant's
+     * @param originVariant: the origin variant containing the PTDF sums
+     * @param destinationVariant: the destination variant
+     */
+    public void copyAbsolutePtdfSumsBetweenVariants(String originVariant, String destinationVariant) {
+        raoData.getCnecs().forEach(cnec ->
+            cnec.getExtension(CnecResultExtension.class).getVariant(destinationVariant).setAbsolutePtdfSum(
+                cnec.getExtension(CnecResultExtension.class).getVariant(originVariant).getAbsolutePtdfSum()
+            ));
+    }
 }

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracVariantManager.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracVariantManager.java
@@ -31,14 +31,13 @@ public class CracVariantManager {
     private final Map<String, SystematicSensitivityResult> systematicSensitivityResultMap;
 
     /**
-     * This constructor creates a new data variant with a pre-optimisation prefix and set it as the working variant.
-     * So accessing data after this constructor will lead directly to the newly created variant data. CRAC and
-     * sensitivity data will be empty. It will create a CRAC ResultVariantManager if it does not exist yet.
+     * This constructor takes in input the id of an already existing variant. The created CracVariantManager
+     * will rely on this given variant, which will be set as the pre-optim variant of the CracVariantManager.
      *
-     * @param crac:             CRAC object.
+     * @param crac CRAC object.
+     * @param cracVariantId given Crac Variant id, which will be used as pre-optim variant
      */
     public CracVariantManager(Crac crac, String cracVariantId) {
-        //TODO :update javadoc
 
         Objects.requireNonNull(cracVariantId);
 
@@ -57,8 +56,6 @@ public class CracVariantManager {
         variantIds.add(cracVariantId);
         systematicSensitivityResultMap.put(cracVariantId, null);
         setWorkingVariant(cracVariantId);
-        // resultVariantManager.setPrePerimeterVariantId(cracVariantId);
-
     }
 
     /**
@@ -66,10 +63,9 @@ public class CracVariantManager {
      * So accessing data after this constructor will lead directly to the newly created variant data. CRAC and
      * sensitivity data will be empty. It will create a CRAC ResultVariantManager if it does not exist yet.
      *
-     * @param crac:             CRAC object.
+     * @param crac CRAC object.
      */
     public CracVariantManager(Crac crac) {
-        //TODO : update javadoc
         this.crac = crac;
         this.variantIds = new ArrayList<>();
         this.systematicSensitivityResultMap = new HashMap<>();

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracVariantManager.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracVariantManager.java
@@ -85,7 +85,6 @@ public class CracVariantManager {
             variantId = createVariantFromWorkingVariant(VariantType.PRE_OPTIM);
         }
 
-        resultVariantManager.setPreOptimVariantId(variantId);
         setWorkingVariant(variantId);
     }
 

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracVariantManager.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracVariantManager.java
@@ -38,35 +38,28 @@ public class CracVariantManager {
      * @param crac:             CRAC object.
      */
     public CracVariantManager(Crac crac, String cracVariantId) {
+        //TODO :update javadoc
+
+        Objects.requireNonNull(cracVariantId);
+
         this.crac = crac;
         this.variantIds = new ArrayList<>();
         this.systematicSensitivityResultMap = new HashMap<>();
-
         ResultVariantManager resultVariantManager = crac.getExtension(ResultVariantManager.class);
-        if (cracVariantId != null) {
-            if (resultVariantManager == null) {
-                throw new FaraoException(format("Rao data is based on an existing variant %s but CRAC variant manager does not exist.", cracVariantId));
-            }
-            if (!resultVariantManager.getVariants().contains(cracVariantId)) {
-                throw new FaraoException(format("Rao data is based on an existing variant %s but this variant does not exist.", cracVariantId));
-            }
-            variantIds.add(cracVariantId);
-            systematicSensitivityResultMap.put(cracVariantId, null);
-            setWorkingVariant(cracVariantId);
-            resultVariantManager.setPreOptimVariantId(cracVariantId);
-        } else { // Case no base CRAC variant is defined so a new CRAC variant must be created
-            String variantId;
-            if (resultVariantManager == null) {
-                resultVariantManager = new ResultVariantManager();
-                crac.addExtension(ResultVariantManager.class, resultVariantManager);
-                variantId = createVariantFromWorkingVariant(VariantType.INITIAL);
-                resultVariantManager.setInitialVariantId(variantId);
-                resultVariantManager.setPreOptimVariantId(variantId);
-            } else {
-                variantId = createVariantFromWorkingVariant(VariantType.PRE_OPTIM);
-            }
-            setWorkingVariant(variantId);
+
+        if (resultVariantManager == null) {
+            throw new FaraoException(format("Rao data is based on an existing variant %s but CRAC variant manager does not exist.", cracVariantId));
         }
+        if (!resultVariantManager.getVariants().contains(cracVariantId)) {
+            throw new FaraoException(format("Rao data is based on an existing variant %s but this variant does not exist.", cracVariantId));
+        }
+
+        variantIds.add(cracVariantId);
+        // TODO : strange, shouldn't we copy some sensi result here ?
+        systematicSensitivityResultMap.put(cracVariantId, null);
+        setWorkingVariant(cracVariantId);
+        resultVariantManager.setPreOptimVariantId(cracVariantId);
+
     }
 
     /**
@@ -77,7 +70,23 @@ public class CracVariantManager {
      * @param crac:             CRAC object.
      */
     public CracVariantManager(Crac crac) {
-        this(crac, null);
+        //TODO : update javadoc
+        this.crac = crac;
+        this.variantIds = new ArrayList<>();
+        this.systematicSensitivityResultMap = new HashMap<>();
+        ResultVariantManager resultVariantManager = crac.getExtension(ResultVariantManager.class);
+
+        String variantId;
+        if (resultVariantManager == null) {
+            resultVariantManager = new ResultVariantManager();
+            crac.addExtension(ResultVariantManager.class, resultVariantManager);
+            variantId = createVariantFromWorkingVariant(VariantType.INITIAL);
+        } else {
+            variantId = createVariantFromWorkingVariant(VariantType.PRE_OPTIM);
+        }
+
+        resultVariantManager.setPreOptimVariantId(variantId);
+        setWorkingVariant(variantId);
     }
 
     public List<String> getVariantIds() {
@@ -91,7 +100,7 @@ public class CracVariantManager {
         return workingVariantId;
     }
 
-    public String getInitialVariantId() {
+    public String getPreOptimVariantId() {
         if (variantIds.isEmpty()) {
             throw new FaraoException("No variants are present in the data");
         }

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracVariantManager.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/CracVariantManager.java
@@ -55,10 +55,9 @@ public class CracVariantManager {
         }
 
         variantIds.add(cracVariantId);
-        // TODO : strange, shouldn't we copy some sensi result here ?
         systematicSensitivityResultMap.put(cracVariantId, null);
         setWorkingVariant(cracVariantId);
-        resultVariantManager.setPreOptimVariantId(cracVariantId);
+        // resultVariantManager.setPrePerimeterVariantId(cracVariantId);
 
     }
 

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/InitialSensitivityAnalysis.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/InitialSensitivityAnalysis.java
@@ -8,23 +8,25 @@ package com.farao_community.farao.rao_commons;
 
 import com.farao_community.farao.commons.Unit;
 import com.farao_community.farao.commons.ZonalData;
-import com.farao_community.farao.data.crac_api.Crac;
+import com.farao_community.farao.commons.ZonalDataImpl;
 import com.farao_community.farao.data.crac_api.cnec.BranchCnec;
-import com.farao_community.farao.data.refprog.reference_program.ReferenceProgram;
+import com.farao_community.farao.data.crac_result_extensions.CnecResultExtension;
+import com.farao_community.farao.data.crac_result_extensions.ResultVariantManager;
+import com.farao_community.farao.data.refprog.reference_program.ReferenceProgramArea;
 import com.farao_community.farao.loopflow_computation.LoopFlowComputation;
 import com.farao_community.farao.loopflow_computation.LoopFlowResult;
 import com.farao_community.farao.rao_api.RaoParameters;
 import com.farao_community.farao.rao_commons.objective_function_evaluator.ObjectiveFunctionEvaluator;
 import com.farao_community.farao.sensitivity_analysis.SystematicSensitivityInterface;
 import com.farao_community.farao.sensitivity_analysis.SystematicSensitivityResult;
-import com.powsybl.iidm.network.Country;
-import com.powsybl.iidm.network.Network;
+import com.farao_community.farao.util.EICode;
 import com.powsybl.sensitivity.factors.variables.LinearGlsk;
-import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This class aims at performing the initial sensitivity analysis of a RAO, the one
@@ -37,45 +39,53 @@ public class InitialSensitivityAnalysis {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InitialSensitivityAnalysis.class);
     private RaoData raoData;
-    private RaoParameters raoParameters;
     private SystematicSensitivityInterface systematicSensitivityInterface;
+    private RaoParameters raoParameters;
 
-    public InitialSensitivityAnalysis(Network network, Crac crac, ReferenceProgram referenceProgram, ZonalData<LinearGlsk> glsk, RaoParameters raoParameters) {
-        this(new RaoData(network, crac, crac.getPreventiveState(), null, referenceProgram, glsk, null, raoParameters.getLoopflowCountries()), raoParameters);
-    }
+    public InitialSensitivityAnalysis(RaoData raoData) {
+        // it is actually quite strange to ask for a RaoData here, but it is required in
+        // order to use the fillResultsWithXXX() methods.
 
-    public InitialSensitivityAnalysis(RaoData raoData, RaoParameters raoParameters) {
         this.raoData = raoData;
-        this.raoParameters = raoParameters;
+        this.raoParameters = raoData.getRaoParameters();
         this.systematicSensitivityInterface = getSystematicSensitivityInterface();
     }
 
     public void run() {
         LOGGER.info("Initial systematic analysis [start]");
 
-        runSensitivityComputation();
+        // run sensitivity analysis
+        SystematicSensitivityResult sensitivityResult = runSensitivityComputation();
+
+        // fill results of initial variant
+        LOGGER.info("Initial systematic analysis [...] - fill reference flow values");
+        raoData.getCracResultManager().fillCnecResultWithFlows();
 
         if (raoParameters.isRaoWithLoopFlowLimitation()) {
             LOGGER.info("Initial systematic analysis [...] - fill reference loop-flow values");
             fillReferenceLoopFlow();
         }
+        if (raoParameters.getObjectiveFunction().doesRequirePtdf()) {
+            LOGGER.info("Initial systematic analysis [...] - fill zone-to-zone PTDFs");
+            fillAbsolutePtdfSums(sensitivityResult);
+        }
 
-        fillReferenceFlowsAndObjectiveFunction();
+        fillObjectiveFunction();
+
+        // tag variant as initial
+        raoData.getCrac().getExtension(ResultVariantManager.class).setInitialVariantId(raoData.getWorkingVariantId());
 
         LOGGER.info("Initial systematic analysis [end] - with initial min margin of {} MW", -raoData.getCracResult().getFunctionalCost());
     }
 
-    private void runSensitivityComputation() {
+    private SystematicSensitivityResult runSensitivityComputation() {
         SystematicSensitivityResult sensitivityResult = systematicSensitivityInterface.run(raoData.getNetwork());
         raoData.setSystematicSensitivityResult(sensitivityResult);
-        if (raoParameters.getObjectiveFunction().doesRequirePtdf()) {
-            fillAbsolutePtdfSums(raoData, raoParameters.getPtdfBoundaries(), sensitivityResult);
-        }
+        return sensitivityResult;
     }
 
-    private void fillReferenceFlowsAndObjectiveFunction() {
+    private void fillObjectiveFunction() {
         ObjectiveFunctionEvaluator objectiveFunction = RaoUtil.createObjectiveFunction(raoParameters);
-        raoData.getCracResultManager().fillCnecResultWithFlows();
         raoData.getCracResultManager().fillCracResultWithCosts(
             objectiveFunction.getFunctionalCost(raoData), objectiveFunction.getVirtualCost(raoData));
     }
@@ -85,6 +95,11 @@ public class InitialSensitivityAnalysis {
         LoopFlowResult lfResults = loopFlowComputation.buildLoopFlowsFromReferenceFlowAndPtdf(raoData.getNetwork(), raoData.getSystematicSensitivityResult(), raoData.getLoopflowCnecs());
         raoData.getCracResultManager().fillCnecLoopFlowExtensionsWithInitialResults(lfResults, raoParameters.getLoopFlowAcceptableAugmentation());
         raoData.getCracResultManager().fillCnecResultsWithLoopFlows(lfResults);
+    }
+
+    private void fillAbsolutePtdfSums(SystematicSensitivityResult sensitivityResult) {
+        Map<BranchCnec, Double> ptdfSums = AbsolutePtdfSumsComputation.computeAbsolutePtdfSums(raoData.getCnecs(), raoData.getGlskProvider(), raoParameters.getPtdfBoundaries(), sensitivityResult);
+        ptdfSums.forEach((key, value) -> key.getExtension(CnecResultExtension.class).getVariant(raoData.getWorkingVariantId()).setAbsolutePtdfSum(value));
     }
 
     private SystematicSensitivityInterface getSystematicSensitivityInterface() {
@@ -100,17 +115,41 @@ public class InitialSensitivityAnalysis {
             .withFallbackParameters(raoParameters.getFallbackSensitivityAnalysisParameters())
             .withRangeActionSensitivities(raoData.getAvailableRangeActions(), raoData.getCnecs(), flowUnits);
 
-        if (raoParameters.getObjectiveFunction().doesRequirePtdf()) {
-            builder.withPtdfSensitivities(raoData.getGlskProvider(), raoData.getCnecs(), Collections.singleton(Unit.MEGAWATT));
+        if (raoParameters.getObjectiveFunction().doesRequirePtdf() && raoParameters.isRaoWithLoopFlowLimitation()) {
+            Set<String> eic = getEicForObjectiveFunction();
+            eic.addAll(getEicForLoopFlows());
+            builder.withPtdfSensitivities(getGlskForEic(eic), raoData.getCnecs(), Collections.singleton(Unit.MEGAWATT));
         } else if (raoParameters.isRaoWithLoopFlowLimitation()) {
-            builder.withPtdfSensitivities(raoData.getGlskProvider(), raoData.getLoopflowCnecs(), Collections.singleton(Unit.MEGAWATT));
+            builder.withPtdfSensitivities(getGlskForEic(getEicForLoopFlows()), raoData.getLoopflowCnecs(), Collections.singleton(Unit.MEGAWATT));
+        } else if (raoParameters.getObjectiveFunction().doesRequirePtdf()) {
+            builder.withPtdfSensitivities(getGlskForEic(getEicForObjectiveFunction()), raoData.getCnecs(), Collections.singleton(Unit.MEGAWATT));
         }
 
         return builder.build();
     }
 
-    private static void fillAbsolutePtdfSums(RaoData raoData, List<Pair<Country, Country>> boundaries, SystematicSensitivityResult sensitivityResult) {
-        Map<BranchCnec, Double> ptdfSums = AbsolutePtdfSumsComputation.computeAbsolutePtdfSums(raoData.getCnecs(), raoData.getGlskProvider(), boundaries, sensitivityResult);
-        raoData.getCracResultManager().fillCnecResultsWithAbsolutePtdfSums(ptdfSums);
+    private Set<String> getEicForObjectiveFunction() {
+        return raoParameters.getPtdfBoundaries().stream().
+            flatMap(pair -> Stream.of(pair.getLeft(), pair.getRight())).
+            map(country -> new EICode(country).getCode()).
+            collect(Collectors.toSet());
+    }
+
+    private Set<String> getEicForLoopFlows() {
+        return raoData.getReferenceProgram().getListOfAreas().stream().
+            map(ReferenceProgramArea::getAreaCode).
+            collect(Collectors.toSet());
+    }
+
+    private ZonalData<LinearGlsk> getGlskForEic(Set<String> listEicCode) {
+        Map<String, LinearGlsk> glskBoundaries = new HashMap<>();
+
+        raoData.getGlskProvider().getDataPerZone().forEach((k, v) -> {
+            if (listEicCode.contains(k)) {
+                glskBoundaries.put(k, v);
+            }
+        });
+
+        return new ZonalDataImpl<>(glskBoundaries);
     }
 }

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/InitialSensitivityAnalysis.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/InitialSensitivityAnalysis.java
@@ -51,7 +51,7 @@ public class InitialSensitivityAnalysis {
         this.systematicSensitivityInterface = getSystematicSensitivityInterface();
     }
 
-    public void run() {
+    public SystematicSensitivityResult run() {
         LOGGER.info("Initial systematic analysis [start]");
 
         // run sensitivity analysis
@@ -80,6 +80,8 @@ public class InitialSensitivityAnalysis {
         fillObjectiveFunction();
 
         LOGGER.info("Initial systematic analysis [end] - with initial min margin of {} MW", -raoData.getCracResult().getFunctionalCost());
+
+        return sensitivityResult;
     }
 
     private SystematicSensitivityResult runSensitivityComputation() {

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/InitialSensitivityAnalysis.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/InitialSensitivityAnalysis.java
@@ -44,7 +44,7 @@ public class InitialSensitivityAnalysis {
 
     public InitialSensitivityAnalysis(RaoData raoData) {
         // it is actually quite strange to ask for a RaoData here, but it is required in
-        // order to use the fillResultsWithXXX() methods.
+        // order to use the fillResultsWithXXX() methods of the CracResultManager.
 
         this.raoData = raoData;
         this.raoParameters = raoData.getRaoParameters();
@@ -57,7 +57,14 @@ public class InitialSensitivityAnalysis {
         // run sensitivity analysis
         SystematicSensitivityResult sensitivityResult = runSensitivityComputation();
 
+        // tag initial variant
+        raoData.getCrac().getExtension(ResultVariantManager.class).setInitialVariantId(raoData.getWorkingVariantId());
+        raoData.getCrac().getExtension(ResultVariantManager.class).setPreOptimVariantId(raoData.getWorkingVariantId());
+
         // fill results of initial variant
+        LOGGER.info("Initial systematic analysis [...] - fill initial range actions values");
+        raoData.getCracResultManager().fillRangeActionResultsWithNetworkValues();
+
         LOGGER.info("Initial systematic analysis [...] - fill reference flow values");
         raoData.getCracResultManager().fillCnecResultWithFlows();
 
@@ -71,9 +78,6 @@ public class InitialSensitivityAnalysis {
         }
 
         fillObjectiveFunction();
-
-        // tag variant as initial
-        raoData.getCrac().getExtension(ResultVariantManager.class).setInitialVariantId(raoData.getWorkingVariantId());
 
         LOGGER.info("Initial systematic analysis [end] - with initial min margin of {} MW", -raoData.getCracResult().getFunctionalCost());
     }

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/InitialSensitivityAnalysis.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/InitialSensitivityAnalysis.java
@@ -59,7 +59,7 @@ public class InitialSensitivityAnalysis {
 
         // tag initial variant
         raoData.getCrac().getExtension(ResultVariantManager.class).setInitialVariantId(raoData.getWorkingVariantId());
-        raoData.getCrac().getExtension(ResultVariantManager.class).setPreOptimVariantId(raoData.getWorkingVariantId());
+        raoData.getCrac().getExtension(ResultVariantManager.class).setPrePerimeterVariantId(raoData.getWorkingVariantId());
 
         // fill results of initial variant
         LOGGER.info("Initial systematic analysis [...] - fill initial range actions values");

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoData.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoData.java
@@ -77,6 +77,7 @@ public final class RaoData {
         this.raoParameters = raoParameters;
         cracResultManager = new CracResultManager(this);
         addRaoDataVariantManager(baseCracVariantId);
+        cracResultManager.fillRangeActionResultsWithNetworkValues();
 
         computePerimeterCnecs();
         computeLoopflowCnecs();
@@ -88,7 +89,6 @@ public final class RaoData {
         } else {
             cracVariantManager = new CracVariantManager(crac);
         }
-        cracResultManager.fillRangeActionResultsWithNetworkValues();
     }
 
     public static RaoData createOnPreventiveState(Network network, Crac crac) {
@@ -160,7 +160,7 @@ public final class RaoData {
     private void computeLoopflowCnecs() {
         if (!raoParameters.getLoopflowCountries().isEmpty()) {
             loopflowCnecs = perimeterCnecs.stream()
-                .filter(cnec -> !Objects.isNull(cnec.getExtension(CnecLoopFlowExtension.class)) && cnecIsInCountryList(cnec, network, loopflowCountries))
+                .filter(cnec -> !Objects.isNull(cnec.getExtension(CnecLoopFlowExtension.class)) && cnecIsInCountryList(cnec, network, raoParameters.getLoopflowCountries()))
                 .collect(Collectors.toSet());
         } else {
             loopflowCnecs = perimeterCnecs.stream()

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoData.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoData.java
@@ -91,22 +91,6 @@ public final class RaoData {
         }
     }
 
-    public static RaoData createOnPreventiveState(Network network, Crac crac) {
-        return createOnPreventiveStateBasedOnExistingVariant(network, crac, null);
-    }
-
-    public static RaoData createOnPreventiveStateBasedOnExistingVariant(Network network, Crac crac, String cracVariantId) {
-        return new RaoData(
-                network,
-                crac,
-                crac.getPreventiveState(),
-                Collections.singleton(crac.getPreventiveState()),
-                null,
-                null,
-                cracVariantId,
-                new RaoParameters());
-    }
-
     public static RaoData create(Network network, RaoData raoData) {
         return new RaoData(
                 network,

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/CoreProblemFiller.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/CoreProblemFiller.java
@@ -193,7 +193,7 @@ public class CoreProblemFiller implements ProblemFiller {
      * AV[r] >= initialSetPoint[r] - S[r]     (POSITIVE)
      */
     private void buildRangeActionConstraints(RaoData raoData, LinearProblem linearProblem) {
-        String preOptimVariantId = raoData.getCrac().getExtension(ResultVariantManager.class).getPreOptimVariantId();
+        String preOptimVariantId = raoData.getCrac().getExtension(ResultVariantManager.class).getPrePerimeterVariantId();
         raoData.getAvailableRangeActions().forEach(rangeAction -> {
             double initialSetPoint = rangeAction.getExtension(RangeActionResultExtension.class).getVariant(preOptimVariantId).getSetPoint(raoData.getOptimizedState().getId());
             MPConstraint varConstraintNegative = linearProblem.addAbsoluteRangeActionVariationConstraint(-initialSetPoint, linearProblem.infinity(), rangeAction, LinearProblem.AbsExtension.NEGATIVE);

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxMinRelativeMarginFiller.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxMinRelativeMarginFiller.java
@@ -11,6 +11,7 @@ import com.farao_community.farao.commons.Unit;
 import com.farao_community.farao.data.crac_api.Side;
 import com.farao_community.farao.data.crac_api.cnec.BranchCnec;
 import com.farao_community.farao.data.crac_result_extensions.CnecResultExtension;
+import com.farao_community.farao.data.crac_result_extensions.ResultVariantManager;
 import com.farao_community.farao.rao_commons.RaoData;
 import com.farao_community.farao.rao_commons.linear_optimisation.LinearProblem;
 import com.google.ortools.linearsolver.MPConstraint;
@@ -70,12 +71,15 @@ public class MaxMinRelativeMarginFiller extends MaxMinMarginFiller {
      * Define the minimum relative margin (like absolute margin but by dividing by sum of PTDFs)
      */
     private void buildMinimumRelativeMarginConstraints(RaoData raoData, LinearProblem linearProblem) {
+
+        String initialVariantId = raoData.getCrac().getExtension(ResultVariantManager.class).getInitialVariantId();
+
         MPVariable minRelMarginVariable = linearProblem.getMinimumRelativeMarginVariable();
         if (minRelMarginVariable == null) {
             throw new FaraoException("Minimum relative margin variable has not yet been created");
         }
         raoData.getCnecs().stream().filter(BranchCnec::isOptimized).forEach(cnec -> {
-            double marginCoef = 1 / Math.max(cnec.getExtension(CnecResultExtension.class).getVariant(raoData.getInitialVariantId()).getAbsolutePtdfSum(), ptdfSumLowerBound);
+            double marginCoef = 1 / Math.max(cnec.getExtension(CnecResultExtension.class).getVariant(initialVariantId).getAbsolutePtdfSum(), ptdfSumLowerBound);
             MPVariable flowVariable = linearProblem.getFlowVariable(cnec);
 
             if (flowVariable == null) {

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizer.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizer.java
@@ -76,7 +76,7 @@ public class IteratingLinearOptimizer {
     public String optimize(RaoData raoData) {
         this.raoData = raoData;
         cracVariantManager = raoData.getCracVariantManager();
-        bestVariantId = raoData.getInitialVariantId();
+        bestVariantId = raoData.getPreOptimVariantId();
         if (!raoData.hasSensitivityValues()) {
             runSensitivityAndUpdateResults();
         }
@@ -158,7 +158,7 @@ public class IteratingLinearOptimizer {
 
     private String getBestVariantWithSafeDelete(String variantToDelete) {
         cracVariantManager.setWorkingVariant(bestVariantId);
-        if (!variantToDelete.equals(raoData.getInitialVariantId())) {
+        if (!variantToDelete.equals(raoData.getPreOptimVariantId())) {
             cracVariantManager.deleteVariant(variantToDelete, false);
         }
         return bestVariantId;
@@ -166,7 +166,7 @@ public class IteratingLinearOptimizer {
 
     private void updateBestVariantId(String optimizedVariantId) {
         cracVariantManager.setWorkingVariant(optimizedVariantId);
-        if (!bestVariantId.equals(raoData.getInitialVariantId())) {
+        if (!bestVariantId.equals(raoData.getPreOptimVariantId())) {
             cracVariantManager.deleteVariant(bestVariantId, false);
         }
         bestVariantId = optimizedVariantId;

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/objective_function_evaluator/MinMarginEvaluator.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/objective_function_evaluator/MinMarginEvaluator.java
@@ -93,7 +93,7 @@ public class MinMarginEvaluator implements CostEvaluator {
         return marginsInAmpere.stream().min(Double::compareTo).orElseThrow(NoSuchElementException::new);
     }
 
-    private List<Double> getMarginsInAmpereFromMegawattConversion(RaoData raoData) {
+    List<Double> getMarginsInAmpereFromMegawattConversion(RaoData raoData) {
         String initialVariantId = raoData.getCrac().getExtension(ResultVariantManager.class).getInitialVariantId();
         return raoData.getCnecs().stream().filter(BranchCnec::isOptimized).map(cnec -> {
                 double leftFlowInMW = raoData.getSystematicSensitivityResult().getReferenceFlow(cnec);

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/CracResultManagerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/CracResultManagerTest.java
@@ -8,7 +8,6 @@
 package com.farao_community.farao.rao_commons;
 
 import com.farao_community.farao.commons.Unit;
-import com.farao_community.farao.data.crac_api.cnec.BranchCnec;
 import com.farao_community.farao.data.crac_api.Crac;
 import com.farao_community.farao.data.crac_impl.utils.CommonCracCreation;
 import com.farao_community.farao.data.crac_impl.utils.NetworkImportsUtil;
@@ -20,8 +19,6 @@ import com.powsybl.iidm.network.Network;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -96,19 +93,11 @@ public class CracResultManagerTest {
     }
 
     @Test
-    public void testFillCnecResultsWithAbsolutePtdfSums() {
-        Map<BranchCnec, Double> ptdfSums = Map.of(raoData.getCrac().getBranchCnec("cnec1basecase"), 0.5, raoData.getCrac().getBranchCnec("cnec2basecase"), 1.3);
-        raoData.getCracResultManager().fillCnecResultsWithAbsolutePtdfSums(ptdfSums);
-        assertEquals(0.5, raoData.getCrac().getBranchCnec("cnec1basecase").getExtension(CnecResultExtension.class).getVariant(raoData.getInitialVariantId()).getAbsolutePtdfSum(), DOUBLE_TOLERANCE);
-        assertEquals(1.3, raoData.getCrac().getBranchCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(raoData.getInitialVariantId()).getAbsolutePtdfSum(), DOUBLE_TOLERANCE);
-    }
-
-    @Test
     public void testCopyCommercialFlowsBetweenVariants() {
-        raoData.getCrac().getBranchCnec("cnec1basecase").getExtension(CnecResultExtension.class).getVariant(raoData.getInitialVariantId()).setCommercialFlowInMW(150.6);
-        raoData.getCrac().getBranchCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(raoData.getInitialVariantId()).setCommercialFlowInMW(653.7);
+        raoData.getCrac().getBranchCnec("cnec1basecase").getExtension(CnecResultExtension.class).getVariant(raoData.getPreOptimVariantId()).setCommercialFlowInMW(150.6);
+        raoData.getCrac().getBranchCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(raoData.getPreOptimVariantId()).setCommercialFlowInMW(653.7);
         String var = raoData.getCracVariantManager().cloneWorkingVariant();
-        raoData.getCracResultManager().copyCommercialFlowsBetweenVariants(raoData.getInitialVariantId(), var);
+        raoData.getCracResultManager().copyCommercialFlowsBetweenVariants(raoData.getPreOptimVariantId(), var);
         assertEquals(150.6, raoData.getCrac().getBranchCnec("cnec1basecase").getExtension(CnecResultExtension.class).getVariant(var).getCommercialFlowInMW(), DOUBLE_TOLERANCE);
         assertEquals(653.7, raoData.getCrac().getBranchCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(var).getCommercialFlowInMW(), DOUBLE_TOLERANCE);
     }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/CracResultManagerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/CracResultManagerTest.java
@@ -14,11 +14,14 @@ import com.farao_community.farao.data.crac_impl.utils.NetworkImportsUtil;
 import com.farao_community.farao.data.crac_loopflow_extension.CnecLoopFlowExtension;
 import com.farao_community.farao.data.crac_result_extensions.CnecResultExtension;
 import com.farao_community.farao.loopflow_computation.LoopFlowResult;
+import com.farao_community.farao.rao_api.RaoParameters;
 import com.farao_community.farao.sensitivity_analysis.SystematicSensitivityResult;
 import com.powsybl.iidm.network.Network;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
@@ -45,7 +48,7 @@ public class CracResultManagerTest {
         crac.getBranchCnec("cnec2basecase").addExtension(CnecLoopFlowExtension.class, cnecLoopFlowExtension2);
         crac.getBranchCnec("cnec2basecase").setReliabilityMargin(20);
 
-        raoData = RaoData.createOnPreventiveState(network, crac);
+        raoData = new RaoData(network, crac, crac.getPreventiveState(), Collections.singleton(crac.getPreventiveState()), null, null, null, new RaoParameters());
 
         loopFlowResult = new LoopFlowResult();
         loopFlowResult.addCnecResult(crac.getBranchCnec("cnec1basecase"), -252, 128., -124.);

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/InitialSensitivityAnalysisTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/InitialSensitivityAnalysisTest.java
@@ -14,8 +14,6 @@ import com.farao_community.farao.rao_api.RaoParameters;
 import com.powsybl.iidm.network.Network;
 import org.junit.Test;
 
-import java.util.HashSet;
-
 import static junit.framework.TestCase.assertNotNull;
 
 /**
@@ -28,10 +26,9 @@ public class InitialSensitivityAnalysisTest {
 
         Network network = NetworkImportsUtil.import12NodesNetwork();
         Crac crac = CommonCracCreation.create();
-        RaoData raoData = new RaoData(network, crac, crac.getPreventiveState(), crac.getStates(), null, null, null, new HashSet<>());
-        RaoParameters raoParameters = new RaoParameters();
+        RaoData raoData = new RaoData(network, crac, crac.getPreventiveState(), crac.getStates(), null, null, null, new RaoParameters());
 
-        InitialSensitivityAnalysis initialSensitivityAnalysis = new InitialSensitivityAnalysis(raoData, raoParameters);
+        InitialSensitivityAnalysis initialSensitivityAnalysis = new InitialSensitivityAnalysis(raoData);
         assertNotNull(initialSensitivityAnalysis);
     }
 }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoDataTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoDataTest.java
@@ -45,8 +45,8 @@ public class RaoDataTest {
         crac.synchronize(network);
         crac.getBranchCnec("cnec1basecase").addExtension(CnecLoopFlowExtension.class, Mockito.mock(CnecLoopFlowExtension.class));
         crac.getBranchCnec("cnec2basecase").addExtension(CnecLoopFlowExtension.class, Mockito.mock(CnecLoopFlowExtension.class));
-        raoData = RaoData.createOnPreventiveState(network, crac);
-        initialVariantId  = raoData.getWorkingVariantId();
+        raoData = new RaoData(network, crac, crac.getPreventiveState(), Collections.singleton(crac.getPreventiveState()), null, null, null, new RaoParameters());
+        initialVariantId = raoData.getWorkingVariantId();
     }
 
     @Test
@@ -77,7 +77,7 @@ public class RaoDataTest {
     public void curativeRangeActionsInitializationTest() {
         Crac crac1 = CommonCracCreation.createWithCurativePstRange();
         crac1.synchronize(network);
-        RaoData raoData1 = RaoData.createOnPreventiveState(network, crac1);
+        RaoData raoData1 = new RaoData(network, crac1, crac1.getPreventiveState(), Collections.singleton(crac1.getPreventiveState()), null, null, null, new RaoParameters());
         raoData1.getCracResultManager().fillRangeActionResultsWithNetworkValues();
         RangeActionResult rangeActionResult = crac1.getRangeAction("pst").getExtension(RangeActionResultExtension.class).getVariant(raoData1.getWorkingVariantId());
         assertNotNull(rangeActionResult);
@@ -197,13 +197,13 @@ public class RaoDataTest {
     public void testCreateFromExistingVariant() {
         Crac crac1 = CommonCracCreation.createWithCurativePstRange();
         crac1.synchronize(network);
-        RaoData preventiveRaoData = RaoData.createOnPreventiveState(network, crac1);
+        RaoData preventiveRaoData = new RaoData(network, crac1, crac1.getPreventiveState(), Collections.singleton(crac1.getPreventiveState()), null, null, null, new RaoParameters());
         String variantId = preventiveRaoData.getPreOptimVariantId();
         RaoData curativeRaoData = new RaoData(
                 network,
                 crac1,
                 crac1.getState("Contingency FR1 FR3", "curative"),
-                Set.of(crac1.getState("Contingency FR1 FR3", "curative")),
+                Collections.singleton(crac1.getState("Contingency FR1 FR3", "curative")),
                 null,
                 null,
                 variantId,

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoDataTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoDataTest.java
@@ -13,6 +13,7 @@ import com.farao_community.farao.data.crac_impl.utils.CommonCracCreation;
 import com.farao_community.farao.data.crac_impl.utils.NetworkImportsUtil;
 import com.farao_community.farao.data.crac_loopflow_extension.CnecLoopFlowExtension;
 import com.farao_community.farao.data.crac_result_extensions.*;
+import com.farao_community.farao.rao_api.RaoParameters;
 import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import org.junit.Assert;
@@ -50,7 +51,7 @@ public class RaoDataTest {
 
     @Test
     public void testNoPerimeter() {
-        RaoData raoData = new RaoData(network, crac, crac.getPreventiveState(), null, null, null, null, new HashSet<>());
+        RaoData raoData = new RaoData(network, crac, crac.getPreventiveState(), null, null, null, null, new RaoParameters());
         assertEquals(crac.getBranchCnecs().size(), raoData.getCnecs().size());
     }
 
@@ -169,7 +170,7 @@ public class RaoDataTest {
 
     @Test
     public void loopflowCountries() {
-        Set<Country> loopflowCountries = raoData.getLoopflowCountries();
+        Set<Country> loopflowCountries = raoData.getRaoParameters().getLoopflowCountries();
         assertEquals(0, loopflowCountries.size());
 
         Set<BranchCnec> loopflowCnecs = raoData.getLoopflowCnecs();
@@ -178,11 +179,14 @@ public class RaoDataTest {
 
     @Test
     public void loopflowSingleCountry() {
+        RaoParameters raoParameters = new RaoParameters();
         Set<Country> countrySet = new HashSet<>();
         countrySet.add(Country.DE);
-        raoData = new RaoData(network, crac, crac.getPreventiveState(), Collections.singleton(crac.getPreventiveState()), null, null, null, countrySet);
+        raoParameters.setLoopflowCountries(countrySet);
 
-        Set<Country> loopflowCountries = raoData.getLoopflowCountries();
+        raoData = new RaoData(network, crac, crac.getPreventiveState(), Collections.singleton(crac.getPreventiveState()), null, null, null, raoParameters);
+
+        Set<Country> loopflowCountries = raoData.getRaoParameters().getLoopflowCountries();
         assertEquals(1, loopflowCountries.size());
 
         Set<BranchCnec> loopflowCnecs = raoData.getLoopflowCnecs();
@@ -194,7 +198,7 @@ public class RaoDataTest {
         Crac crac1 = CommonCracCreation.createWithCurativePstRange();
         crac1.synchronize(network);
         RaoData preventiveRaoData = RaoData.createOnPreventiveState(network, crac1);
-        String variantId = preventiveRaoData.getInitialVariantId();
+        String variantId = preventiveRaoData.getPreOptimVariantId();
         RaoData curativeRaoData = new RaoData(
                 network,
                 crac1,
@@ -203,7 +207,7 @@ public class RaoDataTest {
                 null,
                 null,
                 variantId,
-                new HashSet<>());
+                new RaoParameters());
         RangeActionResult rangeActionResult = curativeRaoData.getCrac().getRangeAction("pst").getExtension(RangeActionResultExtension.class).getVariant(curativeRaoData.getWorkingVariantId());
         assertNotNull(rangeActionResult);
         Assert.assertEquals(0, rangeActionResult.getSetPoint("none-initial"), 0.1);

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoUtilTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoUtilTest.java
@@ -168,7 +168,7 @@ public class RaoUtilTest {
                 raoInput.getReferenceProgram(),
                 raoInput.getGlskProvider(),
                 raoInput.getBaseCracVariantId(),
-                raoParameters.getLoopflowCountries());
+                raoParameters);
         SystematicSensitivityInterface systematicSensitivityInterface = RaoUtil.createSystematicSensitivityInterface(raoParameters, raoData, false);
         assertNotNull(systematicSensitivityInterface);
     }
@@ -215,7 +215,7 @@ public class RaoUtilTest {
                 raoInput.getReferenceProgram(),
                 raoInput.getGlskProvider(),
                 raoInput.getBaseCracVariantId(),
-                raoParameters.getLoopflowCountries());
+                raoParameters);
         SystematicSensitivityInterface systematicSensitivityInterface = RaoUtil.createSystematicSensitivityInterface(raoParameters, raoData, true);
         assertNotNull(systematicSensitivityInterface);
     }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/LinearOptimizerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/LinearOptimizerTest.java
@@ -18,6 +18,7 @@ import com.farao_community.farao.data.crac_impl.utils.CommonCracCreation;
 import com.farao_community.farao.data.crac_impl.utils.NetworkImportsUtil;
 import com.farao_community.farao.data.crac_result_extensions.PstRangeResult;
 import com.farao_community.farao.data.crac_result_extensions.RangeActionResultExtension;
+import com.farao_community.farao.rao_api.RaoParameters;
 import com.farao_community.farao.rao_commons.CracResultManager;
 import com.farao_community.farao.rao_commons.RaoData;
 import com.farao_community.farao.sensitivity_analysis.SystematicSensitivityResult;
@@ -33,6 +34,8 @@ import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Collections;
 
 import static org.junit.Assert.*;
 
@@ -73,7 +76,7 @@ public class LinearOptimizerTest {
         crac = CommonCracCreation.create();
         crac.synchronize(network);
 
-        raoData = RaoData.createOnPreventiveState(network, crac);
+        raoData = new RaoData(network, crac, crac.getPreventiveState(), Collections.singleton(crac.getPreventiveState()), null, null, null, new RaoParameters());
         raoData = Mockito.spy(raoData);
         cracResultManager = raoData.getCracResultManager();
 
@@ -152,7 +155,7 @@ public class LinearOptimizerTest {
         crac = CommonCracCreation.create();
         crac.addRangeAction(rangeAction);
         crac.synchronize(network);
-        raoData = RaoData.createOnPreventiveState(network, crac);
+        raoData = new RaoData(network, crac, crac.getPreventiveState(), Collections.singleton(crac.getPreventiveState()), null, null, null, new RaoParameters());
         cracResultManager = raoData.getCracResultManager();
         Mockito.when(linearProblemMock.getRangeActionSetPointVariable(rangeAction)).thenReturn(rangeActionSetPoint);
         Mockito.when(linearProblemMock.getAbsoluteRangeActionVariationVariable(rangeAction)).thenReturn(rangeActionAbsoluteVariation);

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/LinearOptimizerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/LinearOptimizerTest.java
@@ -233,7 +233,7 @@ public class LinearOptimizerTest {
         String preventiveState = raoData.getCrac().getPreventiveState().getId();
 
         RangeActionResultExtension pstRangeResultMap = raoData.getCrac().getRangeAction("idPstRa").getExtension(RangeActionResultExtension.class);
-        PstRangeResult pstRangeResult = (PstRangeResult) pstRangeResultMap.getVariant(raoData.getInitialVariantId());
+        PstRangeResult pstRangeResult = (PstRangeResult) pstRangeResultMap.getVariant(raoData.getPreOptimVariantId());
         Assert.assertEquals(0, pstRangeResult.getSetPoint(preventiveState), 0.1);
         Assert.assertEquals(0, pstRangeResult.getTap(preventiveState), 0.1);
 

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/AbstractFillerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/AbstractFillerTest.java
@@ -16,6 +16,7 @@ import com.farao_community.farao.data.crac_impl.utils.NetworkImportsUtil;
 import com.farao_community.farao.data.crac_io_api.CracImporters;
 import com.farao_community.farao.data.crac_result_extensions.ResultVariantManager;
 import com.farao_community.farao.data.refprog.reference_program.ReferenceProgram;
+import com.farao_community.farao.rao_api.RaoParameters;
 import com.farao_community.farao.rao_commons.RaoData;
 import com.farao_community.farao.rao_commons.linear_optimisation.mocks.MPSolverMock;
 import com.farao_community.farao.rao_commons.linear_optimisation.LinearProblem;
@@ -30,7 +31,6 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import java.util.Collections;
-import java.util.HashSet;
 
 import static org.mockito.Mockito.*;
 
@@ -119,7 +119,7 @@ abstract class AbstractFillerTest {
     }
 
     void initRaoData(State state) {
-        raoData = new RaoData(network, crac, state, Collections.singleton(state), referenceProgram, glsk, null, new HashSet<>());
+        raoData = new RaoData(network, crac, state, Collections.singleton(state), referenceProgram, glsk, null, new RaoParameters());
         raoData.getCracResultManager().fillRangeActionResultsWithNetworkValues();
         raoData.setSystematicSensitivityResult(systematicSensitivityResult);
     }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/AbstractFillerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/AbstractFillerTest.java
@@ -7,7 +7,6 @@
 package com.farao_community.farao.rao_commons.linear_optimisation.fillers;
 
 import com.farao_community.farao.commons.FaraoException;
-import com.farao_community.farao.commons.ZonalData;
 import com.farao_community.farao.data.crac_api.*;
 import com.farao_community.farao.data.crac_api.usage_rule.UsageMethod;
 import com.farao_community.farao.data.crac_impl.usage_rule.OnStateImpl;
@@ -15,7 +14,6 @@ import com.farao_community.farao.data.crac_api.cnec.BranchCnec;
 import com.farao_community.farao.data.crac_impl.utils.NetworkImportsUtil;
 import com.farao_community.farao.data.crac_io_api.CracImporters;
 import com.farao_community.farao.data.crac_result_extensions.ResultVariantManager;
-import com.farao_community.farao.data.refprog.reference_program.ReferenceProgram;
 import com.farao_community.farao.rao_api.RaoParameters;
 import com.farao_community.farao.rao_commons.RaoData;
 import com.farao_community.farao.rao_commons.linear_optimisation.mocks.MPSolverMock;
@@ -23,7 +21,6 @@ import com.farao_community.farao.rao_commons.linear_optimisation.LinearProblem;
 import com.farao_community.farao.sensitivity_analysis.SystematicSensitivityResult;
 import com.google.ortools.linearsolver.MPSolver;
 import com.powsybl.iidm.network.*;
-import com.powsybl.sensitivity.factors.variables.LinearGlsk;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
@@ -79,24 +76,13 @@ abstract class AbstractFillerTest {
     RaoData raoData;
     Crac crac;
     Network network;
-    ResultVariantManager resultVariantManager;
-
-    private ReferenceProgram referenceProgram;
-    private ZonalData<LinearGlsk> glsk;
 
     void init() {
-        init(null, null);
-    }
-
-    void init(ReferenceProgram referenceProgram, ZonalData<LinearGlsk> glsk) {
-
         // arrange some data for all fillers test
         // crac and network
         crac = CracImporters.importCrac("small-crac.json", getClass().getResourceAsStream("/small-crac.json"));
         network = NetworkImportsUtil.import12NodesNetwork();
         crac.synchronize(network);
-        this.glsk = glsk;
-        this.referenceProgram = referenceProgram;
 
         // get cnec and rangeAction
         cnec1 = crac.getBranchCnecs().stream().filter(c -> c.getId().equals(CNEC_1_ID)).findFirst().orElseThrow(FaraoException::new);
@@ -119,8 +105,10 @@ abstract class AbstractFillerTest {
     }
 
     void initRaoData(State state) {
-        raoData = new RaoData(network, crac, state, Collections.singleton(state), referenceProgram, glsk, null, new RaoParameters());
+        raoData = new RaoData(network, crac, state, Collections.singleton(state), null, null, null, new RaoParameters());
         raoData.getCracResultManager().fillRangeActionResultsWithNetworkValues();
         raoData.setSystematicSensitivityResult(systematicSensitivityResult);
+        raoData.getCrac().getExtension(ResultVariantManager.class).setInitialVariantId(raoData.getWorkingVariantId());
+        raoData.getCrac().getExtension(ResultVariantManager.class).setPreOptimVariantId(raoData.getWorkingVariantId());
     }
 }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/AbstractFillerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/AbstractFillerTest.java
@@ -109,6 +109,6 @@ abstract class AbstractFillerTest {
         raoData.getCracResultManager().fillRangeActionResultsWithNetworkValues();
         raoData.setSystematicSensitivityResult(systematicSensitivityResult);
         raoData.getCrac().getExtension(ResultVariantManager.class).setInitialVariantId(raoData.getWorkingVariantId());
-        raoData.getCrac().getExtension(ResultVariantManager.class).setPreOptimVariantId(raoData.getWorkingVariantId());
+        raoData.getCrac().getExtension(ResultVariantManager.class).setPrePerimeterVariantId(raoData.getWorkingVariantId());
     }
 }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxLoopFlowFillerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxLoopFlowFillerTest.java
@@ -33,14 +33,13 @@ public class MaxLoopFlowFillerTest extends AbstractFillerTest {
     public void setUp() {
         init();
         coreProblemFiller = new CoreProblemFiller();
+        CnecLoopFlowExtension cnecLoopFlowExtension = new CnecLoopFlowExtension(100.0, Unit.MEGAWATT);
+        cnec1.addExtension(CnecLoopFlowExtension.class, cnecLoopFlowExtension);
         initRaoData(crac.getPreventiveState());
     }
 
     @Test
     public void testFill1() {
-        CnecLoopFlowExtension cnecLoopFlowExtension = new CnecLoopFlowExtension(100.0, Unit.MEGAWATT);
-        cnec1.addExtension(CnecLoopFlowExtension.class, cnecLoopFlowExtension);
-        initRaoData(crac.getPreventiveState());
         cnec1.getExtension(CnecResultExtension.class).getVariant(raoData.getWorkingVariantId()).setCommercialFlowInMW(49.0);
         cnec1.getExtension(CnecResultExtension.class).getVariant(crac.getExtension(ResultVariantManager.class).getInitialVariantId()).setLoopflowInMW(0.);
 
@@ -71,9 +70,6 @@ public class MaxLoopFlowFillerTest extends AbstractFillerTest {
 
     @Test
     public void testFill2() {
-        CnecLoopFlowExtension cnecLoopFlowExtension = new CnecLoopFlowExtension(100.0, Unit.MEGAWATT);
-        cnec1.addExtension(CnecLoopFlowExtension.class, cnecLoopFlowExtension);
-        initRaoData(crac.getPreventiveState());
         cnec1.getExtension(CnecResultExtension.class).getVariant(raoData.getWorkingVariantId()).setCommercialFlowInMW(49.0);
         cnec1.getExtension(CnecResultExtension.class).getVariant(crac.getExtension(ResultVariantManager.class).getInitialVariantId()).setLoopflowInMW(80.);
 
@@ -104,9 +100,6 @@ public class MaxLoopFlowFillerTest extends AbstractFillerTest {
 
     @Test
     public void testShouldUpdate() {
-        CnecLoopFlowExtension cnecLoopFlowExtension = new CnecLoopFlowExtension(100.0, Unit.MEGAWATT);
-        cnec1.addExtension(CnecLoopFlowExtension.class, cnecLoopFlowExtension);
-        initRaoData(crac.getPreventiveState());
         cnec1.getExtension(CnecResultExtension.class).getVariant(raoData.getWorkingVariantId()).setCommercialFlowInMW(49.0);
         cnec1.getExtension(CnecResultExtension.class).getVariant(crac.getExtension(ResultVariantManager.class).getInitialVariantId()).setLoopflowInMW(0.);
 
@@ -138,9 +131,6 @@ public class MaxLoopFlowFillerTest extends AbstractFillerTest {
 
     @Test
     public void testShouldNotUpdate() {
-        CnecLoopFlowExtension cnecLoopFlowExtension = new CnecLoopFlowExtension(100.0, Unit.MEGAWATT);
-        cnec1.addExtension(CnecLoopFlowExtension.class, cnecLoopFlowExtension);
-        initRaoData(crac.getPreventiveState());
         cnec1.getExtension(CnecResultExtension.class).getVariant(raoData.getWorkingVariantId()).setCommercialFlowInMW(49.0);
         cnec1.getExtension(CnecResultExtension.class).getVariant(crac.getExtension(ResultVariantManager.class).getInitialVariantId()).setLoopflowInMW(0.);
 

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxMinRelativeMarginFillerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxMinRelativeMarginFillerTest.java
@@ -53,8 +53,8 @@ public class MaxMinRelativeMarginFillerTest extends AbstractFillerTest {
         // this is almost a copy of fillWithMaxMinMarginInMegawatt()
         // only the coefficients in the MinMargin constraint should be different
         fillProblemWithCoreFiller();
-        cnec1.getExtension(CnecResultExtension.class).getVariant(raoData.getInitialVariantId()).setAbsolutePtdfSum(0.9);
-        cnec2.getExtension(CnecResultExtension.class).getVariant(raoData.getInitialVariantId()).setAbsolutePtdfSum(0.7);
+        cnec1.getExtension(CnecResultExtension.class).getVariant(raoData.getPreOptimVariantId()).setAbsolutePtdfSum(0.9);
+        cnec2.getExtension(CnecResultExtension.class).getVariant(raoData.getPreOptimVariantId()).setAbsolutePtdfSum(0.7);
         maxMinRelativeMarginFiller.fill(raoData, linearProblem);
 
         MPVariable flowCnec1 = linearProblem.getFlowVariable(cnec1);
@@ -100,8 +100,8 @@ public class MaxMinRelativeMarginFillerTest extends AbstractFillerTest {
         // this is almost a copy of fillWithMaxMinMarginInAmpere()
         // only the objective function should be different
         fillProblemWithCoreFiller();
-        cnec1.getExtension(CnecResultExtension.class).getVariant(raoData.getInitialVariantId()).setAbsolutePtdfSum(0.005);
-        cnec2.getExtension(CnecResultExtension.class).getVariant(raoData.getInitialVariantId()).setAbsolutePtdfSum(0.1);
+        cnec1.getExtension(CnecResultExtension.class).getVariant(raoData.getPreOptimVariantId()).setAbsolutePtdfSum(0.005);
+        cnec2.getExtension(CnecResultExtension.class).getVariant(raoData.getPreOptimVariantId()).setAbsolutePtdfSum(0.1);
         maxMinRelativeMarginFiller.setUnit(AMPERE);
         maxMinRelativeMarginFiller.fill(raoData, linearProblem);
 

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MnecFillerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MnecFillerTest.java
@@ -79,7 +79,7 @@ public class MnecFillerTest extends AbstractFillerTest {
         // fill the problem : the core filler is required
         mnecFiller = new MnecFiller(unit, 50, 10, 3.5);
         initRaoData(crac.getPreventiveState());
-        raoData.getCrac().getExtension(ResultVariantManager.class).setPreOptimVariantId(raoData.getInitialVariantId());
+        raoData.getCrac().getExtension(ResultVariantManager.class).setPreOptimVariantId(raoData.getPreOptimVariantId());
         coreProblemFiller.fill(raoData, linearProblem);
         mnecFiller.fill(raoData, linearProblem);
     }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MnecFillerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MnecFillerTest.java
@@ -66,20 +66,14 @@ public class MnecFillerTest extends AbstractFillerTest {
 
         initRaoData(crac.getPreventiveState());
 
-        String testVariant = "test-variant";
-        ResultVariantManager resultVariantManager = new ResultVariantManager();
-        crac.addExtension(ResultVariantManager.class, resultVariantManager);
-        crac.getExtension(ResultVariantManager.class).createVariant(testVariant);
-        crac.getExtension(ResultVariantManager.class).setInitialVariantId(testVariant);
-        mnec1.getExtension(CnecResultExtension.class).getVariant(testVariant).setFlowInMW(900.);
-        mnec2.getExtension(CnecResultExtension.class).getVariant(testVariant).setFlowInMW(-200.);
+        String initialVariantId = crac.getExtension(ResultVariantManager.class).getInitialVariantId();
+        mnec1.getExtension(CnecResultExtension.class).getVariant(initialVariantId).setFlowInMW(900.);
+        mnec2.getExtension(CnecResultExtension.class).getVariant(initialVariantId).setFlowInMW(-200.);
     }
 
     private void fillProblemWithFiller(Unit unit) {
         // fill the problem : the core filler is required
         mnecFiller = new MnecFiller(unit, 50, 10, 3.5);
-        initRaoData(crac.getPreventiveState());
-        raoData.getCrac().getExtension(ResultVariantManager.class).setPreOptimVariantId(raoData.getPreOptimVariantId());
         coreProblemFiller.fill(raoData, linearProblem);
         mnecFiller.fill(raoData, linearProblem);
     }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizerTest.java
@@ -153,10 +153,17 @@ public class IteratingLinearOptimizerTest {
         assertTrue(crac.getExtension(ResultVariantManager.class).getVariants().contains(preOptimVariant));
         assertTrue(crac.getExtension(ResultVariantManager.class).getVariants().contains(workingVariants.get(1)));
         assertFalse(crac.getExtension(ResultVariantManager.class).getVariants().contains(workingVariants.get(0)));
+
+        assertEquals(0, crac.getRangeAction("PRA_PST_BE").getExtension(RangeActionResultExtension.class)
+            .getVariant(preOptimVariant)
+            .getSetPoint(crac.getPreventiveState().getId()), DOUBLE_TOLERANCE);
+        assertEquals(0, crac.getRangeAction("PRA_PST_BE").getExtension(RangeActionResultExtension.class)
+            .getVariant(preOptimVariant)
+            .getSetPoint("N-1 NL1-NL3-Défaut"), DOUBLE_TOLERANCE);
+
         assertEquals(3, crac.getRangeAction("PRA_PST_BE").getExtension(RangeActionResultExtension.class)
             .getVariant(bestVariantId)
             .getSetPoint(crac.getPreventiveState().getId()), DOUBLE_TOLERANCE);
-
     }
 
     @Test
@@ -181,5 +188,12 @@ public class IteratingLinearOptimizerTest {
         // In the end CRAC should contain results only for pre-optim variant and post-optim variant
         assertTrue(crac.getExtension(ResultVariantManager.class).getVariants().contains(preOptimVariant));
         assertFalse(crac.getExtension(ResultVariantManager.class).getVariants().contains(workingVariants.get(0)));
+
+        assertEquals(0, crac.getRangeAction("PRA_PST_BE").getExtension(RangeActionResultExtension.class)
+            .getVariant(preOptimVariant)
+            .getSetPoint(crac.getPreventiveState().getId()), DOUBLE_TOLERANCE);
+        assertEquals(0, crac.getRangeAction("PRA_PST_BE").getExtension(RangeActionResultExtension.class)
+            .getVariant(preOptimVariant)
+            .getSetPoint("N-1 NL1-NL3-Défaut"), DOUBLE_TOLERANCE);
     }
 }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizerTest.java
@@ -132,7 +132,7 @@ public class IteratingLinearOptimizerTest {
 
     @Test
     public void optimize() {
-        String preOptimVariant = raoData.getWorkingVariantId();
+        String preOptimVariant = raoData.getPreOptimVariantId();
 
         Mockito.when(linearOptimizer.getSolverResultStatusString()).thenReturn("OPTIMAL");
         Mockito.when(costEvaluator.getFunctionalCost(Mockito.any())).thenReturn(100., 50., 20., 0.);
@@ -153,9 +153,6 @@ public class IteratingLinearOptimizerTest {
         assertTrue(crac.getExtension(ResultVariantManager.class).getVariants().contains(preOptimVariant));
         assertTrue(crac.getExtension(ResultVariantManager.class).getVariants().contains(workingVariants.get(1)));
         assertFalse(crac.getExtension(ResultVariantManager.class).getVariants().contains(workingVariants.get(0)));
-        assertEquals(0, crac.getRangeAction("PRA_PST_BE").getExtension(RangeActionResultExtension.class)
-            .getVariant(preOptimVariant)
-            .getSetPoint(crac.getPreventiveState().getId()), DOUBLE_TOLERANCE);
         assertEquals(3, crac.getRangeAction("PRA_PST_BE").getExtension(RangeActionResultExtension.class)
             .getVariant(bestVariantId)
             .getSetPoint(crac.getPreventiveState().getId()), DOUBLE_TOLERANCE);
@@ -184,8 +181,5 @@ public class IteratingLinearOptimizerTest {
         // In the end CRAC should contain results only for pre-optim variant and post-optim variant
         assertTrue(crac.getExtension(ResultVariantManager.class).getVariants().contains(preOptimVariant));
         assertFalse(crac.getExtension(ResultVariantManager.class).getVariants().contains(workingVariants.get(0)));
-        assertEquals(0, crac.getRangeAction("PRA_PST_BE").getExtension(RangeActionResultExtension.class)
-            .getVariant(preOptimVariant)
-            .getSetPoint(crac.getPreventiveState().getId()), DOUBLE_TOLERANCE);
     }
 }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizerTest.java
@@ -13,6 +13,7 @@ import com.farao_community.farao.data.crac_io_api.CracImporters;
 import com.farao_community.farao.data.crac_result_extensions.CracResultExtension;
 import com.farao_community.farao.data.crac_result_extensions.RangeActionResultExtension;
 import com.farao_community.farao.data.crac_result_extensions.ResultVariantManager;
+import com.farao_community.farao.rao_api.RaoParameters;
 import com.farao_community.farao.rao_commons.RaoData;
 import com.farao_community.farao.rao_commons.linear_optimisation.LinearOptimizer;
 import com.farao_community.farao.rao_commons.objective_function_evaluator.ObjectiveFunctionEvaluator;
@@ -32,6 +33,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -68,7 +70,7 @@ public class IteratingLinearOptimizerTest {
         crac = CracImporters.importCrac("small-crac.json", getClass().getResourceAsStream("/small-crac.json"));
         Network network = NetworkImportsUtil.import12NodesNetwork();
         crac.synchronize(network);
-        raoData = RaoData.createOnPreventiveState(network, crac);
+        raoData = new RaoData(network, crac, crac.getPreventiveState(), Collections.singleton(crac.getPreventiveState()), null, null, null, new RaoParameters());
         parameters = new IteratingLinearOptimizerParameters(10, 0);
 
         workingVariants = new ArrayList<>();

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/objective_function_evaluator/LoopFlowViolationCostEvaluatorTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/objective_function_evaluator/LoopFlowViolationCostEvaluatorTest.java
@@ -13,10 +13,13 @@ import com.farao_community.farao.data.crac_impl.utils.NetworkImportsUtil;
 import com.farao_community.farao.data.crac_loopflow_extension.CnecLoopFlowExtension;
 import com.farao_community.farao.data.crac_result_extensions.CnecResultExtension;
 import com.farao_community.farao.data.crac_result_extensions.ResultVariantManager;
+import com.farao_community.farao.rao_api.RaoParameters;
 import com.farao_community.farao.rao_commons.RaoData;
 import com.powsybl.iidm.network.Network;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
@@ -42,6 +45,10 @@ public class LoopFlowViolationCostEvaluatorTest {
         crac.getExtension(ResultVariantManager.class).setInitialVariantId("initial");
     }
 
+    private RaoData createRaoDataOnPreventiveStateBasedOnExistingVariant(String variantId) {
+        return new RaoData(network, crac, crac.getPreventiveState(), Collections.singleton(crac.getPreventiveState()), null, null, variantId, new RaoParameters());
+    }
+
     @Test
     public void testLoopFlowViolationCostEvaluator1() {
         // no loop-flow violation for both cnecs
@@ -52,7 +59,7 @@ public class LoopFlowViolationCostEvaluatorTest {
         crac.getBranchCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(INITIAL).setLoopflowInMW(0.);
         crac.getBranchCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(CURRENT).setLoopflowInMW(100.);
 
-        RaoData raoData = RaoData.createOnPreventiveStateBasedOnExistingVariant(network, crac, "current");
+        RaoData raoData = createRaoDataOnPreventiveStateBasedOnExistingVariant("current");
 
         assertEquals(0., new LoopFlowViolationCostEvaluator(0., 0.).getCost(raoData), DOUBLE_TOLERANCE);
         assertEquals(0., new LoopFlowViolationCostEvaluator(15., 0.).getCost(raoData), DOUBLE_TOLERANCE);
@@ -70,7 +77,7 @@ public class LoopFlowViolationCostEvaluatorTest {
         crac.getBranchCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(INITIAL).setLoopflowInMW(0.);
         crac.getBranchCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(CURRENT).setLoopflowInMW(9);
 
-        RaoData raoData = RaoData.createOnPreventiveStateBasedOnExistingVariant(network, crac, "current");
+        RaoData raoData = createRaoDataOnPreventiveStateBasedOnExistingVariant("current");
 
         assertEquals(0., new LoopFlowViolationCostEvaluator(0., 0.).getCost(raoData), DOUBLE_TOLERANCE);
         assertEquals(15. * 90., new LoopFlowViolationCostEvaluator(15., 0.).getCost(raoData), DOUBLE_TOLERANCE);
@@ -89,7 +96,7 @@ public class LoopFlowViolationCostEvaluatorTest {
         crac.getBranchCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(INITIAL).setLoopflowInMW(0.);
         crac.getBranchCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(CURRENT).setLoopflowInMW(-110.);
 
-        RaoData raoData = RaoData.createOnPreventiveStateBasedOnExistingVariant(network, crac, "current");
+        RaoData raoData = createRaoDataOnPreventiveStateBasedOnExistingVariant("current");
 
         assertEquals(0., new LoopFlowViolationCostEvaluator(0., 0.).getCost(raoData), DOUBLE_TOLERANCE);
         assertEquals(15. * 10., new LoopFlowViolationCostEvaluator(15., 0.).getCost(raoData), DOUBLE_TOLERANCE);
@@ -107,7 +114,7 @@ public class LoopFlowViolationCostEvaluatorTest {
         crac.getBranchCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(INITIAL).setLoopflowInMW(0.);
         crac.getBranchCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(CURRENT).setLoopflowInMW(-110.);
 
-        RaoData raoData = RaoData.createOnPreventiveStateBasedOnExistingVariant(network, crac, "current");
+        RaoData raoData = createRaoDataOnPreventiveStateBasedOnExistingVariant("current");
 
         assertEquals(0., new LoopFlowViolationCostEvaluator(0., 50.).getCost(raoData), DOUBLE_TOLERANCE);
         assertEquals(15. * 30., new LoopFlowViolationCostEvaluator(15., 50.).getCost(raoData), DOUBLE_TOLERANCE);
@@ -125,7 +132,7 @@ public class LoopFlowViolationCostEvaluatorTest {
         crac.getBranchCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(INITIAL).setLoopflowInMW(100.);
         crac.getBranchCnec("cnec2basecase").getExtension(CnecResultExtension.class).getVariant(CURRENT).setLoopflowInMW(-160.);
 
-        RaoData raoData = RaoData.createOnPreventiveStateBasedOnExistingVariant(network, crac, "current");
+        RaoData raoData = createRaoDataOnPreventiveStateBasedOnExistingVariant("current");
 
         assertEquals(0., new LoopFlowViolationCostEvaluator(0., 50.).getCost(raoData), DOUBLE_TOLERANCE);
         assertEquals(15. * 10., new LoopFlowViolationCostEvaluator(15., 50.).getCost(raoData), DOUBLE_TOLERANCE);
@@ -136,7 +143,7 @@ public class LoopFlowViolationCostEvaluatorTest {
     public void testLoopFlowViolationCostEvaluator6() {
         // no cnec with LF extension
         // assertEquals(0., new LoopFlowViolationCostEvaluator(0.).getCost(raoData), DOUBLE_TOLERANCE);
-        RaoData raoData = RaoData.createOnPreventiveStateBasedOnExistingVariant(network, crac, "current");
+        RaoData raoData = createRaoDataOnPreventiveStateBasedOnExistingVariant("current");
         assertEquals(0., new LoopFlowViolationCostEvaluator(15., 0.).getCost(raoData), DOUBLE_TOLERANCE);
         assertEquals(0., new LoopFlowViolationCostEvaluator(95., 0.).getCost(raoData), DOUBLE_TOLERANCE);
     }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/objective_function_evaluator/MinMarginEvaluatorTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/objective_function_evaluator/MinMarginEvaluatorTest.java
@@ -14,6 +14,7 @@ import com.farao_community.farao.data.crac_api.threshold.BranchThresholdRule;
 import com.farao_community.farao.data.crac_impl.utils.CommonCracCreation;
 import com.farao_community.farao.data.crac_impl.utils.NetworkImportsUtil;
 import com.farao_community.farao.data.crac_result_extensions.CnecResultExtension;
+import com.farao_community.farao.data.crac_result_extensions.ResultVariantManager;
 import com.farao_community.farao.rao_commons.RaoData;
 import com.farao_community.farao.rao_commons.RaoInputHelper;
 import com.farao_community.farao.sensitivity_analysis.SystematicSensitivityResult;
@@ -35,6 +36,7 @@ public class MinMarginEvaluatorTest {
     private RaoData raoData;
     private SystematicSensitivityResult systematicSensitivityResult;
     private Network network;
+    private String initialVariant;
 
     @Before
     public void setUp() {
@@ -42,6 +44,8 @@ public class MinMarginEvaluatorTest {
         network = NetworkImportsUtil.import12NodesNetwork();
         crac.synchronize(network);
         raoData = RaoData.createOnPreventiveState(network, crac);
+        initialVariant = raoData.getPreOptimVariantId();
+        crac.getExtension(ResultVariantManager.class).setInitialVariantId(initialVariant);
 
         setPtdfSum("cnec1basecase", 0.5);
         setPtdfSum("cnec1stateCurativeContingency1", 0.95);
@@ -67,7 +71,7 @@ public class MinMarginEvaluatorTest {
     }
 
     private void setPtdfSum(String cnecId, double ptdfSum) {
-        crac.getBranchCnec(cnecId).getExtension(CnecResultExtension.class).getVariant(raoData.getPreOptimVariantId()).setAbsolutePtdfSum(ptdfSum);
+        crac.getBranchCnec(cnecId).getExtension(CnecResultExtension.class).getVariant(initialVariant).setAbsolutePtdfSum(ptdfSum);
     }
 
     @Test

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/objective_function_evaluator/MinMarginEvaluatorTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/objective_function_evaluator/MinMarginEvaluatorTest.java
@@ -67,7 +67,7 @@ public class MinMarginEvaluatorTest {
     }
 
     private void setPtdfSum(String cnecId, double ptdfSum) {
-        crac.getBranchCnec(cnecId).getExtension(CnecResultExtension.class).getVariant(raoData.getInitialVariantId()).setAbsolutePtdfSum(ptdfSum);
+        crac.getBranchCnec(cnecId).getExtension(CnecResultExtension.class).getVariant(raoData.getPreOptimVariantId()).setAbsolutePtdfSum(ptdfSum);
     }
 
     @Test

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/objective_function_evaluator/MinMarginEvaluatorTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/objective_function_evaluator/MinMarginEvaluatorTest.java
@@ -15,6 +15,7 @@ import com.farao_community.farao.data.crac_impl.utils.CommonCracCreation;
 import com.farao_community.farao.data.crac_impl.utils.NetworkImportsUtil;
 import com.farao_community.farao.data.crac_result_extensions.CnecResultExtension;
 import com.farao_community.farao.data.crac_result_extensions.ResultVariantManager;
+import com.farao_community.farao.rao_api.RaoParameters;
 import com.farao_community.farao.rao_commons.RaoData;
 import com.farao_community.farao.rao_commons.RaoInputHelper;
 import com.farao_community.farao.sensitivity_analysis.SystematicSensitivityResult;
@@ -22,6 +23,9 @@ import com.powsybl.iidm.network.Network;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -43,7 +47,7 @@ public class MinMarginEvaluatorTest {
         crac = CommonCracCreation.create();
         network = NetworkImportsUtil.import12NodesNetwork();
         crac.synchronize(network);
-        raoData = RaoData.createOnPreventiveState(network, crac);
+        raoData = new RaoData(network, crac, crac.getPreventiveState(), Collections.singleton(crac.getPreventiveState()), null, null, null, new RaoParameters());
         initialVariant = raoData.getPreOptimVariantId();
         crac.getExtension(ResultVariantManager.class).setInitialVariantId(initialVariant);
 
@@ -149,5 +153,13 @@ public class MinMarginEvaluatorTest {
     @Test(expected = FaraoException.class)
     public void testRequirePtdfSumLb() {
         new MinMarginEvaluator(Unit.MEGAWATT, true);
+    }
+
+    @Test
+    public void testMarginsInAmpereFromMegawattConversion() {
+        List<Double> margins = new MinMarginEvaluator(Unit.MEGAWATT, true, 0.001).getMarginsInAmpereFromMegawattConversion(raoData);
+        assertEquals(2, margins.size());
+        assertEquals(2990, margins.get(0), DOUBLE_TOLERANCE);
+        assertEquals(4254, margins.get(1), DOUBLE_TOLERANCE);
     }
 }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/objective_function_evaluator/MinMarginObjectiveFunctionTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/objective_function_evaluator/MinMarginObjectiveFunctionTest.java
@@ -22,6 +22,7 @@ import com.powsybl.iidm.network.Network;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.Collections;
 import java.util.Random;
 
 import static com.farao_community.farao.rao_api.RaoParameters.ObjectiveFunction.MAX_MIN_RELATIVE_MARGIN_IN_AMPERE;
@@ -81,7 +82,7 @@ public class MinMarginObjectiveFunctionTest {
                 cnec.getExtension(CnecResultExtension.class).getVariant(TEST_VARIANT).setAbsolutePtdfSum(rand.nextDouble())
         );
 
-        raoData = RaoData.createOnPreventiveStateBasedOnExistingVariant(network, crac, TEST_VARIANT);
+        raoData = new RaoData(network, crac, crac.getPreventiveState(), Collections.singleton(crac.getPreventiveState()), null, null, TEST_VARIANT, new RaoParameters());
 
         sensiResult = Mockito.mock(SystematicSensitivityResult.class);
         Mockito.when(sensiResult.getStatus()).thenReturn(SystematicSensitivityResult.SensitivityComputationStatus.SUCCESS);

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/objective_function_evaluator/MnecViolationCostEvaluatorTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/objective_function_evaluator/MnecViolationCostEvaluatorTest.java
@@ -15,6 +15,7 @@ import com.farao_community.farao.data.crac_impl.utils.NetworkImportsUtil;
 import com.farao_community.farao.data.crac_result_extensions.CnecResultExtension;
 import com.farao_community.farao.data.crac_result_extensions.ResultVariantManager;
 import com.farao_community.farao.data.crac_util.CracCleaner;
+import com.farao_community.farao.rao_api.RaoParameters;
 import com.farao_community.farao.rao_commons.RaoData;
 import com.farao_community.farao.rao_commons.RaoInputHelper;
 import com.farao_community.farao.sensitivity_analysis.SystematicSensitivityResult;
@@ -22,6 +23,8 @@ import com.powsybl.iidm.network.Network;
 import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
@@ -96,13 +99,13 @@ public class MnecViolationCostEvaluatorTest {
         crac.getExtension(ResultVariantManager.class).createVariant(TEST_VARIANT);
         crac.getExtension(ResultVariantManager.class).setInitialVariantId(TEST_VARIANT);
 
-        raoData = RaoData.createOnPreventiveState(network, crac);
+        raoData = new RaoData(network, crac, crac.getPreventiveState(), Collections.singleton(crac.getPreventiveState()), null, null, null, new RaoParameters());
 
         CracCleaner cracCleaner = new CracCleaner();
         cracCleaner.cleanCrac(crac, network);
         RaoInputHelper.synchronize(crac, network);
 
-        raoData = RaoData.createOnPreventiveStateBasedOnExistingVariant(network, crac, TEST_VARIANT);
+        raoData = new RaoData(network, crac, crac.getPreventiveState(), Collections.singleton(crac.getPreventiveState()), null, null, TEST_VARIANT, new RaoParameters());
         sensiResult = Mockito.mock(SystematicSensitivityResult.class);
         raoData.setSystematicSensitivityResult(sensiResult);
     }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/Leaf.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/Leaf.java
@@ -84,7 +84,6 @@ class Leaf {
         this.raoParameters = raoParameters;
         this.raoData = raoData;
         preOptimVariantId = raoData.getPreOptimVariantId();
-        // TODO : create the interface in this class
         systematicSensitivityInterface = RaoUtil.createSystematicSensitivityInterface(raoParameters, raoData,
             raoParameters.getLoopFlowApproximationLevel().shouldUpdatePtdfWithTopologicalChange());
 

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/Leaf.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/Leaf.java
@@ -295,16 +295,6 @@ class Leaf {
     }
 
     /**
-     * This method applies on the rao data network the optimized positions of range actions. It is a delegate method
-     * to avoid calling directly rao data as a leaf user.
-     */
-    void applyRangeActionResultsOnNetwork() {
-        //TODO : remove not used
-        getRaoData().getCracVariantManager().setWorkingVariant(getBestVariantId());
-        getRaoData().getCracResultManager().applyRangeActionResultsOnNetwork();
-    }
-
-    /**
      * This method activates network actions related to this leaf in the CRAC results. This action has to be done
      * every time a new variant is created inside this leaf to ensure results consistency.
      *

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/Leaf.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/Leaf.java
@@ -155,8 +155,12 @@ class Leaf {
      * If the computation works fine status is updated to EVALUATED otherwise it is set to ERROR.
      */
     void evaluate() {
+        ObjectiveFunctionEvaluator objectiveFunctionEvaluator = RaoUtil.createObjectiveFunction(raoParameters);
+
         if (status.equals(Status.EVALUATED)) {
             LOGGER.debug("Leaf has already been evaluated");
+            raoData.getCracResultManager().fillCracResultWithCosts(
+                objectiveFunctionEvaluator.getFunctionalCost(raoData), objectiveFunctionEvaluator.getVirtualCost(raoData));
             return;
         }
 
@@ -169,10 +173,8 @@ class Leaf {
                 LoopFlowUtil.buildLoopFlowsWithLatestSensi(raoData,
                     !raoParameters.getLoopFlowApproximationLevel().shouldUpdatePtdfWithTopologicalChange());
             }
-            ObjectiveFunctionEvaluator objectiveFunctionEvaluator = RaoUtil.createObjectiveFunction(raoParameters);
             raoData.getCracResultManager().fillCracResultWithCosts(
                 objectiveFunctionEvaluator.getFunctionalCost(raoData), objectiveFunctionEvaluator.getVirtualCost(raoData));
-
             status = Status.EVALUATED;
         } catch (FaraoException e) {
             LOGGER.error(String.format("Fail to evaluate leaf: %s", e.getMessage()));

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTree.java
@@ -65,7 +65,7 @@ public class SearchTree {
         this.treeParameters = treeParameters;
 
         LOGGER.info("Evaluate root leaf");
-        rootLeaf.evaluateRootLeaf(treeParameters.getShouldComputeInitialSensitivity());
+        rootLeaf.evaluate();
         SearchTreeRaoLogger.logMostLimitingElementsResults(rootLeaf, raoParameters.getObjectiveFunction().getUnit(), relativePositiveMargins);
         LOGGER.debug("{}", rootLeaf);
         if (rootLeaf.getStatus().equals(Leaf.Status.ERROR)) {
@@ -220,7 +220,7 @@ public class SearchTree {
 
     private RaoResult buildOutput() {
         RaoResult raoResult = new RaoResult(optimalLeaf.getStatus().equals(Leaf.Status.ERROR) ? RaoResult.Status.FAILURE : RaoResult.Status.SUCCESS);
-        raoResult.setPreOptimVariantId(rootLeaf.getInitialVariantId());
+        raoResult.setPreOptimVariantId(rootLeaf.getPreOptimVariantId());
         raoResult.setPostOptimVariantId(optimalLeaf.getBestVariantId());
         return raoResult;
     }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
@@ -156,7 +156,6 @@ public class SearchTreeRaoProvider implements RaoProvider {
             raoInput.getGlskProvider(),
             baseVariantId,
             parameters);
-        // TODO: remove useless shouldCOmputeInitialBlabla parameter
         TreeParameters preventiveTreeParameters = TreeParameters.buildForPreventivePerimeter(parameters.getExtension(SearchTreeRaoParameters.class));
         return new SearchTree().run(preventiveRaoData, parameters, preventiveTreeParameters);
     }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoProvider.java
@@ -97,6 +97,7 @@ public class SearchTreeRaoProvider implements RaoProvider {
 
         // optimize curative perimeters
         double preventiveOptimalCost = raoInput.getCrac().getExtension(CracResultExtension.class).getVariant(preventiveRaoResult.getPostOptimVariantId()).getCost();
+        raoInput.getCrac().getExtension(ResultVariantManager.class).setPrePerimeterVariantId(preventiveRaoResult.getPostOptimVariantId());
         TreeParameters curativeTreeParameters = TreeParameters.buildForCurativePerimeter(parameters.getExtension(SearchTreeRaoParameters.class), preventiveOptimalCost);
         CracResultUtil.applyRemedialActionsForState(raoInput.getNetwork(), raoInput.getCrac(), preventiveRaoResult.getPostOptimVariantId(), raoInput.getCrac().getPreventiveState());
         Map<State, RaoResult> curativeResults = optimizeCurativePerimeters(raoInput, parameters, curativeTreeParameters, network);

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/TreeParameters.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/TreeParameters.java
@@ -20,6 +20,7 @@ import java.util.Objects;
  * @author Peter Mitri {@literal <peter.mitri at rte-france.com>}
  */
 public final class TreeParameters {
+
     public enum StopCriterion {
         MIN_OBJECTIVE,
         AT_TARGET_OBJECTIVE_VALUE

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/TreeParameters.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/TreeParameters.java
@@ -34,19 +34,16 @@ public final class TreeParameters {
     private double absoluteNetworkActionMinimumImpactThreshold;
     private int leavesInParallel;
 
-    private boolean shouldComputeInitialSensitivity;
-
     private TreeParameters() {
     }
 
-    private TreeParameters(SearchTreeRaoParameters searchTreeRaoParameters, StopCriterion stopCriterion, double targetObjectiveValue, boolean shouldComputeInitialSensitivity) {
+    private TreeParameters(SearchTreeRaoParameters searchTreeRaoParameters, StopCriterion stopCriterion, double targetObjectiveValue) {
         this.maximumSearchDepth = searchTreeRaoParameters.getMaximumSearchDepth();
         this.relativeNetworkActionMinimumImpactThreshold = searchTreeRaoParameters.getRelativeNetworkActionMinimumImpactThreshold();
         this.absoluteNetworkActionMinimumImpactThreshold = searchTreeRaoParameters.getAbsoluteNetworkActionMinimumImpactThreshold();
         this.leavesInParallel = searchTreeRaoParameters.getLeavesInParallel();
         this.stopCriterion = stopCriterion;
         this.targetObjectiveValue = targetObjectiveValue;
-        this.shouldComputeInitialSensitivity = shouldComputeInitialSensitivity;
     }
 
     public StopCriterion getStopCriterion() {
@@ -57,17 +54,13 @@ public final class TreeParameters {
         return targetObjectiveValue;
     }
 
-    public boolean getShouldComputeInitialSensitivity() {
-        return shouldComputeInitialSensitivity;
-    }
-
-    public static TreeParameters buildForPreventivePerimeter(@Nullable SearchTreeRaoParameters searchTreeRaoParameters, boolean shouldComputeInitialSensitivity) {
+    public static TreeParameters buildForPreventivePerimeter(@Nullable SearchTreeRaoParameters searchTreeRaoParameters) {
         SearchTreeRaoParameters parameters = Objects.isNull(searchTreeRaoParameters) ? new SearchTreeRaoParameters() : searchTreeRaoParameters;
         switch (parameters.getPreventiveRaoStopCriterion()) {
             case MIN_OBJECTIVE:
-                return new TreeParameters(parameters, StopCriterion.MIN_OBJECTIVE, 0.0, shouldComputeInitialSensitivity);
+                return new TreeParameters(parameters, StopCriterion.MIN_OBJECTIVE, 0.0);
             case SECURE:
-                return new TreeParameters(parameters, StopCriterion.AT_TARGET_OBJECTIVE_VALUE, 0.0, shouldComputeInitialSensitivity);
+                return new TreeParameters(parameters, StopCriterion.AT_TARGET_OBJECTIVE_VALUE, 0.0);
             default:
                 throw new FaraoException("Unknown preventive RAO stop criterion: " + parameters.getPreventiveRaoStopCriterion());
         }
@@ -77,15 +70,15 @@ public final class TreeParameters {
         SearchTreeRaoParameters parameters = Objects.isNull(searchTreeRaoParameters) ? new SearchTreeRaoParameters() : searchTreeRaoParameters;
         switch (parameters.getCurativeRaoStopCriterion()) {
             case MIN_OBJECTIVE:
-                return new TreeParameters(parameters, StopCriterion.MIN_OBJECTIVE, 0.0, true);
+                return new TreeParameters(parameters, StopCriterion.MIN_OBJECTIVE, 0.0);
             case SECURE:
-                return new TreeParameters(parameters, StopCriterion.AT_TARGET_OBJECTIVE_VALUE, 0.0, true);
+                return new TreeParameters(parameters, StopCriterion.AT_TARGET_OBJECTIVE_VALUE, 0.0);
             case PREVENTIVE_OBJECTIVE:
                 return new TreeParameters(parameters, StopCriterion.AT_TARGET_OBJECTIVE_VALUE,
-                        preventiveOptimizedCost - parameters.getCurativeRaoMinObjImprovement(), true);
+                        preventiveOptimizedCost - parameters.getCurativeRaoMinObjImprovement());
             case PREVENTIVE_OBJECTIVE_AND_SECURE:
                 return new TreeParameters(parameters, StopCriterion.AT_TARGET_OBJECTIVE_VALUE,
-                        Math.min(preventiveOptimizedCost - parameters.getCurativeRaoMinObjImprovement(), 0), true);
+                        Math.min(preventiveOptimizedCost - parameters.getCurativeRaoMinObjImprovement(), 0));
             default:
                 throw new FaraoException("Unknown curative RAO stop criterion: " + parameters.getCurativeRaoStopCriterion());
         }

--- a/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/LeafTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/LeafTest.java
@@ -7,7 +7,6 @@
 
 package com.farao_community.farao.search_tree_rao;
 
-import com.farao_community.farao.commons.FaraoException;
 import com.farao_community.farao.data.crac_api.ActionType;
 import com.farao_community.farao.data.crac_api.NetworkAction;
 import com.farao_community.farao.data.crac_api.NetworkElement;
@@ -155,12 +154,6 @@ public class LeafTest {
         assertEquals(Leaf.Status.CREATED, rootLeaf.getStatus());
     }
 
-    @Test(expected = FaraoException.class)
-    public void testErrorOnRootLeafEvaluate() {
-        Leaf rootLeaf = new Leaf(raoDataMock, raoParameters);
-        rootLeaf.evaluate();
-    }
-
     @Test
     public void testLeafDefinition() {
         crac.getBranchCnec("cnec1basecase").getExtension(CnecResultExtension.class).getVariant(raoData.getPreOptimVariantId()).setAbsolutePtdfSum(0.5);
@@ -231,18 +224,6 @@ public class LeafTest {
         rootLeaf.evaluate();
 
         assertEquals(Leaf.Status.ERROR, rootLeaf.getStatus());
-        assertFalse(rootLeaf.getRaoData().hasSensitivityValues());
-    }
-
-    @Test
-    public void testSkipInitialSensitivity() {
-        Mockito.when(systematicSensitivityResult.isSuccess()).thenReturn(false);
-        Mockito.doThrow(new SensitivityAnalysisException("mock")).when(systematicSensitivityInterface).run(any());
-
-        Leaf rootLeaf = new Leaf(raoData, raoParameters);
-        rootLeaf.evaluate();
-
-        assertEquals(Leaf.Status.EVALUATED, rootLeaf.getStatus());
         assertFalse(rootLeaf.getRaoData().hasSensitivityValues());
     }
 

--- a/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/SearchTreeTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/SearchTreeTest.java
@@ -16,7 +16,6 @@ import com.farao_community.farao.rao_api.RaoParameters;
 import com.farao_community.farao.rao_api.RaoResult;
 import com.farao_community.farao.rao_api.json.JsonRaoParameters;
 import com.farao_community.farao.rao_commons.CracResultManager;
-import com.farao_community.farao.rao_commons.InitialSensitivityAnalysis;
 import com.farao_community.farao.rao_commons.RaoData;
 import com.farao_community.farao.rao_commons.RaoUtil;
 import com.farao_community.farao.rao_commons.linear_optimisation.iterating_linear_optimizer.IteratingLinearOptimizer;
@@ -91,6 +90,7 @@ public class SearchTreeTest {
 
         CracResultManager spiedCracResultManager = Mockito.spy(raoData.getCracResultManager());
         Mockito.when(raoData.getCracResultManager()).thenReturn(spiedCracResultManager);
+        Mockito.when(raoData.getSystematicSensitivityResult()).thenReturn(Mockito.mock(SystematicSensitivityResult.class));
         Mockito.doNothing().when(spiedCracResultManager).fillCracResultWithCosts(anyDouble(), anyDouble());
         Mockito.doNothing().when(spiedCracResultManager).fillCnecResultWithFlows();
 
@@ -108,10 +108,6 @@ public class SearchTreeTest {
         PowerMockito.whenNew(Leaf.class).withAnyArguments().thenReturn(mockLeaf);
         when(mockLeaf.getBestCost()).thenReturn(0.);
         PowerMockito.doNothing().when(mockLeaf).evaluate();
-
-        InitialSensitivityAnalysis mockSensi = Mockito.spy(new InitialSensitivityAnalysis(raoData));
-        PowerMockito.whenNew(InitialSensitivityAnalysis.class).withAnyArguments().thenReturn(mockSensi);
-        PowerMockito.doNothing().when(mockSensi).run();
 
         TreeParameters treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters.getExtension(SearchTreeRaoParameters.class));
         RaoResult result = searchTree.run(raoData, raoParameters, treeParameters).join();

--- a/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/SearchTreeTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/SearchTreeTest.java
@@ -67,7 +67,7 @@ public class SearchTreeTest {
         Crac crac = CracImporters.importCrac("small-crac-with-network-actions.json", getClass().getResourceAsStream("/small-crac-with-network-actions.json"));
         RaoUtil.initCrac(crac, network);
 
-        raoData = Mockito.spy(RaoData.createOnPreventiveState(network, crac));
+        raoData = Mockito.spy(new RaoData(network, crac, crac.getPreventiveState(), Collections.singleton(crac.getPreventiveState()), null, null, null, new RaoParameters()));
         raoParameters = JsonRaoParameters.read(getClass().getResourceAsStream("/SearchTreeRaoParameters.json"));
         systematicSensitivityInterface = Mockito.mock(SystematicSensitivityInterface.class);
         iteratingLinearOptimizer = Mockito.mock(IteratingLinearOptimizer.class);

--- a/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/SearchTreeTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/SearchTreeTest.java
@@ -109,7 +109,7 @@ public class SearchTreeTest {
         when(mockLeaf.getBestCost()).thenReturn(0.);
         PowerMockito.doNothing().when(mockLeaf).evaluate();
 
-        InitialSensitivityAnalysis mockSensi = Mockito.spy(new InitialSensitivityAnalysis(raoData, raoParameters));
+        InitialSensitivityAnalysis mockSensi = Mockito.spy(new InitialSensitivityAnalysis(raoData));
         PowerMockito.whenNew(InitialSensitivityAnalysis.class).withAnyArguments().thenReturn(mockSensi);
         PowerMockito.doNothing().when(mockSensi).run();
 

--- a/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/SearchTreeTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/SearchTreeTest.java
@@ -113,7 +113,7 @@ public class SearchTreeTest {
         PowerMockito.whenNew(InitialSensitivityAnalysis.class).withAnyArguments().thenReturn(mockSensi);
         PowerMockito.doNothing().when(mockSensi).run();
 
-        TreeParameters treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters.getExtension(SearchTreeRaoParameters.class), true);
+        TreeParameters treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters.getExtension(SearchTreeRaoParameters.class));
         RaoResult result = searchTree.run(raoData, raoParameters, treeParameters).join();
         assertNotNull(result);
         assertEquals(RaoResult.Status.SUCCESS, result.getStatus());

--- a/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/TreeParametersTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com.farao_community.farao.search_tree_rao/TreeParametersTest.java
@@ -36,16 +36,14 @@ public class TreeParametersTest {
     @Test
     public void testPreventive() {
         searchTreeRaoParameters.setPreventiveRaoStopCriterion(SearchTreeRaoParameters.PreventiveRaoStopCriterion.MIN_OBJECTIVE);
-        TreeParameters treeParameters = TreeParameters.buildForPreventivePerimeter(searchTreeRaoParameters, true);
+        TreeParameters treeParameters = TreeParameters.buildForPreventivePerimeter(searchTreeRaoParameters);
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
-        assertTrue(treeParameters.getShouldComputeInitialSensitivity());
         compareCommonParameters(treeParameters, searchTreeRaoParameters);
 
         searchTreeRaoParameters.setPreventiveRaoStopCriterion(SearchTreeRaoParameters.PreventiveRaoStopCriterion.SECURE);
-        treeParameters = TreeParameters.buildForPreventivePerimeter(searchTreeRaoParameters, false);
+        treeParameters = TreeParameters.buildForPreventivePerimeter(searchTreeRaoParameters);
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
         assertEquals(0, treeParameters.getTargetObjectiveValue(), 1e-6);
-        assertFalse(treeParameters.getShouldComputeInitialSensitivity());
         compareCommonParameters(treeParameters, searchTreeRaoParameters);
     }
 
@@ -100,7 +98,7 @@ public class TreeParametersTest {
     @Test
     public void testDefaultSearchTreeRaoParameters() {
         SearchTreeRaoParameters defaultParameters = new SearchTreeRaoParameters();
-        TreeParameters treeParameters = TreeParameters.buildForPreventivePerimeter(null, true);
+        TreeParameters treeParameters = TreeParameters.buildForPreventivePerimeter(null);
         compareCommonParameters(treeParameters, defaultParameters);
         treeParameters = TreeParameters.buildForCurativePerimeter(null, 0.);
         compareCommonParameters(treeParameters, defaultParameters);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Performance improvement : skip PTDF computation in curative initial sensi

Refactoring : attempt to bring some more clarity in variants (there is still much to do though !), notably change some name conventions which were not always consistent between the different classes of the code

* **initialVariant** (ResultVariantManager) always refers the first security analysis made, without any PRA and any CRA (whatever the perimeter). The initial variant of the N Cnec is computed with the initial network. The initial variant of the N-1 Cnec is computed with the initial network with the contingency.
 
* **prePerimiterVariant** (ResultVariantManager) refers to the situation at the beginning of a perimeter. For preventive perimeters, the initialVariant is equal to the prePerimiterVariant. For curative perimeters, the prePerimiterVariant includes the PRA.
 
* **preOptimVariant** (RaoData) refers to the first variant of a RaoData. Concretely, within a Leaf, it corresponds to the variant before optimisation of the PSTs, but with the topological action which is tested by the Leaf.


Potential bug fix : Make the prePerimeter variant management compatible with multi-threading (previsouly, it was updated by all the curative perimeters, which could be done in //).

Functional change : before, PTDF used in the computation of relative margins of curative Cnec were the "prePerimenter" PTDFs (with contingency and PRA), now they are the initial PTDF (with contingency, without PRA).