### PR TITLE
create missing generators and loads for manual glsks 

### DIFF
--- a/data/glsk/glsk-quality-check-ucte/src/main/java/com/farao_community/farao/data/glsk/ucte/quality_check/GlskQualityCheck.java
+++ b/data/glsk/glsk-quality-check-ucte/src/main/java/com/farao_community/farao/data/glsk/ucte/quality_check/GlskQualityCheck.java
@@ -9,10 +9,11 @@ package com.farao_community.farao.data.glsk.ucte.quality_check;
 import com.farao_community.farao.data.glsk.api.AbstractGlskPoint;
 import com.farao_community.farao.data.glsk.api.AbstractGlskRegisteredResource;
 import com.farao_community.farao.data.glsk.ucte.UcteGlskPoint;
-import com.powsybl.iidm.network.Injection;
-import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.*;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * @author Marc Erkol {@literal <marc.erkol at rte-france.com>}
@@ -36,6 +37,24 @@ class GlskQualityCheck {
     }
 
     private void checkGlskPoint(AbstractGlskPoint glskPoint, Network network, String tso) {
+        List<String> manualGskGenerators =  glskPoint.getGlskShiftKeys().stream()
+                .filter(gskShiftKey -> gskShiftKey.getPsrType().equals(GENERATOR) && gskShiftKey.getBusinessType().equals("B43"))
+                .flatMap(gskShiftKey -> gskShiftKey.getRegisteredResourceArrayList().stream())
+                .map(AbstractGlskRegisteredResource::getGeneratorId).collect(Collectors.toList());
+        List<String> manualGskLoads =  glskPoint.getGlskShiftKeys().stream()
+                .filter(gskShiftKey -> gskShiftKey.getPsrType().equals(LOAD) && gskShiftKey.getBusinessType().equals("B43"))
+                .flatMap(gskShiftKey -> gskShiftKey.getRegisteredResourceArrayList().stream())
+                .map(AbstractGlskRegisteredResource::getLoadId).collect(Collectors.toList());
+
+        network.getVoltageLevelStream().forEach(voltageLevel -> voltageLevel.getBusBreakerView().getBuses().forEach(bus -> {
+            if (manualGskGenerators.contains(bus.getId() + "_generator")) {
+                createMissingGenerator(network, voltageLevel, bus.getId());
+            }
+            if (manualGskLoads.contains(bus.getId() + "_load")) {
+                createMissingLoad(network, voltageLevel, bus.getId());
+            }
+        }));
+
         glskPoint.getGlskShiftKeys().forEach(glskShiftKey -> {
             if (glskShiftKey.getPsrType().equals(GENERATOR)) {
                 glskShiftKey.getRegisteredResourceArrayList()
@@ -45,6 +64,39 @@ class GlskQualityCheck {
                         .forEach(resource -> checkResource(resource, network.getLoad(resource.getLoadId()), "Load", network, tso));
             }
         });
+    }
+
+    private void createMissingGenerator(Network network, VoltageLevel voltageLevel, String busId) {
+        String generatorId = busId + "_generator";
+        if (network.getGenerator(generatorId) == null) {
+            voltageLevel.newGenerator()
+                    .setBus(busId)
+                    .setEnsureIdUnicity(true)
+                    .setId(generatorId)
+                    .setMaxP(9999)
+                    .setMinP(0)
+                    .setTargetP(0)
+                    .setTargetQ(0)
+                    .setTargetV(voltageLevel.getNominalV())
+                    .setVoltageRegulatorOn(false)
+                    .setFictitious(true)
+                    .add()
+                    .newMinMaxReactiveLimits().setMaxQ(99999).setMinQ(99999).add();
+        }
+    }
+
+    private void createMissingLoad(Network network, VoltageLevel voltageLevel, String busId) {
+        String loadId = busId + "_load";
+        if (network.getLoad(loadId) == null) {
+            voltageLevel.newLoad()
+                    .setBus(busId)
+                    .setEnsureIdUnicity(true)
+                    .setId(loadId)
+                    .setP0(0)
+                    .setQ0(0)
+                    .setLoadType(LoadType.FICTITIOUS)
+                    .add();
+        }
     }
 
     private void checkResource(AbstractGlskRegisteredResource registeredResource, Injection<?> injection, String type, Network network, String tso) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
Problem related to core merging


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bugfix


**What is the current behavior?** *(You can also link to an open issue here)*
In the current behaviour we delete from glsk file any block that concerns a load or generator with no power in the network. 
We shouldn't delete them if we have a manual Glsk type, in order to be able to shift on them


**What is the new behavior (if this is a feature change)?**

We don't delete from Glsk file Manual Glsks block if they are present in the network and with no power (0 gen/load)

**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*

No

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
