### PR TITLE
Import all loads and generators in network post-processing

### DIFF
--- a/distribution/src/main/resources/core-cc-ucte-postProcessor.groovy
+++ b/distribution/src/main/resources/core-cc-ucte-postProcessor.groovy
@@ -3,7 +3,6 @@ import com.powsybl.iidm.network.DanglingLine
 import com.powsybl.iidm.network.EnergySource
 import com.powsybl.iidm.network.LoadType
 import com.powsybl.iidm.network.Network
-import com.powsybl.iidm.network.Network
 import com.powsybl.iidm.network.VoltageLevel
 
 /*
@@ -32,6 +31,59 @@ def updateVoltageLevelNominalV(VoltageLevel voltageLevel) {
         voltageLevel.nominalV = 225
     } else {
         // Should not be changed cause is not equal to the default nominal voltage of voltage levels 6 or 7
+    }
+}
+
+/*
+    When importing an UCTE network file, powsybl ignores generators and loads that do not have an initial power flow.
+
+    It can cause an error if a GLSK file associated to this network includes some factors on
+    these nodes. The GLSK importers looks for a Generator (GSK) or Load (LSK) associated to this
+    node. If the Generator/Load does not exist, the GLSK cannot be created.
+
+    This script fix this problem, by creating for all missing generators a generator (P, Q = 0),
+    and all missing loads a load (P, Q = 0).
+ */
+
+createMissingGeneratorsAndLoads()
+
+void createMissingGeneratorsAndLoads() {
+    network.getVoltageLevelStream().forEach({voltageLevel -> createMissingGeneratorsAndLoads(voltageLevel)})
+}
+
+void createMissingGeneratorsAndLoads(VoltageLevel voltageLevel) {
+    voltageLevel.getBusBreakerView().getBuses().forEach({bus -> createMissingGenerator(voltageLevel, bus.getId())})
+    voltageLevel.getBusBreakerView().getBuses().forEach({bus -> createMissingLoad(voltageLevel, bus.getId())})
+}
+
+void createMissingGenerator(VoltageLevel voltageLevel, String busId) {
+    String generatorId = busId + "_generator"
+    if (network.getGenerator(generatorId) == null) {
+        voltageLevel.newGenerator()
+                .setBus(busId)
+                .setEnsureIdUnicity(true)
+                .setId(generatorId)
+                .setMaxP(9999)
+                .setMinP(0)
+                .setTargetP(0)
+                .setTargetQ(0)
+                .setTargetV(voltageLevel.getNominalV())
+                .setVoltageRegulatorOn(false)
+                .add()
+    }
+}
+
+void createMissingLoad(VoltageLevel voltageLevel, String busId) {
+    String loadId = busId + "_load"
+    if (network.getLoad(loadId) == null) {
+        voltageLevel.newLoad()
+                .setBus(busId)
+                .setEnsureIdUnicity(true)
+                .setId(loadId)
+                .setP0(0)
+                .setQ0(0)
+                .setLoadType(LoadType.FICTITIOUS)
+                .add()
     }
 }
 

--- a/distribution/src/main/resources/core-cc-ucte-postProcessor.groovy
+++ b/distribution/src/main/resources/core-cc-ucte-postProcessor.groovy
@@ -59,31 +59,39 @@ void createMissingGeneratorsAndLoads(VoltageLevel voltageLevel) {
 void createMissingGenerator(VoltageLevel voltageLevel, String busId) {
     String generatorId = busId + "_generator"
     if (network.getGenerator(generatorId) == null) {
-        voltageLevel.newGenerator()
-                .setBus(busId)
-                .setEnsureIdUnicity(true)
-                .setId(generatorId)
-                .setMaxP(9999)
-                .setMinP(0)
-                .setTargetP(0)
-                .setTargetQ(0)
-                .setTargetV(voltageLevel.getNominalV())
-                .setVoltageRegulatorOn(false)
-                .add()
+        try {
+            voltageLevel.newGenerator()
+                    .setBus(busId)
+                    .setEnsureIdUnicity(true)
+                    .setId(generatorId)
+                    .setMaxP(9999)
+                    .setMinP(0)
+                    .setTargetP(0)
+                    .setTargetQ(0)
+                    .setTargetV(voltageLevel.getNominalV())
+                    .setVoltageRegulatorOn(false)
+                    .add()
+        } catch (Exception e) {
+            // Can't create generator
+        }
     }
 }
 
 void createMissingLoad(VoltageLevel voltageLevel, String busId) {
     String loadId = busId + "_load"
     if (network.getLoad(loadId) == null) {
-        voltageLevel.newLoad()
-                .setBus(busId)
-                .setEnsureIdUnicity(true)
-                .setId(loadId)
-                .setP0(0)
-                .setQ0(0)
-                .setLoadType(LoadType.FICTITIOUS)
-                .add()
+        try {
+            voltageLevel.newLoad()
+                    .setBus(busId)
+                    .setEnsureIdUnicity(true)
+                    .setId(loadId)
+                    .setP0(0)
+                    .setQ0(0)
+                    .setLoadType(LoadType.FICTITIOUS)
+                    .add()
+        } catch (Exception e) {
+            // Can't create load
+        }
     }
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Powsybl's UCTE network importer ignores generators and loads with no flow. If these are referenced by the GLSK file, sensitivity computation can be wrong.


**What is the new behavior (if this is a feature change)?**
The new post-processing script adds loads and generators for all nodes.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
The network size (thus memory usage) will increase