### PR TITLE
BusIdMatchPolicy: replace the 8th character by a wildcard

### DIFF
--- a/data/crac/crac-creation-util/src/main/java/com/farao_community/farao/data/crac_creation_util/ucte/UcteNetworkAnalyzer.java
+++ b/data/crac/crac-creation-util/src/main/java/com/farao_community/farao/data/crac_creation_util/ucte/UcteNetworkAnalyzer.java
@@ -11,6 +11,7 @@ import com.powsybl.iidm.network.*;
 
 import static com.farao_community.farao.data.crac_creation_util.ConnectableType.*;
 import static com.farao_community.farao.data.crac_creation_util.ucte.UcteNetworkAnalyzerProperties.BusIdMatchPolicy.COMPLETE_WITH_WILDCARDS;
+import static com.farao_community.farao.data.crac_creation_util.ucte.UcteNetworkAnalyzerProperties.BusIdMatchPolicy.REPLACE_8TH_CHARACTER_WITH_WILDCARD;
 
 /**
  * A utility class, that stores network information so as to speed up
@@ -67,7 +68,7 @@ public class UcteNetworkAnalyzer {
     private String completeNodeName(String nodeName) {
         if (nodeName.length() == UcteUtils.UCTE_NODE_LENGTH) {
             return nodeName;
-        } else if (properties.getBusIdMatchPolicy().equals(COMPLETE_WITH_WILDCARDS)) {
+        } else if (properties.getBusIdMatchPolicy().equals(COMPLETE_WITH_WILDCARDS) || properties.getBusIdMatchPolicy().equals(REPLACE_8TH_CHARACTER_WITH_WILDCARD)) {
             return String.format("%1$-7s", nodeName) + UcteUtils.WILDCARD_CHARACTER;
         } else {
             return String.format("%1$-8s", nodeName);

--- a/data/crac/crac-creation-util/src/main/java/com/farao_community/farao/data/crac_creation_util/ucte/UcteNetworkAnalyzerProperties.java
+++ b/data/crac/crac-creation-util/src/main/java/com/farao_community/farao/data/crac_creation_util/ucte/UcteNetworkAnalyzerProperties.java
@@ -17,7 +17,8 @@ public class UcteNetworkAnalyzerProperties {
     // For Bus IDs with 7 characters, either complete them with white spaces or wildcards
     public enum BusIdMatchPolicy {
         COMPLETE_WITH_WHITESPACES,
-        COMPLETE_WITH_WILDCARDS
+        COMPLETE_WITH_WILDCARDS,
+        REPLACE_8TH_CHARACTER_WITH_WILDCARD
     }
 
     private BusIdMatchPolicy busIdMatchPolicy;

--- a/data/crac/crac-creation-util/src/test/java/com/farao_community/farao/data/crac_creation_util/ucte/UcteBusHelperTest.java
+++ b/data/crac/crac-creation-util/src/test/java/com/farao_community/farao/data/crac_creation_util/ucte/UcteBusHelperTest.java
@@ -11,8 +11,7 @@ import com.powsybl.iidm.import_.Importers;
 import com.powsybl.iidm.network.Network;
 import org.junit.Test;
 
-import static com.farao_community.farao.data.crac_creation_util.ucte.UcteNetworkAnalyzerProperties.BusIdMatchPolicy.COMPLETE_WITH_WHITESPACES;
-import static com.farao_community.farao.data.crac_creation_util.ucte.UcteNetworkAnalyzerProperties.BusIdMatchPolicy.COMPLETE_WITH_WILDCARDS;
+import static com.farao_community.farao.data.crac_creation_util.ucte.UcteNetworkAnalyzerProperties.BusIdMatchPolicy.*;
 import static org.junit.Assert.*;
 
 /**
@@ -25,6 +24,7 @@ public class UcteBusHelperTest {
         Network network = Importers.loadNetwork("TestCase_severalVoltageLevels_Xnodes_8characters.uct", getClass().getResourceAsStream("/TestCase_severalVoltageLevels_Xnodes_8characters.uct"));
         UcteNetworkAnalyzer ucteNetworkAnalyzerWhiteSpaces = new UcteNetworkAnalyzer(network, new UcteNetworkAnalyzerProperties(COMPLETE_WITH_WHITESPACES));
         UcteNetworkAnalyzer ucteNetworkAnalyzerWildCards = new UcteNetworkAnalyzer(network, new UcteNetworkAnalyzerProperties(COMPLETE_WITH_WILDCARDS));
+        UcteNetworkAnalyzer ucteNetworkAnalyzerReplaceLast = new UcteNetworkAnalyzer(network, new UcteNetworkAnalyzerProperties(REPLACE_8TH_CHARACTER_WITH_WILDCARD));
 
         UcteBusHelper busHelper = new UcteBusHelper("DDE2AA1*", ucteNetworkAnalyzerWhiteSpaces);
         assertTrue(busHelper.isValid());
@@ -34,6 +34,11 @@ public class UcteBusHelperTest {
         busHelper = new UcteBusHelper("DDE2AA1", ucteNetworkAnalyzerWildCards);
         assertTrue(busHelper.isValid());
         assertEquals("DDE2AA11", busHelper.getIdInNetwork());
+        assertNull(busHelper.getInvalidReason());
+
+        busHelper = new UcteBusHelper("DDE3AA18", ucteNetworkAnalyzerReplaceLast);
+        assertTrue(busHelper.isValid());
+        assertEquals("DDE3AA11", busHelper.getIdInNetwork());
         assertNull(busHelper.getInvalidReason());
 
         busHelper = new UcteBusHelper("DDE2AA1", ucteNetworkAnalyzerWhiteSpaces);


### PR DESCRIPTION
Add a new BusIdMatchPolicy: replace the 8th character by a wildcard if the bus is not found

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

When a bus is not found because of the 8th character, which differs between the CBCoRA file and the network, this character should sometimes be replaced by a wildcard.
