### PR TITLE
Pure MNECs patch & parallelization optimization

### DIFF
--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoUtil.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/RaoUtil.java
@@ -206,6 +206,12 @@ public final class RaoUtil {
                 filter(BranchCnec::isOptimized).
                 sorted(Comparator.comparingDouble(cnec -> computeCnecMargin(cnec, variantId, unit, relativePositiveMargins))).
                 collect(Collectors.toList());
+        if (sortedCnecs.isEmpty()) {
+            // There are only pure MNECs
+            sortedCnecs = cnecs.stream().
+                    sorted(Comparator.comparingDouble(cnec -> computeCnecMargin(cnec, variantId, unit, relativePositiveMargins))).
+                    collect(Collectors.toList());
+        }
         return sortedCnecs.get(0);
     }
 

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxMinMarginFiller.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxMinMarginFiller.java
@@ -43,7 +43,7 @@ public class MaxMinMarginFiller implements ProblemFiller {
     @Override
     public void fill(RaoData raoData, LinearProblem linearProblem) {
         // build variables
-        buildMinimumMarginVariable(linearProblem);
+        buildMinimumMarginVariable(linearProblem, raoData);
 
         // build constraints
         buildMinimumMarginConstraints(raoData, linearProblem);
@@ -63,8 +63,15 @@ public class MaxMinMarginFiller implements ProblemFiller {
      * This variable represents the smallest margin of all Cnecs.
      * It is given in MEGAWATT.
      */
-    private void buildMinimumMarginVariable(LinearProblem linearProblem) {
-        linearProblem.addMinimumMarginVariable(-linearProblem.infinity(), linearProblem.infinity());
+    private void buildMinimumMarginVariable(LinearProblem linearProblem, RaoData raoData) {
+
+        if (raoData.getCnecs().stream().anyMatch(BranchCnec::isOptimized)) {
+            linearProblem.addMinimumMarginVariable(-linearProblem.infinity(), linearProblem.infinity());
+        } else {
+            // if there is no Cnecs, the minMarginVariable is forced to zero.
+            // otherwise it would be unbounded in the LP
+            linearProblem.addMinimumMarginVariable(0.0, 0.0);
+        }
     }
 
     /**

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/objective_function_evaluator/MinMarginEvaluator.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/objective_function_evaluator/MinMarginEvaluator.java
@@ -70,6 +70,10 @@ public class MinMarginEvaluator implements CostEvaluator {
     }
 
     private double getMinMarginInMegawatt(RaoData raoData) {
+        if (raoData.getCnecs().stream().noneMatch(BranchCnec::isOptimized)) {
+            // There are only pure MNECs
+            return 0;
+        }
         String initialVariantId = raoData.getCrac().getExtension(ResultVariantManager.class).getInitialVariantId();
         return raoData.getCnecs().stream().filter(BranchCnec::isOptimized).
             map(cnec -> cnec.computeMargin(raoData.getSystematicSensitivityResult().getReferenceFlow(cnec), Side.LEFT, MEGAWATT) * getRelativeCoef(cnec, initialVariantId)).
@@ -77,6 +81,10 @@ public class MinMarginEvaluator implements CostEvaluator {
     }
 
     private double getMinMarginInAmpere(RaoData raoData) {
+        if (raoData.getCnecs().stream().noneMatch(BranchCnec::isOptimized)) {
+            // There are only pure MNECs
+            return 0;
+        }
         String initialVariantId = raoData.getCrac().getExtension(ResultVariantManager.class).getInitialVariantId();
         List<Double> marginsInAmpere = raoData.getCnecs().stream().filter(BranchCnec::isOptimized).
             map(cnec -> cnec.computeMargin(raoData.getSystematicSensitivityResult().getReferenceIntensity(cnec), Side.LEFT, Unit.AMPERE) * getRelativeCoef(cnec, initialVariantId)

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoUtilTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoUtilTest.java
@@ -273,8 +273,7 @@ public class RaoUtilTest {
         assertEquals(-100, RaoUtil.computeCnecMargin(cnec, variantId, AMPERE, true), DOUBLE_TOLERANCE);
     }
 
-    @Test
-    public void testGetMostLimitingElement() {
+    private Set<BranchCnec> setUpMockCnecs(boolean optimized, boolean monitored) {
         // CNEC 1 : margin of 1000 MW / 100 A, sum of PTDFs = 1
         CnecResult result1 = Mockito.mock(CnecResult.class);
         Mockito.when(result1.getAbsolutePtdfSum()).thenReturn(1.0);
@@ -282,7 +281,9 @@ public class RaoUtilTest {
         Mockito.when(resultExtension1.getVariant(Mockito.anyString())).thenReturn(result1);
 
         BranchCnec cnec1 = Mockito.mock(BranchCnec.class);
-        Mockito.when(cnec1.isOptimized()).thenReturn(true);
+        Mockito.when(cnec1.getId()).thenReturn("cnec1");
+        Mockito.when(cnec1.isOptimized()).thenReturn(optimized);
+        Mockito.when(cnec1.isMonitored()).thenReturn(monitored);
         Mockito.when(cnec1.getExtension(Mockito.eq(CnecResultExtension.class))).thenReturn(resultExtension1);
         Mockito.when(cnec1.computeMargin(Mockito.anyDouble(), Mockito.any(), Mockito.eq(MEGAWATT))).thenReturn(1000.);
         Mockito.when(cnec1.computeMargin(Mockito.anyDouble(), Mockito.any(), Mockito.eq(AMPERE))).thenReturn(100.);
@@ -294,20 +295,41 @@ public class RaoUtilTest {
         Mockito.when(resultExtension2.getVariant(Mockito.anyString())).thenReturn(result2);
 
         BranchCnec cnec2 = Mockito.mock(BranchCnec.class);
-        Mockito.when(cnec2.isOptimized()).thenReturn(true);
+        Mockito.when(cnec2.getId()).thenReturn("cnec2");
+        Mockito.when(cnec2.isOptimized()).thenReturn(optimized);
+        Mockito.when(cnec2.isMonitored()).thenReturn(monitored);
         Mockito.when(cnec2.getExtension(Mockito.eq(CnecResultExtension.class))).thenReturn(resultExtension2);
         Mockito.when(cnec2.computeMargin(Mockito.anyDouble(), Mockito.any(), Mockito.eq(MEGAWATT))).thenReturn(600.);
         Mockito.when(cnec2.computeMargin(Mockito.anyDouble(), Mockito.any(), Mockito.eq(AMPERE))).thenReturn(60.);
 
-        Set<BranchCnec> cnecs = Sets.newHashSet(cnec1, cnec2);
+         return Sets.newHashSet(cnec1, cnec2);
+    }
+
+    @Test
+    public void testGetMostLimitingElement() {
+        Set<BranchCnec> cnecs = setUpMockCnecs(true, false);
 
         // In absolute margins, cnec2 is most limiting
-        assertSame(cnec2, RaoUtil.getMostLimitingElement(cnecs, variantId, MEGAWATT, false));
-        assertSame(cnec2, RaoUtil.getMostLimitingElement(cnecs, variantId, AMPERE, false));
+        assertEquals("cnec2", RaoUtil.getMostLimitingElement(cnecs, variantId, MEGAWATT, false).getId());
+        assertEquals("cnec2", RaoUtil.getMostLimitingElement(cnecs, variantId, AMPERE, false).getId());
 
         // In relative margins, cnec1 is most limiting
-        assertSame(cnec1, RaoUtil.getMostLimitingElement(cnecs, variantId, MEGAWATT, true));
-        assertSame(cnec1, RaoUtil.getMostLimitingElement(cnecs, variantId, AMPERE, true));
+        assertEquals("cnec1", RaoUtil.getMostLimitingElement(cnecs, variantId, MEGAWATT, true).getId());
+        assertEquals("cnec1", RaoUtil.getMostLimitingElement(cnecs, variantId, AMPERE, true).getId());
+    }
+
+    @Test
+    public void testGetMostLimitingElementOnPureMnecs() {
+        Set<BranchCnec> cnecs = setUpMockCnecs(false, true);
+
+        // In absolute margins, cnec2 is most limiting
+        assertEquals("cnec2", RaoUtil.getMostLimitingElement(cnecs, variantId, MEGAWATT, false).getId());
+        assertEquals("cnec2", RaoUtil.getMostLimitingElement(cnecs, variantId, AMPERE, false).getId());
+
+        // In relative margins, cnec1 is most limiting
+        assertEquals("cnec1", RaoUtil.getMostLimitingElement(cnecs, variantId, MEGAWATT, true).getId());
+        assertEquals("cnec1", RaoUtil.getMostLimitingElement(cnecs, variantId, AMPERE, true).getId());
+
     }
 }
 

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoUtilTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/RaoUtilTest.java
@@ -56,14 +56,14 @@ public class RaoUtilTest {
         crac = CommonCracCreation.create();
         variantId = network.getVariantManager().getWorkingVariantId();
         raoInput = RaoInput.buildWithPreventiveState(network, crac)
-            .withNetworkVariantId(variantId)
-            .build();
+                .withNetworkVariantId(variantId)
+                .build();
         raoParameters = new RaoParameters();
     }
 
     private void addGlskProvider() {
         ZonalData<LinearGlsk> glskProvider = UcteGlskDocument.importGlsk(getClass().getResourceAsStream("/GlskCountry.xml"))
-            .getZonalGlsks(network);
+                .getZonalGlsks(network);
         raoInput = RaoInput.buildWithPreventiveState(network, crac)
                 .withNetworkVariantId(variantId)
                 .withGlskProvider(glskProvider)
@@ -160,7 +160,7 @@ public class RaoUtilTest {
     @Test
     public void testCreationOfSystematicSensitivityInterface() {
         raoParameters.setRaoWithLoopFlowLimitation(true);
-        raoData =  new RaoData(
+        raoData = new RaoData(
                 raoInput.getNetwork(),
                 raoInput.getCrac(),
                 raoInput.getOptimizedState(),
@@ -173,7 +173,7 @@ public class RaoUtilTest {
         assertNotNull(systematicSensitivityInterface);
     }
 
-    @Test (expected = FaraoException.class)
+    @Test(expected = FaraoException.class)
     public void testExceptionForGlskOnRelativeMargin() {
         raoParameters.setRelativeMarginPtdfBoundariesFromString(new ArrayList<>(Arrays.asList("FR:ES", "ES:PT")));
         raoParameters.setObjectiveFunction(MAX_MIN_RELATIVE_MARGIN_IN_AMPERE);
@@ -207,7 +207,7 @@ public class RaoUtilTest {
         raoParameters.setRelativeMarginPtdfBoundariesFromString(new ArrayList<>(Arrays.asList("FR/BE", "BE/NL", "FR/DE", "DE/NL")));
         addGlskProvider();
         raoParameters.setObjectiveFunction(MAX_MIN_RELATIVE_MARGIN_IN_MEGAWATT);
-        raoData =  new RaoData(
+        raoData = new RaoData(
                 raoInput.getNetwork(),
                 raoInput.getCrac(),
                 raoInput.getOptimizedState(),
@@ -302,7 +302,7 @@ public class RaoUtilTest {
         Mockito.when(cnec2.computeMargin(Mockito.anyDouble(), Mockito.any(), Mockito.eq(MEGAWATT))).thenReturn(600.);
         Mockito.when(cnec2.computeMargin(Mockito.anyDouble(), Mockito.any(), Mockito.eq(AMPERE))).thenReturn(60.);
 
-         return Sets.newHashSet(cnec1, cnec2);
+        return Sets.newHashSet(cnec1, cnec2);
     }
 
     @Test

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/objective_function_evaluator/MinMarginEvaluatorTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/objective_function_evaluator/MinMarginEvaluatorTest.java
@@ -10,9 +10,11 @@ package com.farao_community.farao.rao_commons.objective_function_evaluator;
 import com.farao_community.farao.commons.FaraoException;
 import com.farao_community.farao.commons.Unit;
 import com.farao_community.farao.data.crac_api.Crac;
+import com.farao_community.farao.data.crac_api.cnec.BranchCnec;
 import com.farao_community.farao.data.crac_api.threshold.BranchThresholdRule;
 import com.farao_community.farao.data.crac_impl.utils.CommonCracCreation;
 import com.farao_community.farao.data.crac_impl.utils.NetworkImportsUtil;
+import com.farao_community.farao.data.crac_result_extensions.CnecResult;
 import com.farao_community.farao.data.crac_result_extensions.CnecResultExtension;
 import com.farao_community.farao.data.crac_result_extensions.ResultVariantManager;
 import com.farao_community.farao.rao_api.RaoParameters;
@@ -20,13 +22,17 @@ import com.farao_community.farao.rao_commons.RaoData;
 import com.farao_community.farao.rao_commons.RaoInputHelper;
 import com.farao_community.farao.sensitivity_analysis.SystematicSensitivityResult;
 import com.powsybl.iidm.network.Network;
+import org.apache.commons.compress.utils.Sets;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
+import static com.farao_community.farao.commons.Unit.AMPERE;
+import static com.farao_community.farao.commons.Unit.MEGAWATT;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 
@@ -162,4 +168,48 @@ public class MinMarginEvaluatorTest {
         assertEquals(2990, margins.get(0), DOUBLE_TOLERANCE);
         assertEquals(4254, margins.get(1), DOUBLE_TOLERANCE);
     }
+
+    private Set<BranchCnec> setUpMockCnecs(boolean optimized, boolean monitored) {
+        // CNEC 1 : margin of 1000 MW / 100 A, sum of PTDFs = 1
+        CnecResult result1 = Mockito.mock(CnecResult.class);
+        Mockito.when(result1.getAbsolutePtdfSum()).thenReturn(1.0);
+        CnecResultExtension resultExtension1 = Mockito.mock(CnecResultExtension.class);
+        Mockito.when(resultExtension1.getVariant(Mockito.anyString())).thenReturn(result1);
+
+        BranchCnec cnec1 = Mockito.mock(BranchCnec.class);
+        Mockito.when(cnec1.getId()).thenReturn("cnec1");
+        Mockito.when(cnec1.isOptimized()).thenReturn(optimized);
+        Mockito.when(cnec1.isMonitored()).thenReturn(monitored);
+        Mockito.when(cnec1.getExtension(Mockito.eq(CnecResultExtension.class))).thenReturn(resultExtension1);
+        Mockito.when(cnec1.computeMargin(Mockito.anyDouble(), Mockito.any(), Mockito.eq(MEGAWATT))).thenReturn(1000.);
+        Mockito.when(cnec1.computeMargin(Mockito.anyDouble(), Mockito.any(), Mockito.eq(AMPERE))).thenReturn(100.);
+
+        // CNEC 2 : margin of 600 MW / 60 A, sum of PTDFs = 0.5
+        CnecResult result2 = Mockito.mock(CnecResult.class);
+        Mockito.when(result2.getAbsolutePtdfSum()).thenReturn(0.5);
+        CnecResultExtension resultExtension2 = Mockito.mock(CnecResultExtension.class);
+        Mockito.when(resultExtension2.getVariant(Mockito.anyString())).thenReturn(result2);
+
+        BranchCnec cnec2 = Mockito.mock(BranchCnec.class);
+        Mockito.when(cnec2.getId()).thenReturn("cnec2");
+        Mockito.when(cnec2.isOptimized()).thenReturn(optimized);
+        Mockito.when(cnec2.isMonitored()).thenReturn(monitored);
+        Mockito.when(cnec2.getExtension(Mockito.eq(CnecResultExtension.class))).thenReturn(resultExtension2);
+        Mockito.when(cnec2.computeMargin(Mockito.anyDouble(), Mockito.any(), Mockito.eq(MEGAWATT))).thenReturn(600.);
+        Mockito.when(cnec2.computeMargin(Mockito.anyDouble(), Mockito.any(), Mockito.eq(AMPERE))).thenReturn(60.);
+
+        return Sets.newHashSet(cnec1, cnec2);
+    }
+
+    @Test
+    public void testPureMnecs() {
+        Set<BranchCnec> mnecs = setUpMockCnecs(false, true);
+        RaoData mockRaoData = Mockito.mock(RaoData.class);
+        Mockito.when(mockRaoData.getCnecs()).thenReturn(mnecs);
+        assertEquals(0, new MinMarginEvaluator(MEGAWATT, false, 0.02).getCost(mockRaoData), DOUBLE_TOLERANCE);
+        assertEquals(0, new MinMarginEvaluator(MEGAWATT, true, 0.02).getCost(mockRaoData), DOUBLE_TOLERANCE);
+        assertEquals(0, new MinMarginEvaluator(AMPERE, false, 0.02).getCost(mockRaoData), DOUBLE_TOLERANCE);
+        assertEquals(0, new MinMarginEvaluator(AMPERE, true, 0.02).getCost(mockRaoData), DOUBLE_TOLERANCE);
+    }
+
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTree.java
@@ -141,8 +141,9 @@ public class SearchTree {
         }
         AtomicInteger remainingLeaves = new AtomicInteger(networkActions.size());
         Network network = rootLeaf.getRaoData().getNetwork(); // NetworkPool starts from root leaf network to keep initial optimization of range actions
-        LOGGER.debug("Evaluating {} leaves in parallel", treeParameters.getLeavesInParallel());
-        try (FaraoNetworkPool networkPool = new FaraoNetworkPool(network, network.getVariantManager().getWorkingVariantId(), treeParameters.getLeavesInParallel())) {
+        int leavesInParallel = Math.min(networkActions.size(), treeParameters.getLeavesInParallel());
+        LOGGER.debug("Evaluating {} leaves in parallel", leavesInParallel);
+        try (FaraoNetworkPool networkPool = new FaraoNetworkPool(network, network.getVariantManager().getWorkingVariantId(), leavesInParallel)) {
             networkActions.forEach(networkAction ->
                     networkPool.submit(() -> {
                         try {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix + feature


**What is the current behavior?** *(You can also link to an open issue here)*
- When an optimized perimeter only has pure MNECs, RaoUtil and MinMarginEvaluator can crash since they search for the minimum margin among CNECs
- In the search tree parallelization, we always create X copies of the network for leaves, where X is the "leaves-in-parallel" parameter, even if there isn't that many network actions

**What is the new behavior (if this is a feature change)?**
- In the evaluator, if only pure MNECs exist; the functional cost is considered equal to zero. This allows the RAO to optimize the functional cost. 
- In RaoUtil, if only pure MNECs exist, then the worst element is considered among these mnecs
- In search tree leaves parallelization, if less network actions exist than the leves-in-parameter exist, then this number is used for parallelization


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No
