### PR TITLE
Post-check RAO results

### DIFF
--- a/ra-optimisation/linear-rao/src/test/resources/LinearRaoParameters.json
+++ b/ra-optimisation/linear-rao/src/test/resources/LinearRaoParameters.json
@@ -18,6 +18,7 @@
   "relative-margin-ptdf-boundaries" : [ ],
   "ptdf-sum-lower-bound" : 0.01,
   "perimeters-in-parallel" : 1,
+  "post-check-rao-results" : false,
   "sensitivity-parameters" : {
     "version" : "1.0",
     "load-flow-parameters" : {

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/RaoParameters.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/RaoParameters.java
@@ -89,6 +89,7 @@ public class RaoParameters extends AbstractExtendable<RaoParameters> {
     public static final double DEFAULT_NEGATIVE_MARGIN_OBJECTIVE_COEFFICIENT = 1000;
     public static final double DEFAULT_PTDF_SUM_LOWER_BOUND = 0.01;
     public static final int DEFAULT_PERIMETERS_IN_PARALLEL = 1;
+    public static final boolean DEFAULT_POST_CHECK_RAO_RESULTS = false;
 
     private ObjectiveFunction objectiveFunction = DEFAULT_OBJECTIVE_FUNCTION;
     private int maxIterations = DEFAULT_MAX_ITERATIONS;
@@ -110,6 +111,15 @@ public class RaoParameters extends AbstractExtendable<RaoParameters> {
     private List<ZoneToZonePtdfDefinition> relativeMarginPtdfBoundaries = new ArrayList<>();
     private double ptdfSumLowerBound = DEFAULT_PTDF_SUM_LOWER_BOUND; // prevents relative margins from diverging to +infinity
     private int perimetersInParallel = DEFAULT_PERIMETERS_IN_PARALLEL;
+    private boolean postCheckRaoResults = DEFAULT_POST_CHECK_RAO_RESULTS; // fallback to initial situation if results are degraded (because of a curative cnec or mnec)
+
+    public boolean isPostCheckRaoResults() {
+        return postCheckRaoResults;
+    }
+
+    public void setPostCheckRaoResults(boolean postCheckRaoResults) {
+        this.postCheckRaoResults = postCheckRaoResults;
+    }
 
     public ObjectiveFunction getObjectiveFunction() {
         return objectiveFunction;
@@ -363,6 +373,7 @@ public class RaoParameters extends AbstractExtendable<RaoParameters> {
                 parameters.setRelativeMarginPtdfBoundariesFromString(config.getStringListProperty("relative-margin-ptdf-boundaries", new ArrayList<>()));
                 parameters.setPtdfSumLowerBound(config.getDoubleProperty("ptdf-sum-lower-bound", DEFAULT_PTDF_SUM_LOWER_BOUND));
                 parameters.setPerimetersInParallel(config.getIntProperty("perimeters-in-parallel", DEFAULT_PERIMETERS_IN_PARALLEL));
+                parameters.setPostCheckRaoResults(config.getBooleanProperty("post-check-rao-results", DEFAULT_POST_CHECK_RAO_RESULTS));
             });
 
         // NB: Only the default sensitivity parameters are loaded, not the fallback ones...

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/RaoParametersDeserializer.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/RaoParametersDeserializer.java
@@ -137,6 +137,10 @@ public class RaoParametersDeserializer extends StdDeserializer<RaoParameters> {
                     parser.nextToken();
                     parameters.setPerimetersInParallel(parser.getIntValue());
                     break;
+                case "post-check-rao-results":
+                    parser.nextToken();
+                    parameters.setPostCheckRaoResults(parser.getBooleanValue());
+                    break;
                 case "extensions":
                     parser.nextToken();
                     if (parameters.getExtensions().isEmpty()) {

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/RaoParametersSerializer.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/RaoParametersSerializer.java
@@ -60,6 +60,7 @@ public class RaoParametersSerializer extends StdSerializer<RaoParameters> {
         jsonGenerator.writeEndArray();
         jsonGenerator.writeNumberField("ptdf-sum-lower-bound", parameters.getPtdfSumLowerBound());
         jsonGenerator.writeNumberField("perimeters-in-parallel", parameters.getPerimetersInParallel());
+        jsonGenerator.writeBooleanField("post-check-rao-results", parameters.isPostCheckRaoResults());
         jsonGenerator.writeFieldName("sensitivity-parameters");
         JsonSensitivityAnalysisParameters.serialize(parameters.getDefaultSensitivityAnalysisParameters(), jsonGenerator, serializerProvider);
         if (parameters.getFallbackSensitivityAnalysisParameters() != null) {

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/RaoParametersTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/RaoParametersTest.java
@@ -157,6 +157,17 @@ public class RaoParametersTest {
     }
 
     @Test
+    public void checkPostCheckConfig() {
+        MapModuleConfig moduleConfig = platformCfg.createModuleConfig("rao-parameters");
+        moduleConfig.setStringProperty("post-check-rao-results", Objects.toString(true));
+
+        RaoParameters parameters = new RaoParameters();
+        RaoParameters.load(parameters, platformCfg);
+
+        assertTrue(parameters.isPostCheckRaoResults());
+    }
+
+    @Test
     public void testUpdatePtdfWithTopo() {
         assertFalse(RaoParameters.LoopFlowApproximationLevel.FIXED_PTDF.shouldUpdatePtdfWithTopologicalChange());
         assertTrue(RaoParameters.LoopFlowApproximationLevel.UPDATE_PTDF_WITH_TOPO.shouldUpdatePtdfWithTopologicalChange());

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoParametersTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoParametersTest.java
@@ -70,6 +70,7 @@ public class JsonRaoParametersTest extends AbstractConverterTest {
         parameters.setRelativeMarginPtdfBoundariesFromString(stringBoundaries);
         parameters.setPtdfSumLowerBound(0.05);
         parameters.setPerimetersInParallel(15);
+        parameters.setPostCheckRaoResults(true);
         roundTripTest(parameters, JsonRaoParameters::write, JsonRaoParameters::read, "/RaoParametersSet.json");
     }
 

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters.json
@@ -18,6 +18,7 @@
   "relative-margin-ptdf-boundaries" : [ ],
   "ptdf-sum-lower-bound" : 0.01,
   "perimeters-in-parallel" : 1,
+  "post-check-rao-results" : false,
   "sensitivity-parameters" : {
     "version" : "1.0",
     "load-flow-parameters" : {

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersSet.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersSet.json
@@ -18,6 +18,7 @@
   "relative-margin-ptdf-boundaries" : [ "{FR}-{ES}", "{ES}-{PT}", "{BE}-{22Y201903144---9}-{DE}-{22Y201903145---4}" ],
   "ptdf-sum-lower-bound" : 0.05,
   "perimeters-in-parallel" : 15,
+  "post-check-rao-results" : true,
   "sensitivity-parameters" : {
     "version" : "1.0",
     "load-flow-parameters" : {

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersWithExtension.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersWithExtension.json
@@ -18,6 +18,7 @@
   "relative-margin-ptdf-boundaries" : [ ],
   "ptdf-sum-lower-bound" : 0.01,
   "perimeters-in-parallel" : 1,
+  "post-check-rao-results" : false,
   "sensitivity-parameters" : {
     "version" : "1.0",
     "load-flow-parameters" : {

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersWithFallback.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersWithFallback.json
@@ -18,6 +18,7 @@
   "relative-margin-ptdf-boundaries" : [ ],
   "ptdf-sum-lower-bound" : 0.01,
   "perimeters-in-parallel" : 1,
+  "post-check-rao-results" : false,
   "sensitivity-parameters" : {
     "version" : "1.0",
     "load-flow-parameters" : {

--- a/ra-optimisation/search-tree-rao/src/test/resources/SearchTreeRaoParameters.json
+++ b/ra-optimisation/search-tree-rao/src/test/resources/SearchTreeRaoParameters.json
@@ -18,6 +18,7 @@
   "relative-margin-ptdf-boundaries" : [ ],
   "ptdf-sum-lower-bound" : 0.01,
   "perimeters-in-parallel" : 1,
+  "post-check-rao-results" : false,
   "sensitivity-parameters" : {
     "version" : "1.0",
     "load-flow-parameters" : {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fixes


**What is the current behavior?** *(You can also link to an open issue here)*
1. Aligned PSTs that have different initial setpoints are considered in the RAO. This makes the initial situation infeasible and can lead to violating virtual costs.
2. Given the separation between preventive and curative RAOs, the preventive RAO can degrade the margins on curative CNECs, and this margin may not be improved by the curative RAs. This may lead to a final solution worse than the initial one.
3. Virtual hubs are considered even if they are disconnected


**What is the new behavior (if this is a feature change)?**
1. Aligned PSTs with different initial setpoints are filtered out of the linear optimizer; thus they are not optimized and keep their initial setpoints.
2. At the end of the RAO, if the RAO has degraded a (curative) margin or virtual cost, the initial solution is kept as optimal.
3. Virtual hubs that are disconnected are not considered in the computations
