### PR TITLE
Sensitivity analysis with curative RA - API + Implementation

### DIFF
--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/ToolProvider.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/ToolProvider.java
@@ -152,17 +152,7 @@ public final class ToolProvider {
         } else if (computePtdfs) {
             builder.withPtdfSensitivities(getGlskForEic(getEicForObjectiveFunction()), cnecs, Collections.singleton(Unit.MEGAWATT));
         }
-
-        Crac crac = CracFactory.findDefault().create("cracId");
-
-        crac.newContingency().withId("co1_fr2_fr3_1").withNetworkElement("FFR2AA1  FFR3AA1  1").add();
-        crac.newNetworkAction().withId("na-id")
-            .newTopologicalAction().withNetworkElement("FFR1AA1  FFR5AA1  1").withActionType(ActionType.CLOSE).add()
-            .newOnStateUsageRule().withContingency("co1_fr2_fr3_1").withInstant(Instant.CURATIVE).withUsageMethod(UsageMethod.AVAILABLE).add()
-            .add();
-
-        builder.withAppliedNetworkAction(crac.getState("co1_fr2_fr3_1", Instant.CURATIVE), crac.getNetworkAction("na-id"));
-
+        
         return builder.build();
     }
 

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/ToolProvider.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/ToolProvider.java
@@ -11,9 +11,14 @@ import com.farao_community.farao.commons.EICode;
 import com.farao_community.farao.commons.Unit;
 import com.farao_community.farao.commons.ZonalData;
 import com.farao_community.farao.commons.ZonalDataImpl;
+import com.farao_community.farao.data.crac_api.Crac;
+import com.farao_community.farao.data.crac_api.CracFactory;
+import com.farao_community.farao.data.crac_api.Instant;
 import com.farao_community.farao.data.crac_api.cnec.FlowCnec;
+import com.farao_community.farao.data.crac_api.network_action.ActionType;
 import com.farao_community.farao.data.crac_api.range_action.RangeAction;
 import com.farao_community.farao.data.crac_api.cnec.Cnec;
+import com.farao_community.farao.data.crac_api.usage_rule.UsageMethod;
 import com.farao_community.farao.data.crac_loopflow_extension.LoopFlowThreshold;
 import com.farao_community.farao.data.refprog.reference_program.ReferenceProgram;
 import com.farao_community.farao.loopflow_computation.LoopFlowComputation;
@@ -147,6 +152,16 @@ public final class ToolProvider {
         } else if (computePtdfs) {
             builder.withPtdfSensitivities(getGlskForEic(getEicForObjectiveFunction()), cnecs, Collections.singleton(Unit.MEGAWATT));
         }
+
+        Crac crac = CracFactory.findDefault().create("cracId");
+
+        crac.newContingency().withId("co1_fr2_fr3_1").withNetworkElement("FFR2AA1  FFR3AA1  1").add();
+        crac.newNetworkAction().withId("na-id")
+            .newTopologicalAction().withNetworkElement("FFR1AA1  FFR5AA1  1").withActionType(ActionType.CLOSE).add()
+            .newOnStateUsageRule().withContingency("co1_fr2_fr3_1").withInstant(Instant.CURATIVE).withUsageMethod(UsageMethod.AVAILABLE).add()
+            .add();
+
+        builder.withAppliedNetworkAction(crac.getState("co1_fr2_fr3_1", Instant.CURATIVE), crac.getNetworkAction("na-id"));
 
         return builder.build();
     }

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/ToolProvider.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/ToolProvider.java
@@ -11,14 +11,9 @@ import com.farao_community.farao.commons.EICode;
 import com.farao_community.farao.commons.Unit;
 import com.farao_community.farao.commons.ZonalData;
 import com.farao_community.farao.commons.ZonalDataImpl;
-import com.farao_community.farao.data.crac_api.Crac;
-import com.farao_community.farao.data.crac_api.CracFactory;
-import com.farao_community.farao.data.crac_api.Instant;
 import com.farao_community.farao.data.crac_api.cnec.FlowCnec;
-import com.farao_community.farao.data.crac_api.network_action.ActionType;
 import com.farao_community.farao.data.crac_api.range_action.RangeAction;
 import com.farao_community.farao.data.crac_api.cnec.Cnec;
-import com.farao_community.farao.data.crac_api.usage_rule.UsageMethod;
 import com.farao_community.farao.data.crac_loopflow_extension.LoopFlowThreshold;
 import com.farao_community.farao.data.refprog.reference_program.ReferenceProgram;
 import com.farao_community.farao.loopflow_computation.LoopFlowComputation;
@@ -152,16 +147,6 @@ public final class ToolProvider {
         } else if (computePtdfs) {
             builder.withPtdfSensitivities(getGlskForEic(getEicForObjectiveFunction()), cnecs, Collections.singleton(Unit.MEGAWATT));
         }
-
-        Crac crac = CracFactory.findDefault().create("cracId");
-
-        crac.newContingency().withId("co1_fr2_fr3_1").withNetworkElement("FFR2AA1  FFR3AA1  1").add();
-        crac.newNetworkAction().withId("na-id")
-            .newTopologicalAction().withNetworkElement("FFR1AA1  FFR5AA1  1").withActionType(ActionType.CLOSE).add()
-            .newOnStateUsageRule().withContingency("co1_fr2_fr3_1").withInstant(Instant.CURATIVE).withUsageMethod(UsageMethod.AVAILABLE).add()
-            .add();
-
-        builder.withAppliedNetworkAction(crac.getState("co1_fr2_fr3_1", Instant.CURATIVE), crac.getNetworkAction("na-id"));
 
         return builder.build();
     }

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/ToolProvider.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/ToolProvider.java
@@ -11,14 +11,9 @@ import com.farao_community.farao.commons.EICode;
 import com.farao_community.farao.commons.Unit;
 import com.farao_community.farao.commons.ZonalData;
 import com.farao_community.farao.commons.ZonalDataImpl;
-import com.farao_community.farao.data.crac_api.Crac;
-import com.farao_community.farao.data.crac_api.CracFactory;
-import com.farao_community.farao.data.crac_api.Instant;
 import com.farao_community.farao.data.crac_api.cnec.FlowCnec;
-import com.farao_community.farao.data.crac_api.network_action.ActionType;
 import com.farao_community.farao.data.crac_api.range_action.RangeAction;
 import com.farao_community.farao.data.crac_api.cnec.Cnec;
-import com.farao_community.farao.data.crac_api.usage_rule.UsageMethod;
 import com.farao_community.farao.data.crac_loopflow_extension.LoopFlowThreshold;
 import com.farao_community.farao.data.refprog.reference_program.ReferenceProgram;
 import com.farao_community.farao.loopflow_computation.LoopFlowComputation;
@@ -152,7 +147,7 @@ public final class ToolProvider {
         } else if (computePtdfs) {
             builder.withPtdfSensitivities(getGlskForEic(getEicForObjectiveFunction()), cnecs, Collections.singleton(Unit.MEGAWATT));
         }
-        
+
         return builder.build();
     }
 

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/AbstractSimpleSensitivityProvider.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/AbstractSimpleSensitivityProvider.java
@@ -7,7 +7,6 @@
 package com.farao_community.farao.sensitivity_analysis;
 
 import com.farao_community.farao.commons.Unit;
-import com.farao_community.farao.data.crac_api.NetworkElement;
 import com.farao_community.farao.data.crac_api.cnec.FlowCnec;
 import com.powsybl.contingency.*;
 import com.powsybl.iidm.network.*;
@@ -55,32 +54,6 @@ public abstract class AbstractSimpleSensitivityProvider implements CnecSensitivi
         return cnecs;
     }
 
