### PR TITLE
Add Z11 and relative margins to CNE export (#12.2) (simple implementation)

### DIFF
--- a/data/crac-io/crac-io-cne/src/main/java/com/farao_community/farao/data/crac_io_cne/CneClassCreator.java
+++ b/data/crac-io/crac-io-cne/src/main/java/com/farao_community/farao/data/crac_io_cne/CneClassCreator.java
@@ -19,6 +19,7 @@ import java.math.BigDecimal;
 import java.util.*;
 
 import static com.farao_community.farao.data.crac_io_cne.CneConstants.*;
+import static com.farao_community.farao.data.crac_io_cne.CneConstants.DIMENSIONLESS_SYMBOL;
 import static com.farao_community.farao.data.crac_io_cne.CneUtil.*;
 
 /**
@@ -28,7 +29,8 @@ import static com.farao_community.farao.data.crac_io_cne.CneUtil.*;
  */
 public final class CneClassCreator {
 
-    private CneClassCreator() { }
+    private CneClassCreator() {
+    }
 
     /*****************
      POINT
@@ -156,7 +158,7 @@ public final class CneClassCreator {
     /*****************
      MEASUREMENT
      *****************/
-    public static Analog newMeasurement(String measurementType, Unit unit, double flow) {
+    public static Analog newFlowMeasurement(String measurementType, Unit unit, double flow) {
         Analog measurement = new Analog();
         measurement.setMeasurementType(measurementType);
 
@@ -175,6 +177,14 @@ public final class CneClassCreator {
         }
         measurement.setAnalogValuesValue(limitFloatInterval(flow));
 
+        return measurement;
+    }
+
+    public static Analog newPtdfMeasurement(String measurementType, double value) {
+        Analog measurement = new Analog();
+        measurement.setMeasurementType(measurementType);
+        measurement.setUnitSymbol(DIMENSIONLESS_SYMBOL);
+        measurement.setAnalogValuesValue((float) (Math.round(value * 1e5) / 1e5));
         return measurement;
     }
 

--- a/data/crac-io/crac-io-cne/src/main/java/com/farao_community/farao/data/crac_io_cne/CneConstants.java
+++ b/data/crac-io/crac-io-cne/src/main/java/com/farao_community/farao/data/crac_io_cne/CneConstants.java
@@ -78,6 +78,7 @@ public final class CneConstants {
     // unitSymbol
     public static final String AMP_UNIT_SYMBOL = "AMP";
     public static final String MAW_UNIT_SYMBOL = "MAW";
+    public static final String DIMENSIONLESS_SYMBOL = "C62";
     // positiveFlowIn
     public static final String DIRECT_POSITIVE_FLOW_IN = "A01";
     public static final String OPPOSITE_POSITIVE_FLOW_IN = "A02";

--- a/data/crac-io/crac-io-cne/src/test/java/com/farao_community/farao/data/crac_io_cne/CneGenerationTest.java
+++ b/data/crac-io/crac-io-cne/src/test/java/com/farao_community/farao/data/crac_io_cne/CneGenerationTest.java
@@ -29,7 +29,6 @@ public class CneGenerationTest {
 
     @Test
     public void testExport1() {
-
         Crac crac = CracImporters.importCrac("US2-3-crac1-standard.json", getClass().getResourceAsStream("/US2-3-crac1-standard.json"));
         Network network = Importers.loadNetwork("US2-3-case1-standard.uct", getClass().getResourceAsStream("/US2-3-case1-standard.uct"));
 
@@ -66,17 +65,17 @@ public class CneGenerationTest {
             // Constraint series B54
             assertEquals(1, constraintSeriesB54.get().getMonitoredSeries().size());
             assertEquals(2, constraintSeriesB54.get().getRemedialActionSeries().size());
-            assertEquals(11, constraintSeriesB54.get().getMonitoredSeries().get(0).getRegisteredResource().get(0).getMeasurements().size());
+            assertEquals(12, constraintSeriesB54.get().getMonitoredSeries().get(0).getRegisteredResource().get(0).getMeasurements().size());
             assertNotSame(constraintSeriesB54.get().getRemedialActionSeries().get(0).getMRID(), constraintSeriesB54.get().getRemedialActionSeries().get(1).getMRID());
             // Constraint series B57
             assertEquals(1, constraintSeriesB57.get().getMonitoredSeries().size());
             assertEquals(2, constraintSeriesB57.get().getRemedialActionSeries().size());
-            assertEquals(11, constraintSeriesB57.get().getMonitoredSeries().get(0).getRegisteredResource().get(0).getMeasurements().size());
+            assertEquals(12, constraintSeriesB57.get().getMonitoredSeries().get(0).getRegisteredResource().get(0).getMeasurements().size());
             // Constraint series B88
             assertEquals("10YFR-RTE------C", constraintSeriesB88.get().getPartyMarketParticipant().get(0).getMRID().getValue());
             assertEquals(0, constraintSeriesB88.get().getContingencySeries().size());
             MonitoredRegisteredResource monitoredRegisteredResource = constraintSeriesB88.get().getMonitoredSeries().get(0).getRegisteredResource().get(0);
-            assertEquals(17, monitoredRegisteredResource.getMeasurements().size());
+            assertEquals(18, monitoredRegisteredResource.getMeasurements().size());
             assertEquals("FFR1AA1  FFR2AA1  1 - N - preventive", monitoredRegisteredResource.getMRID().getValue().substring(0, 36));
             assertEquals("Threshold12", monitoredRegisteredResource.getName());
             assertEquals("FFR1AA1 ", monitoredRegisteredResource.getInAggregateNodeMRID().getValue());
@@ -115,10 +114,13 @@ public class CneGenerationTest {
         double tolerance = 1.0;
         double flowA = preOptim ? 16540 : 13186;
         double flowMW = preOptim ? 2853 : 2278;
+        double absPtdfSum = 0.5;
         double thresholdA = 3325;
         double thresholdMW = 2304;
         double marginA = thresholdA - flowA;
         double marginMW = thresholdMW - flowMW;
+        double objA = marginA > 0 ? -marginA / absPtdfSum : -marginA;
+        double objMW = marginMW > 0 ? -marginMW / absPtdfSum : -marginMW;
         double loopflow = preOptim ? 13.0 : 5.0;
         int iMeasure = 0;
         // Measurement A01 - AMP
@@ -166,6 +168,11 @@ public class CneGenerationTest {
             assertEquals(DIRECT_POSITIVE_FLOW_IN, measurements.get(iMeasure).getPositiveFlowIn());
             assertEquals(thresholdMW, measurements.get(iMeasure).getAnalogValuesValue(), tolerance);
         }
+        // Z11
+        iMeasure++;
+        assertEquals(SUM_PTDF_MEASUREMENT_TYPE, measurements.get(iMeasure).getMeasurementType());
+        assertEquals(DIMENSIONLESS_SYMBOL, measurements.get(iMeasure).getUnitSymbol());
+        assertEquals(absPtdfSum, measurements.get(iMeasure).getAnalogValuesValue(), 0);
         if (withPatl) {
             // Measurement Z12 - AMP
             iMeasure++;
@@ -183,14 +190,14 @@ public class CneGenerationTest {
             iMeasure++;
             assertEquals(OBJ_FUNC_PATL_MEASUREMENT_TYPE, measurements.get(iMeasure).getMeasurementType());
             assertEquals(AMP_UNIT_SYMBOL, measurements.get(iMeasure).getUnitSymbol());
-            assertEquals(marginA > 0 ? OPPOSITE_POSITIVE_FLOW_IN : DIRECT_POSITIVE_FLOW_IN, measurements.get(iMeasure).getPositiveFlowIn());
-            assertEquals(Math.abs(marginA), measurements.get(iMeasure).getAnalogValuesValue(), tolerance);
+            assertEquals(objA < 0 ? OPPOSITE_POSITIVE_FLOW_IN : DIRECT_POSITIVE_FLOW_IN, measurements.get(iMeasure).getPositiveFlowIn());
+            assertEquals(Math.abs(objA), measurements.get(iMeasure).getAnalogValuesValue(), tolerance);
             // Measurement Z13 - MAW
             iMeasure++;
             assertEquals(OBJ_FUNC_PATL_MEASUREMENT_TYPE, measurements.get(iMeasure).getMeasurementType());
             assertEquals(MAW_UNIT_SYMBOL, measurements.get(iMeasure).getUnitSymbol());
-            assertEquals(marginMW > 0 ? OPPOSITE_POSITIVE_FLOW_IN : DIRECT_POSITIVE_FLOW_IN, measurements.get(iMeasure).getPositiveFlowIn());
-            assertEquals(Math.abs(marginMW), measurements.get(iMeasure).getAnalogValuesValue(), tolerance);
+            assertEquals(objMW < 0 ? OPPOSITE_POSITIVE_FLOW_IN : DIRECT_POSITIVE_FLOW_IN, measurements.get(iMeasure).getPositiveFlowIn());
+            assertEquals(Math.abs(objMW), measurements.get(iMeasure).getAnalogValuesValue(), tolerance);
         }
         if (withTatl) {
             // Measurement Z14 - AMP
@@ -209,14 +216,14 @@ public class CneGenerationTest {
             iMeasure++;
             assertEquals(OBJ_FUNC_TATL_MEASUREMENT_TYPE, measurements.get(iMeasure).getMeasurementType());
             assertEquals(AMP_UNIT_SYMBOL, measurements.get(iMeasure).getUnitSymbol());
-            assertEquals(marginA > 0 ? OPPOSITE_POSITIVE_FLOW_IN : DIRECT_POSITIVE_FLOW_IN, measurements.get(iMeasure).getPositiveFlowIn());
-            assertEquals(Math.abs(marginA), measurements.get(iMeasure).getAnalogValuesValue(), tolerance);
+            assertEquals(objA < 0 ? OPPOSITE_POSITIVE_FLOW_IN : DIRECT_POSITIVE_FLOW_IN, measurements.get(iMeasure).getPositiveFlowIn());
+            assertEquals(Math.abs(objA), measurements.get(iMeasure).getAnalogValuesValue(), tolerance);
             // Measurement Z15 - MAW
             iMeasure++;
             assertEquals(OBJ_FUNC_TATL_MEASUREMENT_TYPE, measurements.get(iMeasure).getMeasurementType());
             assertEquals(MAW_UNIT_SYMBOL, measurements.get(iMeasure).getUnitSymbol());
-            assertEquals(marginMW > 0 ? OPPOSITE_POSITIVE_FLOW_IN : DIRECT_POSITIVE_FLOW_IN, measurements.get(iMeasure).getPositiveFlowIn());
-            assertEquals(Math.abs(marginMW), measurements.get(iMeasure).getAnalogValuesValue(), tolerance);
+            assertEquals(objMW < 0 ? OPPOSITE_POSITIVE_FLOW_IN : DIRECT_POSITIVE_FLOW_IN, measurements.get(iMeasure).getPositiveFlowIn());
+            assertEquals(Math.abs(objMW), measurements.get(iMeasure).getAnalogValuesValue(), tolerance);
         }
         // Measurement Z16 - MAW
         iMeasure++;

--- a/data/crac-io/crac-io-cne/src/test/resources/US2-3-crac1-standard.json
+++ b/data/crac-io/crac-io-cne/src/test/resources/US2-3-crac1-standard.json
@@ -59,7 +59,8 @@
             "minThresholdInA" : -3325.0,
             "maxThresholdInA" : 3325.0,
             "loopflowInMW" : -5.0,
-            "loopflowThresholdInMW" : 19.0
+            "loopflowThresholdInMW" : 19.0,
+            "absolutePtdfSum" : 0.5
           },
           "preOptimisationResults-2ad0d908-b660-48cf-9f1a-f3add0d6f005" : {
             "type" : "cnec-result",
@@ -70,7 +71,8 @@
             "minThresholdInA" : -3325.0,
             "maxThresholdInA" : 3325.0,
             "loopflowInMW" : -13.0,
-            "loopflowThresholdInMW" : 19.0
+            "loopflowThresholdInMW" : 19.0,
+            "absolutePtdfSum" : 0.5
           }
         }
       }

--- a/data/crac-io/crac-io-cne/src/test/resources/US3-2-pst-direct.json
+++ b/data/crac-io/crac-io-cne/src/test/resources/US3-2-pst-direct.json
@@ -92,7 +92,8 @@
             "minThresholdInMW" : -Infinity,
             "maxThresholdInMW" : 1039.2304845413264,
             "minThresholdInA" : -Infinity,
-            "maxThresholdInA" : 1500.0
+            "maxThresholdInA" : 1500.0,
+            "absolutePtdfSum" : NaN
           },
           "postOptimisationResults-5541441d-b49f-4670-bb70-d30e60c8ccaa" : {
             "type" : "cnec-result",
@@ -101,7 +102,8 @@
             "minThresholdInMW" : -Infinity,
             "maxThresholdInMW" : 1039.2304845413264,
             "minThresholdInA" : -Infinity,
-            "maxThresholdInA" : 1500.0
+            "maxThresholdInA" : 1500.0,
+            "absolutePtdfSum" : NaN
           }
         }
       }
@@ -130,7 +132,8 @@
             "minThresholdInMW" : -1039.2304845413264,
             "maxThresholdInMW" : 1039.2304845413264,
             "minThresholdInA" : -1500.0,
-            "maxThresholdInA" : 1500.0
+            "maxThresholdInA" : 1500.0,
+            "absolutePtdfSum" : NaN
           },
           "postOptimisationResults-5541441d-b49f-4670-bb70-d30e60c8ccaa" : {
             "type" : "cnec-result",
@@ -139,7 +142,8 @@
             "minThresholdInMW" : -1039.2304845413264,
             "maxThresholdInMW" : 1039.2304845413264,
             "minThresholdInA" : -1500.0,
-            "maxThresholdInA" : 1500.0
+            "maxThresholdInA" : 1500.0,
+            "absolutePtdfSum" : NaN
           }
         }
       }
@@ -168,7 +172,8 @@
             "minThresholdInMW" : -1039.2304845413264,
             "maxThresholdInMW" : 1039.2304845413264,
             "minThresholdInA" : -1500.0,
-            "maxThresholdInA" : 1500.0
+            "maxThresholdInA" : 1500.0,
+            "absolutePtdfSum" : NaN
           },
           "postOptimisationResults-5541441d-b49f-4670-bb70-d30e60c8ccaa" : {
             "type" : "cnec-result",
@@ -177,7 +182,8 @@
             "minThresholdInMW" : -1039.2304845413264,
             "maxThresholdInMW" : 1039.2304845413264,
             "minThresholdInA" : -1500.0,
-            "maxThresholdInA" : 1500.0
+            "maxThresholdInA" : 1500.0,
+            "absolutePtdfSum" : NaN
           }
         }
       }
