### PR TITLE
Fix behaviour when a LinearGlsk is missing

### DIFF
--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/AbsolutePtdfSumsComputation.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/AbsolutePtdfSumsComputation.java
@@ -53,6 +53,7 @@ public final class AbsolutePtdfSumsComputation {
 
     private static double computeZToZPtdf(ZoneToZonePtdfDefinition zToz, Map<EICode, Double> zToSlackPtdfMap) {
         if (zToz.getZoneToSlackPtdfs().stream().anyMatch(zToS -> !zToSlackPtdfMap.containsKey(zToS.getEiCode()))) {
+            // If one zone is missing its PTDF, ignore the boundary
             return 0;
         }
         return zToz.getZoneToSlackPtdfs().stream()

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/AbsolutePtdfSumsComputation.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/AbsolutePtdfSumsComputation.java
@@ -52,6 +52,9 @@ public final class AbsolutePtdfSumsComputation {
     }
 
     private static double computeZToZPtdf(ZoneToZonePtdfDefinition zToz, Map<EICode, Double> zToSlackPtdfMap) {
+        if (zToz.getZoneToSlackPtdfs().stream().anyMatch(zToS -> !zToSlackPtdfMap.containsKey(zToS.getEiCode()))) {
+            return 0;
+        }
         return zToz.getZoneToSlackPtdfs().stream()
             .mapToDouble(zToS -> zToS.getWeight() * zToSlackPtdfMap.get(zToS.getEiCode()))
             .sum();

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/AbsolutePtdfSumsComputation.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/AbsolutePtdfSumsComputation.java
@@ -43,8 +43,10 @@ public final class AbsolutePtdfSumsComputation {
         Map<EICode, Double> ptdfs = new HashMap<>();
         for (EICode eiCode : eiCodesInBoundaries) {
             LinearGlsk linearGlsk = glsks.getData(eiCode.getAreaCode());
-            double ptdfValue = sensitivityResult.getSensitivityOnFlow(linearGlsk, cnec);
-            ptdfs.put(eiCode, ptdfValue);
+            if (linearGlsk != null) {
+                double ptdfValue = sensitivityResult.getSensitivityOnFlow(linearGlsk, cnec);
+                ptdfs.put(eiCode, ptdfValue);
+            }
         }
         return ptdfs;
     }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/AbsolutePtdfSumsComputationTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/AbsolutePtdfSumsComputationTest.java
@@ -107,4 +107,24 @@ public class AbsolutePtdfSumsComputationTest {
         assertEquals(0, ptdfSums.get(crac.getBranchCnec("cnec2stateCurativeContingency1")), DOUBLE_TOLERANCE);
         assertEquals(0, ptdfSums.get(crac.getBranchCnec("cnec2stateCurativeContingency2")), DOUBLE_TOLERANCE);
     }
+
+    @Test
+    public void testIgnoreAbsentGlsk() {
+        boundaries = Arrays.asList(
+                new ZoneToZonePtdfDefinition("{FR}-{BE}"),
+                new ZoneToZonePtdfDefinition("{FR}-{DE}"),
+                new ZoneToZonePtdfDefinition("{DE}-{BE}"),
+                new ZoneToZonePtdfDefinition("{BE}-{22Y201903144---9}-{DE}+{22Y201903145---4}"),
+                new ZoneToZonePtdfDefinition("{FR}-{ES}"), // ES doesn't exist in GLSK map
+                new ZoneToZonePtdfDefinition("{ES}-{DE}"), // ES doesn't exist in GLSK map
+                new ZoneToZonePtdfDefinition("{22Y201903144---0}-{22Y201903144---1}")); // EICodes that don't exist in GLSK map
+        Map<BranchCnec, Double> ptdfSums = AbsolutePtdfSumsComputation.computeAbsolutePtdfSums(crac.getBranchCnecs(), glskProvider, boundaries, systematicSensitivityResult);
+        // Test that these 3 new boundaries are ignored (results should be the same as previous test)
+        assertEquals(0.6, ptdfSums.get(crac.getBranchCnec("cnec1basecase")), DOUBLE_TOLERANCE);
+        assertEquals(0.9, ptdfSums.get(crac.getBranchCnec("cnec2basecase")), DOUBLE_TOLERANCE);
+        assertEquals(0, ptdfSums.get(crac.getBranchCnec("cnec1stateCurativeContingency1")), DOUBLE_TOLERANCE);
+        assertEquals(0, ptdfSums.get(crac.getBranchCnec("cnec1stateCurativeContingency2")), DOUBLE_TOLERANCE);
+        assertEquals(0, ptdfSums.get(crac.getBranchCnec("cnec2stateCurativeContingency1")), DOUBLE_TOLERANCE);
+        assertEquals(0, ptdfSums.get(crac.getBranchCnec("cnec2stateCurativeContingency2")), DOUBLE_TOLERANCE);
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When a GLSK is missing for an area / timestamp, the absolute PTDF sums cannot be computed


**What is the new behavior (if this is a feature change)?**
When a GLSK is missing for an area / timestamp, the boundary is ignored