-    private Contingency convertCracContingencyToPowsybl(com.farao_community.farao.data.crac_api.Contingency cracContingency, Network network) {
-        String id = cracContingency.getId();
-        List<ContingencyElement> contingencyElements = cracContingency.getNetworkElements().stream()
-            .map(element -> convertCracContingencyElementToPowsybl(element, network))
-            .collect(Collectors.toList());
-        return new Contingency(id, contingencyElements);
-    }
-
-    private ContingencyElement convertCracContingencyElementToPowsybl(NetworkElement cracContingencyElement, Network network) {
-        String elementId = cracContingencyElement.getId();
-        Identifiable<?> networkIdentifiable = network.getIdentifiable(elementId);
-        if (networkIdentifiable instanceof Branch) {
-            return new BranchContingency(elementId);
-        } else if (networkIdentifiable instanceof Generator) {
-            return new GeneratorContingency(elementId);
-        } else if (networkIdentifiable instanceof HvdcLine) {
-            return new HvdcLineContingency(elementId);
-        } else if (networkIdentifiable instanceof BusbarSection) {
-            return new BusbarSectionContingency(elementId);
-        } else if (networkIdentifiable instanceof DanglingLine) {
-            return new DanglingLineContingency(elementId);
-        } else {
-            throw new SensitivityAnalysisException("Unable to apply contingency element " + elementId);
-        }
-    }
-
     @Override
     public List<Contingency> getContingencies(Network network) {
         Set<com.farao_community.farao.data.crac_api.Contingency> cracContingencies =  cnecs.stream()
@@ -88,7 +61,7 @@ public abstract class AbstractSimpleSensitivityProvider implements CnecSensitivi
             .map(cnec -> cnec.getState().getContingency().get())
             .collect(Collectors.toSet());
         return cracContingencies.stream()
-            .map(contingency -> convertCracContingencyToPowsybl(contingency, network))
+            .map(contingency -> SensitivityAnalysisUtil.convertCracContingencyToPowsybl(contingency, network))
             .collect(Collectors.toList());
     }
 }

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/AbstractSimpleSensitivityProvider.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/AbstractSimpleSensitivityProvider.java
@@ -26,6 +26,7 @@ public abstract class AbstractSimpleSensitivityProvider implements CnecSensitivi
     protected Set<FlowCnec> cnecs;
     protected boolean factorsInMegawatt;
     protected boolean factorsInAmpere;
+    protected boolean afterContingencyOnly = false;
 
     AbstractSimpleSensitivityProvider(Set<FlowCnec> cnecs, Set<Unit> requestedUnits) {
         this.cnecs = cnecs;
@@ -63,5 +64,10 @@ public abstract class AbstractSimpleSensitivityProvider implements CnecSensitivi
         return cracContingencies.stream()
             .map(contingency -> SensitivityAnalysisUtil.convertCracContingencyToPowsybl(contingency, network))
             .collect(Collectors.toList());
+    }
+
+    @Override
+    public void disableFactorsForBaseCaseSituation() {
+        this.afterContingencyOnly = true;
     }
 }

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/AppliedRemedialActions.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/AppliedRemedialActions.java
@@ -52,7 +52,7 @@ public class AppliedRemedialActions {
         if (!state.getInstant().equals(Instant.CURATIVE)) {
             throw new FaraoException("Sensitivity analysis with applied remedial actions only work with CURATIVE remedial actions.");
         }
-        if (appliedRa.containsKey(state)) {
+        if (!appliedRa.containsKey(state)) {
             appliedRa.put(state, new AppliedRemedialActionsPerState());
         }
     }

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/AppliedRemedialActions.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/AppliedRemedialActions.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.farao_community.farao.sensitivity_analysis;
+
+import com.farao_community.farao.commons.FaraoException;
+import com.farao_community.farao.data.crac_api.Instant;
+import com.farao_community.farao.data.crac_api.State;
+import com.farao_community.farao.data.crac_api.network_action.NetworkAction;
+import com.farao_community.farao.data.crac_api.range_action.RangeAction;
+import com.powsybl.iidm.network.Network;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com>}
+ */
+public class AppliedRemedialActions {
+
+    private Map<State, AppliedRemedialActionsPerState> appliedRa = new HashMap<>();
+
+    private class AppliedRemedialActionsPerState {
+        private Set<NetworkAction> networkActions = new HashSet<>();
+        private Map<RangeAction, Double> rangeActions = new HashMap<>();
+    }
+
+    void addAppliedNetworkAction(State state, NetworkAction networkAction) {
+        checkState(state);
+        appliedRa.get(state).networkActions.add(networkAction);
+    }
+
+    void addAppliedRangeAction(State state, RangeAction rangeAction, double setpoint) {
+        checkState(state);
+        appliedRa.get(state).rangeActions.put(rangeAction, setpoint);
+    }
+
+    boolean isEmpty() {
+        return appliedRa.isEmpty();
+    }
+
+    Set<State> getStatesWithRa() {
+        return appliedRa.keySet();
+    }
+
+    private void checkState(State state) {
+        if (!state.getInstant().equals(Instant.CURATIVE)) {
+            throw new FaraoException("Sensitivity analysis with applied remedial actions only work with CURATIVE remedial actions.");
+        }
+        if (appliedRa.containsKey(state)) {
+            appliedRa.put(state, new AppliedRemedialActionsPerState());
+        }
+    }
+
+    void apply(State state, Network network) {
+        if (appliedRa.containsKey(state)) {
+            appliedRa.get(state).rangeActions.forEach((rangeAction, setPoint) -> rangeAction.apply(network, setPoint));
+            appliedRa.get(state).networkActions.forEach(networkAction -> networkAction.apply(network));
+        }
+    }
+
+}

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/AppliedRemedialActions.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/AppliedRemedialActions.java
@@ -59,8 +59,6 @@ class AppliedRemedialActions {
         if (!state.getInstant().equals(Instant.CURATIVE)) {
             throw new FaraoException("Sensitivity analysis with applied remedial actions only work with CURATIVE remedial actions.");
         }
-        if (!appliedRa.containsKey(state)) {
-            appliedRa.put(state, new AppliedRemedialActionsPerState());
-        }
+        appliedRa.putIfAbsent(state, new AppliedRemedialActionsPerState());
     }
 }

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/AppliedRemedialActions.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/AppliedRemedialActions.java
@@ -21,7 +21,7 @@ import java.util.Set;
 /**
  * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com>}
  */
