### PR TITLE
Bugfix infinitely iterating linear rao

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/RangeActionFilter.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/RangeActionFilter.java
@@ -267,6 +267,6 @@ class RangeActionFilter {
     }
 
     boolean isRangeActionUsed(RangeAction rangeAction, Leaf leaf) {
-        return leaf.getRangeActions().contains(rangeAction) && Math.abs(leaf.getOptimizedSetPoint(rangeAction) - prePerimeterSetPoints.get(rangeAction)) >= 0.000001;
+        return leaf.getRangeActions().contains(rangeAction) && Math.abs(leaf.getOptimizedSetPoint(rangeAction) - prePerimeterSetPoints.get(rangeAction)) >= 1e-6;
     }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/RangeActionFilter.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/RangeActionFilter.java
@@ -267,6 +267,6 @@ class RangeActionFilter {
     }
 
     boolean isRangeActionUsed(RangeAction rangeAction, Leaf leaf) {
-        return leaf.getRangeActions().contains(rangeAction) && leaf.getOptimizedSetPoint(rangeAction) != prePerimeterSetPoints.get(rangeAction);
+        return leaf.getRangeActions().contains(rangeAction) && Math.abs(leaf.getOptimizedSetPoint(rangeAction) - prePerimeterSetPoints.get(rangeAction)) >= 0.000001;
     }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTree.java
@@ -257,7 +257,7 @@ public class SearchTree {
         Set<RangeAction> previousIterationRangeActions = null;
         Set<RangeAction> rangeActions = applyRangeActionsFilters(leaf, availableRangeActions, false);
         // Iterate on optimizer until the list of range actions stops changing
-        while (!rangeActions.equals(previousIterationRangeActions)) {
+        while (!rangeActions.equals(previousIterationRangeActions) && Math.abs(previousCost - leaf.getCost()) >= 0.000006 && iteration < 10) {
             iteration++;
             if (iteration > 1) {
                 LOGGER.info("{}", leaf);

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTree.java
@@ -257,7 +257,7 @@ public class SearchTree {
         Set<RangeAction> previousIterationRangeActions = null;
         Set<RangeAction> rangeActions = applyRangeActionsFilters(leaf, availableRangeActions, false);
         // Iterate on optimizer until the list of range actions stops changing
-        while (!rangeActions.equals(previousIterationRangeActions) && Math.abs(previousCost - leaf.getCost()) >= 0.000001 && iteration < 10) {
+        while (!rangeActions.equals(previousIterationRangeActions) && Math.abs(previousCost - leaf.getCost()) >= 1e-6 && iteration < 10) {
             previousCost = leaf.getCost();
             iteration++;
             if (iteration > 1) {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTree.java
@@ -257,7 +257,8 @@ public class SearchTree {
         Set<RangeAction> previousIterationRangeActions = null;
         Set<RangeAction> rangeActions = applyRangeActionsFilters(leaf, availableRangeActions, false);
         // Iterate on optimizer until the list of range actions stops changing
-        while (!rangeActions.equals(previousIterationRangeActions) && Math.abs(previousCost - leaf.getCost()) >= 0.000006 && iteration < 10) {
+        while (!rangeActions.equals(previousIterationRangeActions) && Math.abs(previousCost - leaf.getCost()) >= 0.000001 && iteration < 10) {
+            previousCost = leaf.getCost();
             iteration++;
             if (iteration > 1) {
                 LOGGER.info("{}", leaf);
@@ -284,7 +285,6 @@ public class SearchTree {
             } else {
                 LOGGER.info("No range actions to optimize");
             }
-            previousCost = leaf.getCost();
             previousIterationRangeActions = rangeActions;
             rangeActions = applyRangeActionsFilters(leaf, availableRangeActions, true);
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
If we have 3 psts, the first being moved during linear optim, the others not, and max pst at 2, then we iterate on the iterating linear rao with psts (1 & 2) and (1 & 3) indefinitely.


**What is the new behavior (if this is a feature change)?**
We now check if we manage to get a better cost before iterating again. We also have a failsafe "just in case".


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No.
