### PR TITLE
Rollback RangeAction setpoints after degradation in iterating LP (v2.4 patch)

### DIFF
--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizer.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizer.java
@@ -158,6 +158,7 @@ public class IteratingLinearOptimizer {
 
     private String getBestVariantWithSafeDelete(String variantToDelete) {
         cracVariantManager.setWorkingVariant(bestVariantId);
+        raoData.getCracResultManager().applyRangeActionResultsOnNetwork();
         if (!variantToDelete.equals(raoData.getPreOptimVariantId())) {
             cracVariantManager.deleteVariant(variantToDelete, false);
         }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/iterating_linear_optimizer/IteratingLinearOptimizerTest.java
@@ -171,6 +171,7 @@ public class IteratingLinearOptimizerTest {
 
     @Test
     public void optimizeWithInfeasibility() {
+        raoData.getNetwork().getTwoWindingsTransformer("BBE2AA1  BBE3AA1  1").getPhaseTapChanger().setTapPosition(5);
         String preOptimVariant = raoData.getWorkingVariantId();
 
         Mockito.when(linearOptimizer.getSolverResultStatusString()).thenReturn("INFEASIBLE");
@@ -198,5 +199,8 @@ public class IteratingLinearOptimizerTest {
         assertEquals(0, crac.getRangeAction("PRA_PST_BE").getExtension(RangeActionResultExtension.class)
             .getVariant(preOptimVariant)
             .getSetPoint(crac.getState("N-1 NL1-NL3", Instant.OUTAGE).getId()), DOUBLE_TOLERANCE);
+
+        // The network should be rolled back to initial setpoint also
+        assertEquals(0, raoData.getNetwork().getTwoWindingsTransformer("BBE2AA1  BBE3AA1  1").getPhaseTapChanger().getTapPosition());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When an LP optimal solution degrades the cost (for example if it creates a virtual cost, only detected after sensi), the applied range actions after optim are not rolled back. This can lead to unexpected behavior (for example in controlling the max number of PSTs or CRAs)


**What is the new behavior (if this is a feature change)?**
Range actions are rolled back to their initial value