### PR TITLE
Relative PST sensitivity threshold

### DIFF
--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxLoopFlowFillerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxLoopFlowFillerTest.java
@@ -53,9 +53,10 @@ public class MaxLoopFlowFillerTest extends AbstractFillerTest {
                 Set.of(cnec1),
                 Set.of(rangeAction),
                 initialRangeActionResult,
-                0.
+                0.,
+                false
         );
-        ((FlowCnec) cnec1).newExtension(LoopFlowThresholdAdder.class).withValue(100.).withUnit(Unit.MEGAWATT).add();
+        cnec1.newExtension(LoopFlowThresholdAdder.class).withValue(100.).withUnit(Unit.MEGAWATT).add();
     }
 
     private void createMaxLoopFlowFiller(double initialLoopFlowValue) {

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxLoopFlowFillerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxLoopFlowFillerTest.java
@@ -8,7 +8,6 @@
 package com.farao_community.farao.rao_commons.linear_optimisation.fillers;
 
 import com.farao_community.farao.commons.Unit;
-import com.farao_community.farao.data.crac_api.cnec.FlowCnec;
 import com.farao_community.farao.data.crac_loopflow_extension.LoopFlowThresholdAdder;
 import com.farao_community.farao.rao_api.parameters.LoopFlowParameters;
 import com.farao_community.farao.rao_api.parameters.RaoParameters;

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxMinMarginFillerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxMinMarginFillerTest.java
@@ -48,7 +48,8 @@ public class MaxMinMarginFillerTest extends AbstractFillerTest {
                 Set.of(cnec1),
                 Set.of(rangeAction),
                 initialRangeActionResult,
-                0.
+                0.,
+                false
         );
         maxMinMarginParameters = new MaxMinMarginParameters(0.01);
     }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxMinRelativeMarginFillerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxMinRelativeMarginFillerTest.java
@@ -55,7 +55,8 @@ public class MaxMinRelativeMarginFillerTest extends AbstractFillerTest {
                 Set.of(cnec1),
                 Set.of(rangeAction),
                 initialRangeActionResult,
-                0.
+                0.,
+                false
         );
         parameters = new MaxMinRelativeMarginParameters(0.01, 1000, 0.01);
     }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MnecFillerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MnecFillerTest.java
@@ -80,7 +80,8 @@ public class MnecFillerTest extends AbstractFillerTest {
                 Set.of(mnec1, mnec2),
                 Collections.emptySet(),
                 new RangeActionResultImpl(Collections.emptyMap()),
-                0.
+                0.,
+                false
         );
     }
 

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/UnoptimizedCnecFillerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/UnoptimizedCnecFillerTest.java
@@ -69,7 +69,8 @@ public class UnoptimizedCnecFillerTest extends AbstractFillerTest {
                 Set.of(cnecNl, cnecFr),
                 Collections.emptySet(),
                 new RangeActionResultImpl(Collections.emptyMap()),
-                0.
+                0.,
+                false
         );
     }
 

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeProblem.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeProblem.java
@@ -62,7 +62,8 @@ public class SearchTreeProblem {
                 flowCnecs,
                 rangeActions,
                 prePerimeterSetPoints,
-                linearOptimizerParameters.getPstSensitivityThreshold()
+                linearOptimizerParameters.getPstSensitivityThreshold(),
+                linearOptimizerParameters.getObjectiveFunction().relativePositiveMargins()
         );
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
The PST sensitivity threshold is expressed in MW/degree and filters out PSTs with a smaller sensitivity in absolute MW.


**What is the new behavior (if this is a feature change)?**
When the objective function has relative positive margins (and the CNEC's margin is positive), the sensitivity of the PST is rendered relative before comparing it to the threshold.
Thus the threshold is always homogeneous to the objective function, and expressed in "unit of the objective function / degree"

Also, this PR fixes a bug in the update() method of the CoreProblemFiller
