### PR TITLE
Fix imported GLSK when generator inital target power is not in merit order block range

### DIFF
--- a/data/glsk/glsk-document-api/src/main/java/com/farao_community/farao/data/glsk/api/util/converters/GlskPointScalableConverter.java
+++ b/data/glsk/glsk-document-api/src/main/java/com/farao_community/farao/data/glsk/api/util/converters/GlskPointScalableConverter.java
@@ -154,8 +154,6 @@ public final class GlskPointScalableConverter {
                 LOGGER.warn("Generator '{}' has initial target P that is above GLSK min P. Extending GLSK min P from {} to {}.", generatorId, incomingMinP, generatorTargetP);
                 incomingMinP = generatorTargetP;
             }
-            incomingMaxP = Math.max(incomingMaxP, generator.getTargetP());
-            incomingMinP = Math.min(incomingMinP, generator.getTargetP());
         }
         return Scalable.onGenerator(generatorId, incomingMinP, incomingMaxP);
     }

--- a/data/glsk/glsk-document-api/src/main/java/com/farao_community/farao/data/glsk/api/util/converters/GlskPointScalableConverter.java
+++ b/data/glsk/glsk-document-api/src/main/java/com/farao_community/farao/data/glsk/api/util/converters/GlskPointScalableConverter.java
@@ -147,11 +147,11 @@ public final class GlskPointScalableConverter {
         if (generator != null) {
             double generatorTargetP = generator.getTargetP();
             if (!Double.isNaN(incomingMaxP) && incomingMaxP < generatorTargetP) {
-                LOGGER.warn("Generator '{}' has initial target P that is above GLSK target P. Extending GLSK max P from {} to {}.", generatorId, incomingMaxP, generatorTargetP);
+                LOGGER.warn("Generator '{}' has initial target P that is above GLSK max P. Extending GLSK max P from {} to {}.", generatorId, incomingMaxP, generatorTargetP);
                 incomingMaxP = generatorTargetP;
             }
             if (!Double.isNaN(incomingMinP) && incomingMinP > generatorTargetP) {
-                LOGGER.warn("Generator '{}' has initial target P that is above GLSK target P. Extending GLSK min P from {} to {}.", generatorId, incomingMinP, generatorTargetP);
+                LOGGER.warn("Generator '{}' has initial target P that is above GLSK min P. Extending GLSK min P from {} to {}.", generatorId, incomingMinP, generatorTargetP);
                 incomingMinP = generatorTargetP;
             }
             incomingMaxP = Math.max(incomingMaxP, generator.getTargetP());

--- a/data/glsk/glsk-document-cse/src/test/java/com/farao_community/farao/data/glsk/cse/CseGlskDocumentImporterTest.java
+++ b/data/glsk/glsk-document-cse/src/test/java/com/farao_community/farao/data/glsk/cse/CseGlskDocumentImporterTest.java
@@ -198,4 +198,38 @@ public class CseGlskDocumentImporterTest {
         assertEquals(3000., network.getGenerator("FFR3AA1 _generator").getTargetP(), EPSILON);
     }
 
+    @Test
+    public void checkCseGlskDocumentImporterCorrectlyConvertMeritOrderGskBlocksWithTargetPIssueDown() {
+        Network network = Importers.loadNetwork("testCase.xiidm", getClass().getResourceAsStream("/testCase.xiidm"));
+        GlskDocument glskDocument = GlskDocumentImporters.importGlsk(getClass().getResourceAsStream("/testGlsk.xml"));
+        Scalable meritOrderGskScalable = glskDocument.getZonalScalable(network).getData("FR_MERITORDER_ISSUE_PC");
+
+        assertNotNull(meritOrderGskScalable);
+        assertEquals(2000., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(3000., network.getGenerator("FFR3AA1 _generator").getTargetP(), EPSILON);
+
+        meritOrderGskScalable.scale(network, -4000.);
+        assertEquals(2000., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(1000., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(0., network.getGenerator("FFR3AA1 _generator").getTargetP(), EPSILON);
+    }
+
+    @Test
+    public void checkCseGlskDocumentImporterCorrectlyConvertMeritOrderGskBlocksWithTargetPIssueUp() {
+        Network network = Importers.loadNetwork("testCase.xiidm", getClass().getResourceAsStream("/testCase.xiidm"));
+        GlskDocument glskDocument = GlskDocumentImporters.importGlsk(getClass().getResourceAsStream("/testGlsk.xml"));
+        Scalable meritOrderGskScalable = glskDocument.getZonalScalable(network).getData("FR_MERITORDER_ISSUE_PC");
+
+        assertNotNull(meritOrderGskScalable);
+        assertEquals(2000., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(3000., network.getGenerator("FFR3AA1 _generator").getTargetP(), EPSILON);
+
+        meritOrderGskScalable.scale(network, 5000.);
+        assertEquals(2000., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(4000., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(6000., network.getGenerator("FFR3AA1 _generator").getTargetP(), EPSILON);
+    }
+
 }

--- a/data/glsk/glsk-document-cse/src/test/resources/testGlsk.xml
+++ b/data/glsk/glsk-document-cse/src/test/resources/testGlsk.xml
@@ -140,4 +140,44 @@
             </Down>
         </MeritOrderGSKBlock>
     </TimeSeries>
+    <TimeSeries>
+        <TimeSeriesIdentification v="1"/>
+        <BusinessType v="Z02"/>
+        <Area v="FR_MERITORDER_ISSUE_PC" codingScheme="A01"/>
+        <Name v="FR_MERITORDER_ISSUE_PC"/>
+        <TimeInterval v="2020-09-16T22:00Z/2020-09-16T22:59Z"/>
+        <MeritOrderGSKBlock>
+            <Factor v="1"/>
+            <Up>
+                <Factor v="1"/>
+                <Node>
+                    <Name v="FFR1AA1 "/>
+                    <Pmax v="-1500"/>
+                </Node>
+                <Node>
+                    <Name v="FFR2AA1 "/>
+                    <Pmax v="-4000"/>
+                </Node>
+                <Node>
+                    <Name v="FFR3AA1 "/>
+                    <Pmax v="-6000"/>
+                </Node>
+            </Up>
+            <Down>
+                <Node>
+                    <Name v="FFR1AA1 "/>
+                    <Pmin v="-2500"/>
+                </Node>
+                <Factor v="1"/>
+                <Node>
+                    <Name v="FFR3AA1 "/>
+                    <Pmin v="0"/>
+                </Node>
+                <Node>
+                    <Name v="FFR2AA1 "/>
+                    <Pmin v="0"/>
+                </Node>
+            </Down>
+        </MeritOrderGSKBlock>
+    </TimeSeries>
 </GSKDocument>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
It may happen in some use cases that merit order GLSK block validity range does not include initial target power of a generator.
This causes an Exception while scaling the network, whereas it should be silently ignored.


**What is the new behavior (if this is a feature change)?**
Imported GLSK has been modified to include initial target power. 


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No


**Other information**:
Even if this patch fixes the issue, a better fix should be done in PowSyBl framework, to allow keeping the initial data range in the generated scalable object.
