### PR TITLE
Fix min and max values for remaining capacities scalable

### DIFF
--- a/data/glsk/glsk-document-api/src/main/java/com/farao_community/farao/data/glsk/api/util/converters/GlskPointLinearGlskConverter.java
+++ b/data/glsk/glsk-document-api/src/main/java/com/farao_community/farao/data/glsk/api/util/converters/GlskPointLinearGlskConverter.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * Convert a single GlskPoint to LinearGlsk
@@ -92,20 +91,14 @@ public final class GlskPointLinearGlskConverter {
         //Generator A04 or Load A05
         if (glskShiftKey.getPsrType().equals("A04")) {
             //Generator A04
-            List<Generator> generators = network.getGeneratorStream()
-                    .filter(generator -> country.equals(generator.getTerminal().getVoltageLevel().getSubstation().getNullableCountry()))
-                    .filter(NetworkUtil::isCorrectGenerator)
-                    .collect(Collectors.toList());
+            List<Generator> generators = NetworkUtil.getCountryGenerators(country, network);
             //calculate sum P of country's generators
             double totalCountryP = generators.stream().mapToDouble(NetworkUtil::pseudoTargetP).sum();
             //calculate factor of each generator
             generators.forEach(generator -> linearGlskMap.put(generator.getId(), glskShiftKey.getQuantity().floatValue() * (float) NetworkUtil.pseudoTargetP(generator) / (float) totalCountryP));
         } else if (glskShiftKey.getPsrType().equals("A05")) {
             //Load A05
-            List<Load> loads = network.getLoadStream()
-                    .filter(load -> country.equals(load.getTerminal().getVoltageLevel().getSubstation().getNullableCountry()))
-                    .filter(NetworkUtil::isCorrectLoad)
-                    .collect(Collectors.toList());
+            List<Load> loads = NetworkUtil.getCountryLoads(country, network);
             double totalCountryLoad = loads.stream().mapToDouble(NetworkUtil::pseudoP0).sum();
             loads.forEach(load -> linearGlskMap.put(load.getId(), glskShiftKey.getQuantity().floatValue() * (float) NetworkUtil.pseudoP0(load) / (float) totalCountryLoad));
         } else {
@@ -123,22 +116,12 @@ public final class GlskPointLinearGlskConverter {
         //Generator A04 or Load A05
         if (glskShiftKey.getPsrType().equals("A04")) {
             //Generator A04
-            List<Generator> generators = glskShiftKey.getRegisteredResourceArrayList().stream()
-                    .map(AbstractGlskRegisteredResource::getGeneratorId)
-                    .filter(generatorId -> network.getGenerator(generatorId) != null)
-                    .map(network::getGenerator)
-                    .filter(NetworkUtil::isCorrectGenerator)
-                    .collect(Collectors.toList());
+            List<Generator> generators = NetworkUtil.getAvailableGenerators(glskShiftKey.getRegisteredResourceArrayList(), network);
             double totalP = generators.stream().mapToDouble(NetworkUtil::pseudoTargetP).sum();
             generators.forEach(generator -> linearGlskMap.put(generator.getId(), glskShiftKey.getQuantity().floatValue() * (float) NetworkUtil.pseudoTargetP(generator) / (float) totalP));
         } else if (glskShiftKey.getPsrType().equals("A05")) {
             //Load A05
-            List<Load> loads = glskShiftKey.getRegisteredResourceArrayList().stream()
-                    .map(AbstractGlskRegisteredResource::getLoadId)
-                    .filter(loadId -> network.getLoad(loadId) != null)
-                    .map(network::getLoad)
-                    .filter(NetworkUtil::isCorrectLoad)
-                    .collect(Collectors.toList());
+            List<Load> loads = NetworkUtil.getAvailableLoads(glskShiftKey.getRegisteredResourceArrayList(), network);
             double totalLoad = loads.stream().mapToDouble(NetworkUtil::pseudoP0).sum();
             loads.forEach(load -> linearGlskMap.put(load.getId(), glskShiftKey.getQuantity().floatValue() * (float) NetworkUtil.pseudoP0(load) / (float) totalLoad));
         } else {
@@ -156,19 +139,15 @@ public final class GlskPointLinearGlskConverter {
         //Generator A04 or Load A05
         if (glskShiftKey.getPsrType().equals("A04")) {
             //Generator A04
-            List<AbstractGlskRegisteredResource> generatorResources = glskShiftKey.getRegisteredResourceArrayList().stream()
-                    .filter(generatorResource -> network.getGenerator(generatorResource.getGeneratorId()) != null)
-                    .filter(generatorResource -> NetworkUtil.isCorrectGenerator(network.getGenerator(generatorResource.getGeneratorId())))
-                    .collect(Collectors.toList());
+            List<AbstractGlskRegisteredResource> generatorResources =
+                    NetworkUtil.getAvailableGeneratorsAsResources(glskShiftKey.getRegisteredResourceArrayList(), network);
             double totalFactor = generatorResources.stream().mapToDouble(AbstractGlskRegisteredResource::getParticipationFactor).sum();
 
             generatorResources.forEach(generatorResource -> linearGlskMap.put(generatorResource.getGeneratorId(), glskShiftKey.getQuantity().floatValue() * (float) generatorResource.getParticipationFactor() / (float) totalFactor));
         } else if (glskShiftKey.getPsrType().equals("A05")) {
             //Load A05
-            List<AbstractGlskRegisteredResource> loadResources = glskShiftKey.getRegisteredResourceArrayList().stream()
-                    .filter(loadResource -> network.getLoad(loadResource.getLoadId()) != null)
-                    .filter(loadResource -> NetworkUtil.isCorrectLoad(network.getLoad(loadResource.getLoadId())))
-                    .collect(Collectors.toList());
+            List<AbstractGlskRegisteredResource> loadResources =
+                    NetworkUtil.getAvailableLoadsAsResources(glskShiftKey.getRegisteredResourceArrayList(), network);
             double totalFactor = loadResources.stream().mapToDouble(AbstractGlskRegisteredResource::getParticipationFactor).sum();
 
             loadResources.forEach(loadResource -> linearGlskMap.put(loadResource.getLoadId(), glskShiftKey.getQuantity().floatValue() * (float) loadResource.getParticipationFactor() / (float) totalFactor));

--- a/data/glsk/glsk-document-api/src/main/java/com/farao_community/farao/data/glsk/api/util/converters/NetworkUtil.java
+++ b/data/glsk/glsk-document-api/src/main/java/com/farao_community/farao/data/glsk/api/util/converters/NetworkUtil.java
@@ -65,6 +65,10 @@ public final class NetworkUtil {
         return network.getGeneratorStream()
                 .filter(generator -> country.equals(generator.getTerminal().getVoltageLevel().getSubstation().getNullableCountry()))
                 .filter(NetworkUtil::isCorrectGenerator)
+                .filter(generator -> {
+                    double targetP = generator.getTargetP();
+                    return targetP >= generator.getMinP() && targetP <= generator.getMaxP();
+                })
                 .collect(Collectors.toList());
     }
 

--- a/data/glsk/glsk-document-cse/src/test/java/com/farao_community/farao/data/glsk/cse/CseGlskDocumentImporterTest.java
+++ b/data/glsk/glsk-document-cse/src/test/java/com/farao_community/farao/data/glsk/cse/CseGlskDocumentImporterTest.java
@@ -66,12 +66,28 @@ public class CseGlskDocumentImporterTest {
         Scalable reserveScalable = glskDocument.getZonalScalable(network).getData("FR_RESERVE");
 
         assertNotNull(reserveScalable);
-        assertEquals(2000., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
-        assertEquals(2000., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
 
-        reserveScalable.scale(network, -900.);
-        assertEquals(1400., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
-        assertEquals(1700., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(-900, reserveScalable.scale(network, -900), EPSILON);
+        assertEquals(1400, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(1700, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+    }
+
+    @Test
+    public void checkCseGlskDocumentImporterCorrectlyConvertReserveGskBlocksDownWithReachingLimits() {
+        Network network = Importers.loadNetwork("testCase.xiidm", getClass().getResourceAsStream("/testCase.xiidm"));
+        GlskDocument glskDocument = GlskDocumentImporters.importGlsk(getClass().getResourceAsStream("/testGlsk.xml"));
+        Scalable reserveScalable = glskDocument.getZonalScalable(network).getData("FR_RESERVE");
+
+        assertNotNull(reserveScalable);
+        assertEquals(2000, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+
+        // 1000 MW missing for down-scaling
+        assertEquals(-3000, reserveScalable.scale(network, -4000), EPSILON);
+        assertEquals(0, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(1000, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
     }
 
     @Test
@@ -81,12 +97,28 @@ public class CseGlskDocumentImporterTest {
         Scalable reserveScalable = glskDocument.getZonalScalable(network).getData("FR_RESERVE");
 
         assertNotNull(reserveScalable);
-        assertEquals(2000., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
-        assertEquals(2000., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
 
-        reserveScalable.scale(network, 1000.);
-        assertEquals(2600., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
-        assertEquals(2400., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(1000, reserveScalable.scale(network, 1000), EPSILON);
+        assertEquals(2600, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2400, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+    }
+
+    @Test
+    public void checkCseGlskDocumentImporterCorrectlyConvertReserveGskBlocksUpWithReachingLimits() {
+        Network network = Importers.loadNetwork("testCase.xiidm", getClass().getResourceAsStream("/testCase.xiidm"));
+        GlskDocument glskDocument = GlskDocumentImporters.importGlsk(getClass().getResourceAsStream("/testGlsk.xml"));
+        Scalable reserveScalable = glskDocument.getZonalScalable(network).getData("FR_RESERVE");
+
+        assertNotNull(reserveScalable);
+        assertEquals(2000, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+
+        // 1000 MW missing for up-scaling
+        assertEquals(5000, reserveScalable.scale(network, 6000), EPSILON);
+        assertEquals(5000, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(4000, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
     }
 
     @Test


### PR DESCRIPTION
- Proper filters for generators and loads -- excludes target P out of range and missing or disconnected resources
- Rationalize generator scalable creation to adapt min/max values

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix and refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
In GLSK CSE format it exists a Resrve block tag that acts as a proportional scalable according to remaining capacities (up or down). These blocks have min and max values but it is not taken into account for limiting the scaling on generators.


**What is the new behavior (if this is a feature change)?**
This development aims at taking these min/max values into account to limit scaling.

By making some common methods for GlskToLinearGlskConverter and GlskToScalableConverter for generator and load selections I harmonized the behavior but so it has some addtionnal features now : 
- we filter out generators and loads that we could not find in the network
- we filter out generators and loads that are not connected or that are not in the main synchronous component of the netwwork
- we filter out generators that have a target P that are outside the defined min and max values for P (defined in the network or overloaded by the GLSK)


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No