-public class AppliedRemedialActions {
+class AppliedRemedialActions {
 
     private Map<State, AppliedRemedialActionsPerState> appliedRa = new HashMap<>();
 
@@ -48,6 +48,13 @@ public class AppliedRemedialActions {
         return appliedRa.keySet();
     }
 
+    void applyOnNetwork(State state, Network network) {
+        if (appliedRa.containsKey(state)) {
+            appliedRa.get(state).rangeActions.forEach((rangeAction, setPoint) -> rangeAction.apply(network, setPoint));
+            appliedRa.get(state).networkActions.forEach(networkAction -> networkAction.apply(network));
+        }
+    }
+
     private void checkState(State state) {
         if (!state.getInstant().equals(Instant.CURATIVE)) {
             throw new FaraoException("Sensitivity analysis with applied remedial actions only work with CURATIVE remedial actions.");
@@ -56,12 +63,4 @@ public class AppliedRemedialActions {
             appliedRa.put(state, new AppliedRemedialActionsPerState());
         }
     }
-
-    void apply(State state, Network network) {
-        if (appliedRa.containsKey(state)) {
-            appliedRa.get(state).rangeActions.forEach((rangeAction, setPoint) -> rangeAction.apply(network, setPoint));
-            appliedRa.get(state).networkActions.forEach(networkAction -> networkAction.apply(network));
-        }
-    }
-
 }

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/CnecSensitivityProvider.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/CnecSensitivityProvider.java
@@ -18,4 +18,6 @@ import java.util.Set;
 public interface CnecSensitivityProvider extends SensitivityFactorsProvider, ContingenciesProvider {
 
     Set<FlowCnec> getFlowCnecs();
+
+    void disableFactorsForBaseCaseSituation();
 }

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/LoadflowProvider.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/LoadflowProvider.java
@@ -56,6 +56,9 @@ public class LoadflowProvider extends AbstractSimpleSensitivityProvider {
     @Override
     public List<SensitivityFactor> getAdditionalFactors(Network network, String contingencyId) {
         List<SensitivityFactor> factors = new ArrayList<>();
+        if (afterContingencyOnly) {
+            return factors;
+        }
         SensitivityVariable defaultSensitivityVariable = defaultSensitivityVariable(network);
         getSensitivityFunctions(network, contingencyId).forEach(fun -> factors.add(sensitivityFactorMapping(fun, defaultSensitivityVariable)));
         return factors;

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/LoadflowProvider.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/LoadflowProvider.java
@@ -48,6 +48,9 @@ public class LoadflowProvider extends AbstractSimpleSensitivityProvider {
     @Override
     public List<SensitivityFactor> getAdditionalFactors(Network network) {
         List<SensitivityFactor> factors = new ArrayList<>();
+        if (afterContingencyOnly) {
+            return factors;
+        }
         SensitivityVariable defaultSensitivityVariable = defaultSensitivityVariable(network);
         getSensitivityFunctions(network, null).forEach(fun -> factors.add(sensitivityFactorMapping(fun, defaultSensitivityVariable)));
         return factors;
@@ -56,9 +59,6 @@ public class LoadflowProvider extends AbstractSimpleSensitivityProvider {
     @Override
     public List<SensitivityFactor> getAdditionalFactors(Network network, String contingencyId) {
         List<SensitivityFactor> factors = new ArrayList<>();
-        if (afterContingencyOnly) {
-            return factors;
-        }
         SensitivityVariable defaultSensitivityVariable = defaultSensitivityVariable(network);
         getSensitivityFunctions(network, contingencyId).forEach(fun -> factors.add(sensitivityFactorMapping(fun, defaultSensitivityVariable)));
         return factors;

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/MultipleSensitivityProvider.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/MultipleSensitivityProvider.java
@@ -36,6 +36,11 @@ public class MultipleSensitivityProvider implements CnecSensitivityProvider {
     }
 
     @Override
+    public void disableFactorsForBaseCaseSituation() {
+        cnecSensitivityProviders.forEach(CnecSensitivityProvider::disableFactorsForBaseCaseSituation);
+    }
+
+    @Override
     public List<Contingency> getContingencies(Network network) {
         //using a set to avoid duplicates
         Set<Contingency> contingencies = new HashSet<>();

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/PtdfSensitivityProvider.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/PtdfSensitivityProvider.java
@@ -48,8 +48,12 @@ public class PtdfSensitivityProvider extends AbstractSimpleSensitivityProvider {
     @Override
     public List<SensitivityFactor> getAdditionalFactors(Network network) {
         List<SensitivityFactor> factors = new ArrayList<>();
-        Map<String, LinearGlsk> mapCountryLinearGlsk = glsk.getDataPerZone();
 
+        if (afterContingencyOnly) {
+            return factors;
+        }
+
+        Map<String, LinearGlsk> mapCountryLinearGlsk = glsk.getDataPerZone();
         cnecs.stream()
             .filter(cnec -> cnec.getState().getContingency().isEmpty())
             .map(Cnec::getNetworkElement)

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/RangeActionSensitivityProvider.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/RangeActionSensitivityProvider.java
@@ -37,6 +37,11 @@ public class RangeActionSensitivityProvider extends LoadflowProvider {
     @Override
     public List<SensitivityFactor> getAdditionalFactors(Network network) {
         List<SensitivityFactor> factors = new ArrayList<>();
+
+        if (afterContingencyOnly) {
+            return factors;
+        }
+
         List<SensitivityVariable> sensitivityVariables = rangeActions.stream()
             .map(ra -> rangeActionToSensitivityVariables(network, ra))
             .flatMap(Collection::stream)

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SensitivityAnalysisUtil.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SensitivityAnalysisUtil.java
@@ -19,7 +19,7 @@ final class SensitivityAnalysisUtil {
         return new Contingency(id, contingencyElements);
     }
 
-    static private ContingencyElement convertCracContingencyElementToPowsybl(NetworkElement cracContingencyElement, Network network) {
+    private static ContingencyElement convertCracContingencyElementToPowsybl(NetworkElement cracContingencyElement, Network network) {
         String elementId = cracContingencyElement.getId();
         Identifiable<?> networkIdentifiable = network.getIdentifiable(elementId);
         if (networkIdentifiable instanceof Branch) {

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SensitivityAnalysisUtil.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SensitivityAnalysisUtil.java
@@ -1,0 +1,39 @@
+package com.farao_community.farao.sensitivity_analysis;
+
+import com.farao_community.farao.data.crac_api.NetworkElement;
+import com.powsybl.contingency.*;
+import com.powsybl.iidm.network.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+final class SensitivityAnalysisUtil {
+
+    private SensitivityAnalysisUtil() { }
+
+    static Contingency convertCracContingencyToPowsybl(com.farao_community.farao.data.crac_api.Contingency cracContingency, Network network) {
+        String id = cracContingency.getId();
+        List<ContingencyElement> contingencyElements = cracContingency.getNetworkElements().stream()
+            .map(element -> convertCracContingencyElementToPowsybl(element, network))
+            .collect(Collectors.toList());
+        return new Contingency(id, contingencyElements);
+    }
+
+    static private ContingencyElement convertCracContingencyElementToPowsybl(NetworkElement cracContingencyElement, Network network) {
+        String elementId = cracContingencyElement.getId();
+        Identifiable<?> networkIdentifiable = network.getIdentifiable(elementId);
+        if (networkIdentifiable instanceof Branch) {
+            return new BranchContingency(elementId);
+        } else if (networkIdentifiable instanceof Generator) {
+            return new GeneratorContingency(elementId);
+        } else if (networkIdentifiable instanceof HvdcLine) {
+            return new HvdcLineContingency(elementId);
+        } else if (networkIdentifiable instanceof BusbarSection) {
+            return new BusbarSectionContingency(elementId);
+        } else if (networkIdentifiable instanceof DanglingLine) {
+            return new DanglingLineContingency(elementId);
+        } else {
+            throw new SensitivityAnalysisException("Unable to apply contingency element " + elementId);
+        }
+    }
+}

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityAdapter.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityAdapter.java
@@ -6,11 +6,10 @@
  */
 package com.farao_community.farao.sensitivity_analysis;
 
+import com.farao_community.farao.commons.FaraoException;
 import com.farao_community.farao.commons.RandomizedString;
 import com.farao_community.farao.data.crac_api.State;
 import com.farao_community.farao.data.crac_api.cnec.Cnec;
-import com.powsybl.computation.ComputationManager;
-import com.powsybl.computation.DefaultComputationManagerConfig;
 import com.powsybl.contingency.Contingency;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.sensitivity.*;
@@ -35,10 +34,10 @@ final class SystematicSensitivityAdapter {
     static SystematicSensitivityResult runSensitivity(Network network,
                                                       CnecSensitivityProvider cnecSensitivityProvider,
                                                       SensitivityAnalysisParameters sensitivityComputationParameters) {
-        LOGGER.debug("Sensitivity analysis without applied RA [start]");
+        LOGGER.debug("Systematic sensitivity analysis [start]");
         SensitivityAnalysisResult result = SensitivityAnalysis.run(network, cnecSensitivityProvider, cnecSensitivityProvider.getContingencies(network), sensitivityComputationParameters);
-        LOGGER.debug("Sensitivity analysis without applied RA [end]");
-        return new SystematicSensitivityResult(result);
+        LOGGER.debug("Systematic sensitivity analysis [end]");
+        return new SystematicSensitivityResult().completeData(result).postTreatIntensities();
     }
 
     static SystematicSensitivityResult runSensitivity(Network network,
@@ -50,50 +49,52 @@ final class SystematicSensitivityAdapter {
             return runSensitivity(network, cnecSensitivityProvider, sensitivityComputationParameters);
         }
 
-        // systematic analysis for states without RA
-        LOGGER.debug("Sensitivity analysis with applied RA [start]");
-        LOGGER.debug("- states without RA");
+        LOGGER.debug("Systematic sensitivity analysis with applied RA [start]");
 
         Set<State> statesWithoutRa = getStatesWithoutRa(appliedRemedialActions, cnecSensitivityProvider);
+        Set<State> statesWithRa = appliedRemedialActions.getStatesWithRa();
+
+        // systematic analysis for states without RA
+        LOGGER.debug("... (1/{}) {} state(s) without RA ", statesWithRa.size() + 1, statesWithoutRa.size());
+
         List<Contingency> contingenciesWithoutRa = statesWithoutRa.stream()
             .filter(state -> state.getContingency().isPresent())
             .map(state -> convertCracContingencyToPowsybl(state.getContingency().get(), network))
             .collect(Collectors.toList());
 
-        //todo : better handling of the cnecSensitivityProvider to avoid the computation of useless sensis
-        SensitivityAnalysisResult resultWithoutRa = SensitivityAnalysis.run(network, cnecSensitivityProvider, contingenciesWithoutRa, sensitivityComputationParameters);
-        SystematicSensitivityResult result = new SystematicSensitivityResult(resultWithoutRa);
+        SystematicSensitivityResult result = new SystematicSensitivityResult();
+        result.completeData(SensitivityAnalysis.run(network, cnecSensitivityProvider, contingenciesWithoutRa, sensitivityComputationParameters));
 
         // systematic analyses for states with RA
-        Map<State, SensitivityAnalysisResult> resultWithRaMap = new HashMap<>();
         String workingVariantId = network.getVariantManager().getWorkingVariantId();
-        int i = 1;
+        int counterForLogs = 2;
         for (State state : appliedRemedialActions.getStatesWithRa()) {
 
-            LOGGER.debug("- curative state {} with RA [{}/{}]", i, state.getContingency().get().getId(), appliedRemedialActions.getStatesWithRa().size());
+            if (state.getContingency().isEmpty()) {
+                throw new FaraoException("Sensitivity analysis with applied RA does not handled preventive RA.");
+            }
+
+            com.farao_community.farao.data.crac_api.Contingency contingency = state.getContingency().get();
+
+            LOGGER.debug("... ({}/{}) curative state {}", counterForLogs, appliedRemedialActions.getStatesWithRa().size() + 1, contingency.getId());
 
             String variantForState = RandomizedString.getRandomizedString();
             network.getVariantManager().cloneVariant(workingVariantId, variantForState);
             network.getVariantManager().setWorkingVariant(variantForState);
 
-            appliedRemedialActions.apply(state, network);
+            appliedRemedialActions.applyOnNetwork(state, network);
 
-            List<Contingency> contingency = Collections.singletonList(convertCracContingencyToPowsybl(state.getContingency().get(), network));
+            List<Contingency> contingencyList = Collections.singletonList(convertCracContingencyToPowsybl(contingency, network));
 
-            SensitivityAnalysisResult resultWithRa = SensitivityAnalysis.run(network, variantForState, cnecSensitivityProvider, contingency, sensitivityComputationParameters);
-            resultWithRaMap.put(state, resultWithRa);
-
-            result.fillData(resultWithRa);
+            result.completeData(SensitivityAnalysis.run(network, variantForState, cnecSensitivityProvider, contingencyList, sensitivityComputationParameters));
             network.getVariantManager().removeVariant(variantForState);
-            i++;
+            counterForLogs++;
         }
 
-        // merge results
-        result.postTreatIntensities();
+        LOGGER.debug("Systematic sensitivity analysis with applied RA [end]");
 
         network.getVariantManager().setWorkingVariant(workingVariantId);
-
-        return result;
+        return result.postTreatIntensities();
     }
 
     private static Set<State> getStatesWithoutRa(AppliedRemedialActions appliedRemedialActions, CnecSensitivityProvider cnecSensitivityProvider) {

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityAdapter.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityAdapter.java
@@ -42,8 +42,8 @@ final class SystematicSensitivityAdapter {
 
     static SystematicSensitivityResult runSensitivity(Network network,
                                                       CnecSensitivityProvider cnecSensitivityProvider,
-                                                      SensitivityAnalysisParameters sensitivityComputationParameters,
-                                                      AppliedRemedialActions appliedRemedialActions) {
+                                                      AppliedRemedialActions appliedRemedialActions,
+                                                      SensitivityAnalysisParameters sensitivityComputationParameters) {
 
         if (appliedRemedialActions == null || appliedRemedialActions.isEmpty()) {
             return runSensitivity(network, cnecSensitivityProvider, sensitivityComputationParameters);

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityAdapter.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityAdapter.java
@@ -51,8 +51,9 @@ final class SystematicSensitivityAdapter {
 
         LOGGER.debug("Systematic sensitivity analysis with applied RA [start]");
 
-        Set<State> statesWithoutRa = getStatesWithoutRa(appliedRemedialActions, cnecSensitivityProvider);
         Set<State> statesWithRa = appliedRemedialActions.getStatesWithRa();
+        Set<State> statesWithoutRa = cnecSensitivityProvider.getFlowCnecs().stream().map(Cnec::getState).collect(Collectors.toSet());
+        statesWithoutRa.removeAll(statesWithRa);
 
         // systematic analysis for states without RA
         LOGGER.debug("... (1/{}) {} state(s) without RA ", statesWithRa.size() + 1, statesWithoutRa.size());
@@ -96,11 +97,5 @@ final class SystematicSensitivityAdapter {
 
         network.getVariantManager().setWorkingVariant(workingVariantId);
         return result.postTreatIntensities();
-    }
-
-    private static Set<State> getStatesWithoutRa(AppliedRemedialActions appliedRemedialActions, CnecSensitivityProvider cnecSensitivityProvider) {
-        Set<State> states = cnecSensitivityProvider.getFlowCnecs().stream().map(Cnec::getState).collect(Collectors.toSet());
-        states.removeAll(appliedRemedialActions.getStatesWithRa());
-        return states;
     }
 }

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityAdapter.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityAdapter.java
@@ -71,13 +71,13 @@ final class SystematicSensitivityAdapter {
         int counterForLogs = 2;
         for (State state : appliedRemedialActions.getStatesWithRa()) {
 
-            if (state.getContingency().isEmpty()) {
+            Optional<com.farao_community.farao.data.crac_api.Contingency> optContingency = state.getContingency();
+
+            if (optContingency.isEmpty()) {
                 throw new FaraoException("Sensitivity analysis with applied RA does not handled preventive RA.");
             }
 
-            com.farao_community.farao.data.crac_api.Contingency contingency = state.getContingency().get();
-
-            LOGGER.debug("... ({}/{}) curative state {}", counterForLogs, appliedRemedialActions.getStatesWithRa().size() + 1, contingency.getId());
+            LOGGER.debug("... ({}/{}) curative state {}", counterForLogs, appliedRemedialActions.getStatesWithRa().size() + 1, optContingency.get().getId());
 
             String variantForState = RandomizedString.getRandomizedString();
             network.getVariantManager().cloneVariant(workingVariantId, variantForState);
@@ -85,7 +85,7 @@ final class SystematicSensitivityAdapter {
 
             appliedRemedialActions.applyOnNetwork(state, network);
 
-            List<Contingency> contingencyList = Collections.singletonList(convertCracContingencyToPowsybl(contingency, network));
+            List<Contingency> contingencyList = Collections.singletonList(convertCracContingencyToPowsybl(optContingency.get(), network));
 
             result.completeData(SensitivityAnalysis.run(network, variantForState, cnecSensitivityProvider, contingencyList, sensitivityComputationParameters));
             network.getVariantManager().removeVariant(variantForState);

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityAdapter.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityAdapter.java
@@ -66,6 +66,7 @@ final class SystematicSensitivityAdapter {
         result.completeData(SensitivityAnalysis.run(network, cnecSensitivityProvider, contingenciesWithoutRa, sensitivityComputationParameters));
 
         // systematic analyses for states with RA
+        cnecSensitivityProvider.disableFactorsForBaseCaseSituation();
         String workingVariantId = network.getVariantManager().getWorkingVariantId();
         int counterForLogs = 2;
         for (State state : appliedRemedialActions.getStatesWithRa()) {

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityInterface.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityInterface.java
@@ -9,7 +9,9 @@ package com.farao_community.farao.sensitivity_analysis;
 
 import com.farao_community.farao.commons.Unit;
 import com.farao_community.farao.commons.ZonalData;
+import com.farao_community.farao.data.crac_api.State;
 import com.farao_community.farao.data.crac_api.cnec.FlowCnec;
+import com.farao_community.farao.data.crac_api.network_action.NetworkAction;
 import com.farao_community.farao.data.crac_api.range_action.RangeAction;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.sensitivity.SensitivityAnalysisParameters;
@@ -88,6 +90,14 @@ public final class SystematicSensitivityInterface {
 
         public SystematicSensitivityInterfaceBuilder withLoadflow(Set<FlowCnec> cnecs, Set<Unit> units) {
             return this.withSensitivityProvider(new LoadflowProvider(cnecs, units));
+        }
+
+        public SystematicSensitivityInterfaceBuilder withAppliedNetworkAction(State state, NetworkAction networkAction) {
+            return this;
+        }
+
+        public SystematicSensitivityInterfaceBuilder withAppliedRangeAction(State state, RangeAction rangeAction, double setpoint) {
+            return this;
         }
 
         public SystematicSensitivityInterface build() {

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityInterface.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityInterface.java
@@ -52,12 +52,18 @@ public final class SystematicSensitivityInterface {
     private boolean fallbackMode = false;
 
     /**
+     * The remedialActions that are applied in the initial network or after some contingencies
+     */
+    private AppliedRemedialActions appliedRemedialActions;
+
+    /**
      * Builder
      */
     public static final class SystematicSensitivityInterfaceBuilder {
         private SensitivityAnalysisParameters defaultParameters;
         private SensitivityAnalysisParameters fallbackParameters;
         private MultipleSensitivityProvider multipleSensitivityProvider = new MultipleSensitivityProvider();
+        private AppliedRemedialActions appliedRemedialActions = new AppliedRemedialActions();
         private boolean providerInitialised = false;
 
         private SystematicSensitivityInterfaceBuilder() {
@@ -93,14 +99,17 @@ public final class SystematicSensitivityInterface {
         }
 
         public SystematicSensitivityInterfaceBuilder withAppliedNetworkAction(State state, NetworkAction networkAction) {
+            appliedRemedialActions.addAppliedNetworkAction(state, networkAction);
             return this;
         }
 
         public SystematicSensitivityInterfaceBuilder withAppliedRangeAction(State state, RangeAction rangeAction, double setpoint) {
+            appliedRemedialActions.addAppliedRangeAction(state, rangeAction, setpoint);
             return this;
         }
 
         public SystematicSensitivityInterface build() {
+
             if (!providerInitialised) {
                 throw new SensitivityAnalysisException("Sensitivity provider is mandatory when building a SystematicSensitivityInterface.");
             }

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityInterface.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityInterface.java
@@ -120,6 +120,7 @@ public final class SystematicSensitivityInterface {
             systematicSensitivityInterface.defaultParameters = defaultParameters;
             systematicSensitivityInterface.fallbackParameters = fallbackParameters;
             systematicSensitivityInterface.cnecSensitivityProvider = multipleSensitivityProvider;
+            systematicSensitivityInterface.appliedRemedialActions = appliedRemedialActions;
             return systematicSensitivityInterface;
         }
     }
@@ -176,7 +177,7 @@ public final class SystematicSensitivityInterface {
     private SystematicSensitivityResult runWithConfig(Network network, SensitivityAnalysisParameters sensitivityAnalysisParameters) {
         try {
             SystematicSensitivityResult tempSystematicSensitivityAnalysisResult = SystematicSensitivityAdapter
-                .runSensitivity(network, cnecSensitivityProvider, sensitivityAnalysisParameters);
+                .runSensitivity(network, cnecSensitivityProvider, sensitivityAnalysisParameters, appliedRemedialActions);
 
             if (!tempSystematicSensitivityAnalysisResult.isSuccess()) {
                 throw new SensitivityAnalysisException("Some output data of the sensitivity analysis are missing.");

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityInterface.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityInterface.java
@@ -177,7 +177,7 @@ public final class SystematicSensitivityInterface {
     private SystematicSensitivityResult runWithConfig(Network network, SensitivityAnalysisParameters sensitivityAnalysisParameters) {
         try {
             SystematicSensitivityResult tempSystematicSensitivityAnalysisResult = SystematicSensitivityAdapter
-                .runSensitivity(network, cnecSensitivityProvider, sensitivityAnalysisParameters, appliedRemedialActions);
+                .runSensitivity(network, cnecSensitivityProvider, appliedRemedialActions, sensitivityAnalysisParameters);
 
             if (!tempSystematicSensitivityAnalysisResult.isSuccess()) {
                 throw new SensitivityAnalysisException("Some output data of the sensitivity analysis are missing.");

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityResult.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityResult.java
@@ -100,6 +100,12 @@ public class SystematicSensitivityResult {
         });
     }
 
+    void fillData(SensitivityAnalysisResult results, Contingency contingency) {
+        StateResult contingencyStateResult = new StateResult();
+        results.getSensitivityValues().forEach(sensitivityValue -> fillIndividualValue(sensitivityValue, contingencyStateResult));
+        contingencyResults.put(contingency.getId(), contingencyStateResult);
+    }
+
     private void fillIndividualValue(SensitivityValue value, StateResult stateResult) {
         double reference = value.getFunctionReference();
         double sensitivity = value.getValue();

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityResult.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityResult.java
@@ -69,13 +69,11 @@ public class SystematicSensitivityResult {
             return;
         }
         this.status = SensitivityComputationStatus.SUCCESS;
-        LOGGER.debug("Filling data...");
         fillData(results);
-        LOGGER.debug("Data post treatment...");
         postTreatIntensities();
     }
 
-    private void postTreatIntensities() {
+    void postTreatIntensities() {
         postTreatIntensitiesOnState(nStateResult);
         contingencyResults.values().forEach(this::postTreatIntensitiesOnState);
     }
@@ -93,7 +91,7 @@ public class SystematicSensitivityResult {
         });
     }
 
-    private void fillData(SensitivityAnalysisResult results) {
+    void fillData(SensitivityAnalysisResult results) {
         results.getSensitivityValues().forEach(sensitivityValue -> fillIndividualValue(sensitivityValue, nStateResult));
         results.getSensitivityValuesContingencies().forEach((contingencyId, sensitivityValues) -> {
             StateResult contingencyStateResult = new StateResult();

--- a/sensitivity-analysis/src/test/java/com/farao_community/farao/sensitivity_analysis/AppliedRemedialActionsTest.java
+++ b/sensitivity-analysis/src/test/java/com/farao_community/farao/sensitivity_analysis/AppliedRemedialActionsTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.farao_community.farao.sensitivity_analysis;
+
+import com.farao_community.farao.commons.FaraoException;
+import com.farao_community.farao.data.crac_api.Crac;
+import com.farao_community.farao.data.crac_api.Instant;
+import com.farao_community.farao.data.crac_api.network_action.ActionType;
+import com.farao_community.farao.data.crac_api.network_action.NetworkAction;
+import com.farao_community.farao.data.crac_api.range_action.PstRangeAction;
+import com.farao_community.farao.data.crac_api.usage_rule.UsageMethod;
+import com.farao_community.farao.data.crac_impl.utils.CommonCracCreation;
+import com.farao_community.farao.data.crac_impl.utils.NetworkImportsUtil;
+import com.powsybl.iidm.network.Network;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com>}
+ */
+public class AppliedRemedialActionsTest {
+
+    private Network network;
+    private Crac crac;
+    private NetworkAction networkAction;
+    private PstRangeAction pstRangeAction;
+
+    @Before
+    public void setUp() {
+        network = NetworkImportsUtil.import12NodesNetwork();
+        crac = CommonCracCreation.createWithCurativePstRange();
+        pstRangeAction = crac.getPstRangeAction("pst");
+        networkAction = crac.newNetworkAction()
+                .withId("na-id")
+                .newTopologicalAction().withActionType(ActionType.OPEN).withNetworkElement("BBE2AA1  FFR3AA1  1").add()
+                .newFreeToUseUsageRule().withUsageMethod(UsageMethod.AVAILABLE).withInstant(Instant.CURATIVE).add()
+                .add();
+    }
+
+    @Test
+    public void testAppliedRemedialActionOnOneState() {
+        AppliedRemedialActions appliedRemedialActions = new AppliedRemedialActions();
+        appliedRemedialActions.addAppliedNetworkAction(crac.getState("Contingency FR1 FR3", Instant.CURATIVE), networkAction);
+        appliedRemedialActions.addAppliedRangeAction(crac.getState("Contingency FR1 FR3", Instant.CURATIVE), pstRangeAction, 3.1);
+
+        // check object
+        assertFalse(appliedRemedialActions.isEmpty());
+        assertEquals(1, appliedRemedialActions.getStatesWithRa().size());
+        assertEquals("Contingency FR1 FR3", appliedRemedialActions.getStatesWithRa().iterator().next().getContingency().get().getId());
+
+        // apply remedial actions on network
+        assertTrue(network.getBranch("BBE2AA1  FFR3AA1  1").getTerminal1().isConnected());
+        assertEquals(0, network.getTwoWindingsTransformer("BBE2AA1  BBE3AA1  1").getPhaseTapChanger().getTapPosition(), 0);
+        assertEquals(0, network.getTwoWindingsTransformer("BBE2AA1  BBE3AA1  1").getPhaseTapChanger().getCurrentStep().getAlpha(), 1e-3);
+
+        appliedRemedialActions.applyOnNetwork(crac.getState("Contingency FR1 FR3", Instant.CURATIVE), network);
+
+        assertFalse(network.getBranch("BBE2AA1  FFR3AA1  1").getTerminal1().isConnected());
+        assertEquals(8, network.getTwoWindingsTransformer("BBE2AA1  BBE3AA1  1").getPhaseTapChanger().getTapPosition(), 0);
+        assertEquals(3.1, network.getTwoWindingsTransformer("BBE2AA1  BBE3AA1  1").getPhaseTapChanger().getCurrentStep().getAlpha(), 1e-1);
+    }
+
+    @Test
+    public void testAppliedRemedialActionOnTwoStates() {
+        AppliedRemedialActions appliedRemedialActions = new AppliedRemedialActions();
+        appliedRemedialActions.addAppliedNetworkAction(crac.getState("Contingency FR1 FR3", Instant.CURATIVE), networkAction);
+        appliedRemedialActions.addAppliedRangeAction(crac.getState("Contingency FR1 FR2", Instant.CURATIVE), pstRangeAction, 3.2);
+
+        assertFalse(appliedRemedialActions.isEmpty());
+        assertEquals(2, appliedRemedialActions.getStatesWithRa().size());
+
+        // apply remedial actions on network
+        assertTrue(network.getBranch("BBE2AA1  FFR3AA1  1").getTerminal1().isConnected());
+        assertEquals(0, network.getTwoWindingsTransformer("BBE2AA1  BBE3AA1  1").getPhaseTapChanger().getTapPosition(), 0);
+
+        appliedRemedialActions.applyOnNetwork(crac.getState("Contingency FR1 FR3", Instant.CURATIVE), network);
+
+        assertFalse(network.getBranch("BBE2AA1  FFR3AA1  1").getTerminal1().isConnected());
+        assertEquals(0, network.getTwoWindingsTransformer("BBE2AA1  BBE3AA1  1").getPhaseTapChanger().getTapPosition(), 0);
+    }
+
+    @Test
+    public void testEmptyAppliedRemedialActions() {
+        AppliedRemedialActions appliedRemedialActions = new AppliedRemedialActions();
+
+        assertTrue(appliedRemedialActions.isEmpty());
+        assertEquals(0, appliedRemedialActions.getStatesWithRa().size());
+    }
+
+    @Test (expected = FaraoException.class)
+    public void testAppliedRemedialActionOnPreventiveState() {
+        AppliedRemedialActions appliedRemedialActions = new AppliedRemedialActions();
+        appliedRemedialActions.addAppliedNetworkAction(crac.getPreventiveState(), networkAction);
+    }
+}

--- a/sensitivity-analysis/src/test/java/com/farao_community/farao/sensitivity_analysis/MockSensiProvider.java
+++ b/sensitivity-analysis/src/test/java/com/farao_community/farao/sensitivity_analysis/MockSensiProvider.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.farao_community.farao.sensitivity_analysis;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.computation.ComputationManager;
+import com.powsybl.contingency.Contingency;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.TwoWindingsTransformer;
+import com.powsybl.sensitivity.*;
+import com.powsybl.sensitivity.factors.functions.BranchFlow;
+import com.powsybl.sensitivity.factors.functions.BranchIntensity;
+import com.powsybl.sensitivity.factors.variables.LinearGlsk;
+import com.powsybl.sensitivity.factors.variables.PhaseTapChangerAngle;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+/**
+ * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
+ */
+@AutoService(SensitivityAnalysisProvider.class)
+public final class MockSensiProvider implements SensitivityAnalysisProvider {
+
+    @Override
+    public CompletableFuture<SensitivityAnalysisResult> run(Network network, String s, SensitivityFactorsProvider sensitivityFactorsProvider, List<Contingency> contingencies, SensitivityAnalysisParameters sensitivityAnalysisParameters, ComputationManager computationManager) {
+
+        TwoWindingsTransformer pst = network.getTwoWindingsTransformer("BBE2AA1  BBE3AA1  1");
+
+        if (pst == null || pst.getPhaseTapChanger().getTapPosition() == 0) {
+            // used for most of the tests
+            return getResultsIfPstIsAtNeutralTap(network, sensitivityFactorsProvider, contingencies);
+        } else {
+            // used for tests with already applied RangeActions in Curative states
+            return getResultsIfPstIsNotAtNeutralTap(network, sensitivityFactorsProvider, contingencies);
+        }
+    }
+
+    private CompletableFuture<SensitivityAnalysisResult> getResultsIfPstIsAtNeutralTap(Network network, SensitivityFactorsProvider sensitivityFactorsProvider, List<Contingency> contingencies) {
+        List<SensitivityValue> nStateValues = sensitivityFactorsProvider.getAdditionalFactors(network).stream()
+            .map(factor -> {
+                if (factor.getFunction() instanceof BranchFlow && factor.getVariable() instanceof PhaseTapChangerAngle) {
+                    return new SensitivityValue(factor, 0.5, 10, 0);
+                } else if (factor.getFunction() instanceof BranchIntensity && factor.getVariable() instanceof PhaseTapChangerAngle) {
+                    return new SensitivityValue(factor, 0.25, 25, 0);
+                } else if (factor.getFunction() instanceof BranchFlow && factor.getVariable() instanceof LinearGlsk) {
+                    return new SensitivityValue(factor, 0.140, 10, 0);
+                } else {
+                    throw new AssertionError();
+                }
+            })
+            .collect(Collectors.toList());
+        Map<String, List<SensitivityValue>> contingenciesValues = contingencies.stream()
+            .collect(Collectors.toMap(
+                Contingency::getId,
+                contingency -> sensitivityFactorsProvider.getAdditionalFactors(network, contingency.getId()).stream()
+                    .map(factor -> {
+                        if (factor.getFunction() instanceof BranchFlow && factor.getVariable() instanceof PhaseTapChangerAngle) {
+                            return new SensitivityValue(factor, -5, -20, 0);
+                        } else if (factor.getFunction() instanceof BranchIntensity && factor.getVariable() instanceof PhaseTapChangerAngle) {
+                            return new SensitivityValue(factor, 5, 200, 0);
+                        } else if (factor.getFunction() instanceof BranchFlow && factor.getVariable() instanceof LinearGlsk) {
+                            return new SensitivityValue(factor, 6, -20, 0);
+                        } else {
+                            throw new AssertionError();
+                        }
+                    })
+                    .collect(Collectors.toList())
+            ));
+        return CompletableFuture.completedFuture(new SensitivityAnalysisResult(true, Collections.emptyMap(), "", nStateValues, contingenciesValues));
+    }
+
+    private CompletableFuture<SensitivityAnalysisResult> getResultsIfPstIsNotAtNeutralTap(Network network, SensitivityFactorsProvider sensitivityFactorsProvider, List<Contingency> contingencies) {
+        List<SensitivityValue> nStateValues = sensitivityFactorsProvider.getAdditionalFactors(network).stream()
+            .map(factor -> {
+                if (factor.getFunction() instanceof BranchFlow && factor.getVariable() instanceof PhaseTapChangerAngle) {
+                    return new SensitivityValue(factor, 1.5, 110, 0);
+                } else if (factor.getFunction() instanceof BranchIntensity && factor.getVariable() instanceof PhaseTapChangerAngle) {
+                    return new SensitivityValue(factor, 1.25, 1100, 0);
+                } else if (factor.getFunction() instanceof BranchFlow && factor.getVariable() instanceof LinearGlsk) {
+                    return new SensitivityValue(factor, 1.140, 110, 0);
+                } else {
+                    throw new AssertionError();
+                }
+            })
+            .collect(Collectors.toList());
+        Map<String, List<SensitivityValue>> contingenciesValues = contingencies.stream()
+            .collect(Collectors.toMap(
+                Contingency::getId,
+                contingency -> sensitivityFactorsProvider.getAdditionalFactors(network, contingency.getId()).stream()
+                    .map(factor -> {
+                        if (factor.getFunction() instanceof BranchFlow && factor.getVariable() instanceof PhaseTapChangerAngle) {
+                            return new SensitivityValue(factor, -2.5, -40, 0);
+                        } else if (factor.getFunction() instanceof BranchIntensity && factor.getVariable() instanceof PhaseTapChangerAngle) {
+                            return new SensitivityValue(factor, 4.5, 180, 0);
+                        } else if (factor.getFunction() instanceof BranchFlow && factor.getVariable() instanceof LinearGlsk) {
+                            return new SensitivityValue(factor, 6.6, -40, 0);
+                        } else {
+                            throw new AssertionError();
+                        }
+                    })
+                    .collect(Collectors.toList())
+            ));
+        return CompletableFuture.completedFuture(new SensitivityAnalysisResult(true, Collections.emptyMap(), "", nStateValues, contingenciesValues));    }
+
+    @Override
+    public String getName() {
+        return "MockSensi";
+    }
+
+    @Override
+    public String getVersion() {
+        return "0";
+    }
+}

--- a/sensitivity-analysis/src/test/java/com/farao_community/farao/sensitivity_analysis/PtdfSensitivityProviderTest.java
+++ b/sensitivity-analysis/src/test/java/com/farao_community/farao/sensitivity_analysis/PtdfSensitivityProviderTest.java
@@ -55,11 +55,25 @@ public class PtdfSensitivityProviderTest {
         assertTrue(sensitivityFactors.stream().anyMatch(sensitivityFactor -> sensitivityFactor.getFunction().getId().contains("FFR2AA1  DDE3AA1  1")
                                                                           && sensitivityFactor.getVariable().getId().contains("10YCB-GERMANY--8")));
 
-        String contingencyId = crac.getContingencies().iterator().next().getId();
         sensitivityFactors = ptdfSensitivityProvider.getAdditionalFactors(network, crac.getContingencies().iterator().next().getId());
         assertEquals(8, sensitivityFactors.size());
         assertTrue(sensitivityFactors.stream().anyMatch(sensitivityFactor -> sensitivityFactor.getFunction().getId().contains("FFR2AA1  DDE3AA1  1")
             && sensitivityFactor.getVariable().getId().contains("10YCB-GERMANY--8")));
+    }
+
+    @Test
+    public void testDisableFactorForBaseCase() {
+        PtdfSensitivityProvider ptdfSensitivityProvider = new PtdfSensitivityProvider(glskMock, crac.getFlowCnecs(), Collections.singleton(Unit.MEGAWATT));
+
+        // factors with basecase and contingency
+        assertEquals(8, ptdfSensitivityProvider.getAdditionalFactors(network).size());
+        assertEquals(8, ptdfSensitivityProvider.getAdditionalFactors(network, "Contingency FR1 FR3").size());
+
+        ptdfSensitivityProvider.disableFactorsForBaseCaseSituation();
+
+        // factors after disabling basecase
+        assertEquals(0, ptdfSensitivityProvider.getAdditionalFactors(network).size());
+        assertEquals(8, ptdfSensitivityProvider.getAdditionalFactors(network, "Contingency FR1 FR3").size());
     }
 
     @Test

--- a/sensitivity-analysis/src/test/java/com/farao_community/farao/sensitivity_analysis/RangeActionSensitivityProviderTest.java
+++ b/sensitivity-analysis/src/test/java/com/farao_community/farao/sensitivity_analysis/RangeActionSensitivityProviderTest.java
@@ -27,8 +27,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
@@ -112,6 +111,23 @@ public class RangeActionSensitivityProviderTest {
         assertTrue(contingencyList.stream().anyMatch(contingency -> contingency.getId().equals("contingency-generator")));
         assertTrue(contingencyList.stream().anyMatch(contingency -> contingency.getId().equals("contingency-hvdc")));
         assertTrue(contingencyList.stream().anyMatch(contingency -> contingency.getId().equals("contingency-busbar-section")));
+    }
+
+    @Test
+    public void testDisableFactorForBaseCase() {
+        Network network = NetworkImportsUtil.import12NodesNetwork();
+        Crac crac = CommonCracCreation.createWithPreventivePstRange();
+        RangeActionSensitivityProvider provider = new RangeActionSensitivityProvider(crac.getRangeActions(), crac.getFlowCnecs(), Stream.of(Unit.MEGAWATT, Unit.AMPERE).collect(Collectors.toSet()));
+
+        // factors with basecase and contingency
+        assertEquals(4, provider.getAdditionalFactors(network).size());
+        assertEquals(4, provider.getAdditionalFactors(network, "Contingency FR1 FR3").size());
+
+        provider.disableFactorsForBaseCaseSituation();
+
+        // factors after disabling basecase
+        assertEquals(0, provider.getAdditionalFactors(network).size());
+        assertEquals(4, provider.getAdditionalFactors(network, "Contingency FR1 FR3").size());
     }
 
     @Test(expected = FaraoException.class)

--- a/sensitivity-analysis/src/test/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityInterfaceTest.java
+++ b/sensitivity-analysis/src/test/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityInterfaceTest.java
@@ -63,7 +63,7 @@ public class SystematicSensitivityInterfaceTest {
     @Test
     public void testRunDefaultConfigOk() {
         // mock sensi service - run OK
-        Mockito.when(SystematicSensitivityAdapter.runSensitivity(Mockito.any(), Mockito.any(), Mockito.any()))
+        Mockito.when(SystematicSensitivityAdapter.runSensitivity(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
             .thenAnswer(invocationOnMock -> systematicAnalysisResultOk);
 
         // run engine
@@ -110,10 +110,10 @@ public class SystematicSensitivityInterfaceTest {
     @Test
     public void testRunDefaultConfigFailsButFallbackOk() {
         // mock sensi service - run with null sensi
-        Mockito.when(SystematicSensitivityAdapter.runSensitivity(Mockito.any(), Mockito.any(), ArgumentMatchers.eq(defaultParameters)))
+        Mockito.when(SystematicSensitivityAdapter.runSensitivity(Mockito.any(), Mockito.any(), Mockito.any(), ArgumentMatchers.eq(defaultParameters)))
             .thenAnswer(invocationOnMock -> systematicAnalysisResultFailed);
 
-        Mockito.when(SystematicSensitivityAdapter.runSensitivity(Mockito.any(), Mockito.any(), ArgumentMatchers.eq(fallbackParameters)))
+        Mockito.when(SystematicSensitivityAdapter.runSensitivity(Mockito.any(), Mockito.any(), Mockito.any(), ArgumentMatchers.eq(fallbackParameters)))
             .thenAnswer(invocationOnMock -> systematicAnalysisResultOk);
 
         SystematicSensitivityInterface systematicSensitivityInterface = SystematicSensitivityInterface.builder()
@@ -142,10 +142,10 @@ public class SystematicSensitivityInterfaceTest {
     @Test
     public void testRunDefaultConfigAndFallbackFail() {
         // mock sensi service - run with null sensi
-        Mockito.when(SystematicSensitivityAdapter.runSensitivity(Mockito.any(), Mockito.any(), ArgumentMatchers.eq(defaultParameters)))
+        Mockito.when(SystematicSensitivityAdapter.runSensitivity(Mockito.any(), Mockito.any(), Mockito.any(), ArgumentMatchers.eq(defaultParameters)))
             .thenAnswer(invocationOnMock -> systematicAnalysisResultFailed);
 
-        Mockito.when(SystematicSensitivityAdapter.runSensitivity(Mockito.any(), Mockito.any(), ArgumentMatchers.eq(fallbackParameters)))
+        Mockito.when(SystematicSensitivityAdapter.runSensitivity(Mockito.any(), Mockito.any(), Mockito.any(), ArgumentMatchers.eq(fallbackParameters)))
             .thenAnswer(invocationOnMock -> systematicAnalysisResultFailed);
 
         SystematicSensitivityInterface systematicSensitivityInterface = SystematicSensitivityInterface.builder()

--- a/sensitivity-analysis/src/test/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityResultTest.java
+++ b/sensitivity-analysis/src/test/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityResultTest.java
@@ -76,7 +76,7 @@ public class SystematicSensitivityResultTest {
     public void testCompleteRaResultManipulation() {
         // When
         SensitivityAnalysisResult sensitivityAnalysisResult = SensitivityAnalysis.run(network, network.getVariantManager().getWorkingVariantId(), rangeActionSensitivityProvider, rangeActionSensitivityProvider.getContingencies(network), SensitivityAnalysisParameters.load());
-        SystematicSensitivityResult result = new SystematicSensitivityResult(sensitivityAnalysisResult);
+        SystematicSensitivityResult result = new SystematicSensitivityResult();
 
         // Then
         assertTrue(result.isSuccess());
@@ -98,7 +98,7 @@ public class SystematicSensitivityResultTest {
     public void testCompletePtdfResultManipulation() {
         // When
         SensitivityAnalysisResult sensitivityAnalysisResult = SensitivityAnalysis.run(network, network.getVariantManager().getWorkingVariantId(), ptdfSensitivityProvider, ptdfSensitivityProvider.getContingencies(network), SensitivityAnalysisParameters.load());
-        SystematicSensitivityResult result = new SystematicSensitivityResult(sensitivityAnalysisResult);
+        SystematicSensitivityResult result = new SystematicSensitivityResult();
 
         // Then
         assertTrue(result.isSuccess());
@@ -117,7 +117,7 @@ public class SystematicSensitivityResultTest {
         // When
         SensitivityAnalysisResult sensitivityAnalysisResult = Mockito.mock(SensitivityAnalysisResult.class);
         Mockito.when(sensitivityAnalysisResult.isOk()).thenReturn(false);
-        SystematicSensitivityResult result = new SystematicSensitivityResult(sensitivityAnalysisResult);
+        SystematicSensitivityResult result = new SystematicSensitivityResult();
 
         // Then
         assertFalse(result.isSuccess());

--- a/sensitivity-analysis/src/test/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityResultTest.java
+++ b/sensitivity-analysis/src/test/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityResultTest.java
@@ -73,10 +73,26 @@ public class SystematicSensitivityResultTest {
     }
 
     @Test
-    public void testCompleteRaResultManipulation() {
+    public void testPostTreatIntensities() {
+        // When
+        SensitivityAnalysisResult sensitivityAnalysisResult = SensitivityAnalysis.run(network, network.getVariantManager().getWorkingVariantId(), rangeActionSensitivityProvider, ptdfSensitivityProvider.getContingencies(network), SensitivityAnalysisParameters.load());
+        SystematicSensitivityResult result = new SystematicSensitivityResult().completeData(sensitivityAnalysisResult);
+
+        // Before postTreating intensities
+        assertEquals(-20, result.getReferenceFlow(contingencyCnec), EPSILON);
+        assertEquals(200, result.getReferenceIntensity(contingencyCnec), EPSILON);
+
+        // After postTreating intensities
+        result.postTreatIntensities();
+        assertEquals(-20, result.getReferenceFlow(contingencyCnec), EPSILON);
+        assertEquals(-200, result.getReferenceIntensity(contingencyCnec), EPSILON);
+    }
+
+    @Test
+    public void testPstResultManipulation() {
         // When
         SensitivityAnalysisResult sensitivityAnalysisResult = SensitivityAnalysis.run(network, network.getVariantManager().getWorkingVariantId(), rangeActionSensitivityProvider, rangeActionSensitivityProvider.getContingencies(network), SensitivityAnalysisParameters.load());
-        SystematicSensitivityResult result = new SystematicSensitivityResult();
+        SystematicSensitivityResult result = new SystematicSensitivityResult().completeData(sensitivityAnalysisResult).postTreatIntensities();
 
         // Then
         assertTrue(result.isSuccess());
@@ -95,10 +111,10 @@ public class SystematicSensitivityResultTest {
     }
 
     @Test
-    public void testCompletePtdfResultManipulation() {
+    public void testPtdfResultManipulation() {
         // When
         SensitivityAnalysisResult sensitivityAnalysisResult = SensitivityAnalysis.run(network, network.getVariantManager().getWorkingVariantId(), ptdfSensitivityProvider, ptdfSensitivityProvider.getContingencies(network), SensitivityAnalysisParameters.load());
-        SystematicSensitivityResult result = new SystematicSensitivityResult();
+        SystematicSensitivityResult result = new SystematicSensitivityResult().completeData(sensitivityAnalysisResult).postTreatIntensities();
 
         // Then
         assertTrue(result.isSuccess());
@@ -113,11 +129,11 @@ public class SystematicSensitivityResultTest {
     }
 
     @Test
-    public void testIncompleteSensiResult() {
+    public void testNokSensiResult() {
         // When
         SensitivityAnalysisResult sensitivityAnalysisResult = Mockito.mock(SensitivityAnalysisResult.class);
         Mockito.when(sensitivityAnalysisResult.isOk()).thenReturn(false);
-        SystematicSensitivityResult result = new SystematicSensitivityResult();
+        SystematicSensitivityResult result = new SystematicSensitivityResult().completeData(sensitivityAnalysisResult).postTreatIntensities();
 
         // Then
         assertFalse(result.isSuccess());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
New feature


**What is the current behavior?** *(You can also link to an open issue here)*
SystematicSensitivityInterface enables to run a "standard" systematicSensitivityAnalysis

**What is the new behavior (if this is a feature change)?**
SystematicSensitivityInterface enables to run a systematicSensitivityAnalysis with CRA on some curative states. Actually, to do so, the interface orchestrate several sensitivity analysis : 
- one systematic sensi for the N states + all N-k without CRA
- for each N-k with CRA, one sensi on the N-k, after applying "manually" the CRA on the network

**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No

some methods has been added to the SystematicSensitivityInterface in order to defined applied CRA, but previous methods should work as before.
