### PR TITLE
Consider GLSK not connected when bus is null

### DIFF
--- a/loopflow-computation/src/main/java/com/farao_community/farao/loopflow_computation/LoopFlowComputationImpl.java
+++ b/loopflow-computation/src/main/java/com/farao_community/farao/loopflow_computation/LoopFlowComputationImpl.java
@@ -79,14 +79,15 @@ public class LoopFlowComputationImpl implements LoopFlowComputation {
         for (String glsk : linearGlsk.getGLSKs().keySet()) {
             Generator generator = network.getGenerator(glsk);
             if (generator != null) {
-                if (generator.getTerminal().getBusView().getBus().isInMainConnectedComponent()) {
+                // If bus is disconnected, then powsybl returns a null bus
+                if (generator.getTerminal().getBusView().getBus() != null && generator.getTerminal().getBusView().getBus().isInMainConnectedComponent()) {
                     atLeastOneGlskConnected = true;
                 }
             } else {
                 Load load = network.getLoad(glsk);
                 if (load == null) {
                     throw new FaraoException(String.format("%s is neither a generator nor a load in the network. It is not a valid GLSK.", glsk));
-                } else if (load.getTerminal().getBusView().getBus().isInMainConnectedComponent()) {
+                } else if (load.getTerminal().getBusView().getBus() != null && load.getTerminal().getBusView().getBus().isInMainConnectedComponent()) {
                     atLeastOneGlskConnected = true;
                 }
             }

--- a/loopflow-computation/src/test/java/com/farao_community/farao/loopflow_computation/LoopFlowComputationImplTest.java
+++ b/loopflow-computation/src/test/java/com/farao_community/farao/loopflow_computation/LoopFlowComputationImplTest.java
@@ -143,6 +143,31 @@ public class LoopFlowComputationImplTest {
     }
 
     @Test
+    public void testIsInMainComponentNullBus() {
+        LinearGlsk linearGlsk = Mockito.mock(LinearGlsk.class);
+        Network network = Mockito.mock(Network.class);
+
+        Terminal.BusView busView = Mockito.mock(Terminal.BusView.class);
+        Mockito.doReturn(null).when(busView).getBus();
+        Terminal terminal = Mockito.mock(Terminal.class);
+        Mockito.doReturn(busView).when(terminal).getBusView();
+
+        Mockito.doReturn(Map.of("gen1", 5f, "load1", 6f)).when(linearGlsk).getGLSKs();
+        Generator gen1 = Mockito.mock(Generator.class);
+        Load load1 = Mockito.mock(Load.class);
+        Mockito.doReturn(gen1).when(network).getGenerator("gen1");
+        Mockito.doReturn(load1).when(network).getLoad("load1");
+
+        Mockito.doReturn(terminal).when(gen1).getTerminal();
+        Mockito.doReturn(mockInjection(false)).when(load1).getTerminal();
+        assertFalse(LoopFlowComputationImpl.isInMainComponent(linearGlsk, network));
+
+        Mockito.doReturn(mockInjection(false)).when(gen1).getTerminal();
+        Mockito.doReturn(terminal).when(load1).getTerminal();
+        assertFalse(LoopFlowComputationImpl.isInMainComponent(linearGlsk, network));
+    }
+
+    @Test
     public void testComputeLoopFlowsWithIsolatedGlsk() {
         ZonalData<LinearGlsk> glsk = ExampleGenerator.glskProvider();
         ReferenceProgram referenceProgram = ExampleGenerator.referenceProgram();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*
When a bus is completely disconnected from the network, PowSyBl's BusBreakerVoltage.getBus() and getConnectableBus() return null. This actually results in a NullPointerException when trying to access isInMainConnectedComponent() in LoopFlowComputationImpl

**What is the new behavior (if this is a feature change)?**
When the bus is null, it is considered disconnected from the main component of the network