@@ -206,7 +212,8 @@
             "minThresholdInMW" : -1039.2304845413264,
             "maxThresholdInMW" : 1039.2304845413264,
             "minThresholdInA" : -1500.0,
-            "maxThresholdInA" : 1500.0
+            "maxThresholdInA" : 1500.0,
+            "absolutePtdfSum" : NaN
           },
           "postOptimisationResults-5541441d-b49f-4670-bb70-d30e60c8ccaa" : {
             "type" : "cnec-result",
@@ -215,7 +222,8 @@
             "minThresholdInMW" : -1039.2304845413264,
             "maxThresholdInMW" : 1039.2304845413264,
             "minThresholdInA" : -1500.0,
-            "maxThresholdInA" : 1500.0
+            "maxThresholdInA" : 1500.0,
+            "absolutePtdfSum" : NaN
           }
         }
       }
@@ -244,7 +252,8 @@
             "minThresholdInMW" : -Infinity,
             "maxThresholdInMW" : 1039.2304845413264,
             "minThresholdInA" : -Infinity,
-            "maxThresholdInA" : 1500.0
+            "maxThresholdInA" : 1500.0,
+            "absolutePtdfSum" : NaN
           },
           "postOptimisationResults-5541441d-b49f-4670-bb70-d30e60c8ccaa" : {
             "type" : "cnec-result",
@@ -253,7 +262,8 @@
             "minThresholdInMW" : -Infinity,
             "maxThresholdInMW" : 1039.2304845413264,
             "minThresholdInA" : -Infinity,
-            "maxThresholdInA" : 1500.0
+            "maxThresholdInA" : 1500.0,
+            "absolutePtdfSum" : NaN
           }
         }
       }
