### PR TITLE
Fix AFTER_ARA bug in RaoResult

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/output/PreventiveAndCurativesRaoOutput.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/output/PreventiveAndCurativesRaoOutput.java
@@ -80,15 +80,14 @@ public class PreventiveAndCurativesRaoOutput implements SearchTreeRaoResult {
             case AFTER_PRA:
                 return postPreventiveResult;
             case AFTER_ARA:
-                if (state.getInstant().equals(Instant.CURATIVE)) {
-                    Optional<State> autoState = postContingencyResults.keySet().stream()
-                        .filter(optimizedState -> optimizedState.getInstant().equals(Instant.AUTO) && optimizedState.getContingency().equals(state.getContingency()))
-                        .findAny();
-                    if (autoState.isPresent()) {
-                        return postContingencyResults.get(autoState.get());
-                    }
+                Optional<State> autoState = postContingencyResults.keySet().stream()
+                    .filter(optimizedState -> optimizedState.getInstant().equals(Instant.AUTO) && optimizedState.getContingency().equals(state.getContingency()))
+                    .findAny();
+                if (autoState.isPresent()) {
+                    return postContingencyResults.get(autoState.get());
+                } else {
+                    return null;
                 }
-                return postContingencyResults.get(state);
             case AFTER_CRA:
                 return postContingencyResults.get(state);
             default:

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/output/PreventiveAndCurativesRaoOutputTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/output/PreventiveAndCurativesRaoOutputTest.java
@@ -546,8 +546,7 @@ public class PreventiveAndCurativesRaoOutputTest {
         assertEquals(3., perimeterResult.getPtdfZonalSum(cnec1), DOUBLE_TOLERANCE);
         perimeterResult = output.getPerimeterResult(AFTER_ARA, curativeState1);
         assertEquals(3., perimeterResult.getPtdfZonalSum(cnec1), DOUBLE_TOLERANCE);
-        perimeterResult = output.getPerimeterResult(AFTER_ARA, curativeState2);
-        assertEquals(5., perimeterResult.getPtdfZonalSum(cnec1), DOUBLE_TOLERANCE);
+        assertNull(output.getPerimeterResult(AFTER_ARA, curativeState2));
 
         // AFTER_CRA
         assertThrows(FaraoException.class, () -> output.getPerimeterResult(AFTER_CRA, preventiveState));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When there is no automaton simulation after a given contingency, the exported RaoResult exports "AFTER-ARA" tagged results, containing the same results as "AFTER_CRA"


**What is the new behavior (if this is a feature change)?**
Now in this case, no result is given for the AUTO state