@@ -282,7 +292,8 @@
             "minThresholdInMW" : -Infinity,
             "maxThresholdInMW" : 1039.2304845413264,
             "minThresholdInA" : -Infinity,
-            "maxThresholdInA" : 1500.0
+            "maxThresholdInA" : 1500.0,
+            "absolutePtdfSum" : NaN
           },
           "postOptimisationResults-5541441d-b49f-4670-bb70-d30e60c8ccaa" : {
             "type" : "cnec-result",
@@ -291,7 +302,8 @@
             "minThresholdInMW" : -Infinity,
             "maxThresholdInMW" : 1039.2304845413264,
             "minThresholdInA" : -Infinity,
-            "maxThresholdInA" : 1500.0
+            "maxThresholdInA" : 1500.0,
+            "absolutePtdfSum" : NaN
           }
         }
       }


### PR DESCRIPTION
**<!>** This is a simple implementation of feature mentioned here : #405 
The difference is that relative positive margins are detected upon the presence of absolute ptdf sums, which is not very clean but a lot less intrusive in the rest of the code.
When CRAC import / export is refactored, this info can be taken from RaoParameters' objective function directly, which can be stored in RaoResult.

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Z11 measurement (absolute PTDF sum for a given CNEC) is not exported in CNE file
The objective function (Z13 and Z15) is always equal to the opposite of the margin


**What is the new behavior (if this is a feature change)?**
Z11 is exported
The objective function is relative (divided by Z11) when the margin is positive


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
Know that if Z11 exists, positive margins will automatically be divided by Z11 regardless of the objective function.
But for now, absolute ptdf sums (Z11) are only computed if the objective function is relative anyway.