### PR TITLE
Better cost handling in RaoResult

### DIFF
--- a/loopflow-computation/src/main/java/com/farao_community/farao/loopflow_computation/LoopFlowResult.java
+++ b/loopflow-computation/src/main/java/com/farao_community/farao/loopflow_computation/LoopFlowResult.java
@@ -17,7 +17,7 @@ import java.util.Map;
  */
 public class LoopFlowResult {
 
-    private Map<Cnec<?>, LoopFlow> loopFlowmap;
+    private Map<Cnec<?>, LoopFlow> loopFlowMap;
 
     private class LoopFlow {
         double loopFlowValue;
@@ -44,15 +44,15 @@ public class LoopFlowResult {
     }
 
     public LoopFlowResult() {
-        this.loopFlowmap = new HashMap<>();
+        this.loopFlowMap = new HashMap<>();
     }
 
     public void addCnecResult(Cnec<?> cnec, double loopFlowValue, double commercialFlowValue, double referenceFlowValue) {
-        loopFlowmap.put(cnec, new LoopFlow(loopFlowValue, commercialFlowValue, referenceFlowValue));
+        loopFlowMap.put(cnec, new LoopFlow(loopFlowValue, commercialFlowValue, referenceFlowValue));
     }
 
     public double getLoopFlow(Cnec<?> cnec) {
-        LoopFlow loopFlow = loopFlowmap.get(cnec);
+        LoopFlow loopFlow = loopFlowMap.get(cnec);
         if (loopFlow == null) {
             throw new FaraoException(String.format("No loop-flow value found for cnec %s", cnec.getId()));
         }
@@ -60,7 +60,7 @@ public class LoopFlowResult {
     }
 
     public double getCommercialFlow(Cnec<?> cnec) {
-        LoopFlow loopFlow = loopFlowmap.get(cnec);
+        LoopFlow loopFlow = loopFlowMap.get(cnec);
         if (loopFlow == null) {
             throw new FaraoException(String.format("No commercial flow value found for cnec %s", cnec.getId()));
         }
@@ -68,7 +68,7 @@ public class LoopFlowResult {
     }
 
     public double getReferenceFlow(Cnec<?> cnec) {
-        LoopFlow loopFlow = loopFlowmap.get(cnec);
+        LoopFlow loopFlow = loopFlowMap.get(cnec);
         if (loopFlow == null) {
             throw new FaraoException(String.format("No reference flow value found for cnec %s", cnec.getId()));
         }
@@ -76,6 +76,6 @@ public class LoopFlowResult {
     }
 
     public boolean containValues(Cnec<?> cnec) {
-        return loopFlowmap.get(cnec) != null;
+        return loopFlowMap.get(cnec) != null;
     }
 }

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/PrePerimeterSensitivityAnalysis.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/PrePerimeterSensitivityAnalysis.java
@@ -17,6 +17,7 @@ import com.farao_community.farao.rao_commons.result.RangeActionResultImpl;
 import com.farao_community.farao.rao_commons.result_api.FlowResult;
 import com.farao_community.farao.rao_commons.result_api.ObjectiveFunctionResult;
 import com.farao_community.farao.rao_commons.result_api.PrePerimeterResult;
+import com.farao_community.farao.rao_commons.result_api.SensitivityResult;
 import com.farao_community.farao.sensitivity_analysis.AppliedRemedialActions;
 import com.powsybl.iidm.network.Network;
 
@@ -103,17 +104,19 @@ public class PrePerimeterSensitivityAnalysis {
 
     private PrePerimeterResult runAndGetResult(Network network, ObjectiveFunction objectiveFunction) {
         sensitivityComputer.compute(network);
-        ObjectiveFunctionResult objectiveFunctionResult = getResult(objectiveFunction);
+        FlowResult flowResult = sensitivityComputer.getBranchResult();
+        SensitivityResult sensitivityResult = sensitivityComputer.getSensitivityResult();
+        ObjectiveFunctionResult objectiveFunctionResult = getResult(objectiveFunction, flowResult, sensitivityResult);
         return new PrePerimeterSensitivityOutput(
-                sensitivityComputer.getBranchResult(),
-                sensitivityComputer.getSensitivityResult(),
+                flowResult,
+                sensitivityResult,
                 new RangeActionResultImpl(network, rangeActions),
                 objectiveFunctionResult
         );
     }
 
-    private ObjectiveFunctionResult getResult(ObjectiveFunction objectiveFunction) {
-        return objectiveFunction.evaluate(sensitivityComputer.getBranchResult(), sensitivityComputer.getSensitivityResult().getSensitivityStatus());
+    private ObjectiveFunctionResult getResult(ObjectiveFunction objectiveFunction, FlowResult flowResult, SensitivityResult sensitivityResult) {
+        return objectiveFunction.evaluate(flowResult, sensitivityResult.getSensitivityStatus());
     }
 
     private ObjectiveFunction getInitialMinMarginObjectiveFunction() {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/output/PreventiveAndCurativesRaoOutput.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/output/PreventiveAndCurativesRaoOutput.java
@@ -110,16 +110,19 @@ public class PreventiveAndCurativesRaoOutput implements SearchTreeRaoResult {
         if (optimizationState == OptimizationState.INITIAL) {
             return initialResult.getFunctionalCost();
         }
-        if (optimizationState == OptimizationState.AFTER_PRA) {
-            return postPreventiveResult.getFunctionalCost();
-        }
+        return getHighestFunctionalCostUntilInstant(optimizationState.getFirstInstant());
+    }
+
+    private double getHighestFunctionalCostUntilInstant(Instant instant) {
         double highestFunctionalCost = postPreventiveResult.getFunctionalCost();
         highestFunctionalCost = Math.max(
-                highestFunctionalCost,
-                postContingencyResults.values().stream()
-                        .map(PerimeterResult::getFunctionalCost)
-                        .max(Double::compareTo)
-                        .orElseThrow(() -> new FaraoException("Should not happen"))
+            highestFunctionalCost,
+            postContingencyResults.entrySet().stream()
+                .filter(entry -> entry.getKey().getInstant().comesBefore(instant) || entry.getKey().getInstant().equals(instant))
+                .map(Map.Entry::getValue)
+                .map(PerimeterResult::getFunctionalCost)
+                .max(Double::compareTo)
+                .orElse(-Double.MAX_VALUE)
         );
         return highestFunctionalCost;
     }

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/output/PreventiveAndCurativesRaoOutputTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/output/PreventiveAndCurativesRaoOutputTest.java
@@ -238,11 +238,13 @@ public class PreventiveAndCurativesRaoOutputTest {
     @Test
     public void testGetFunctionalCost() {
         assertEquals(1000., output.getFunctionalCost(INITIAL), DOUBLE_TOLERANCE);
-        assertEquals(-1020., output.getFunctionalCost(AFTER_PRA), DOUBLE_TOLERANCE);
+        assertEquals(-1050., output.getFunctionalCost(AFTER_PRA), DOUBLE_TOLERANCE);
+        assertEquals(-1020., output.getFunctionalCost(AFTER_ARA), DOUBLE_TOLERANCE);
         assertEquals(-1020., output.getFunctionalCost(AFTER_CRA), DOUBLE_TOLERANCE);
 
         when(postPrevResult.getFunctionalCost()).thenReturn(-2020.);
-        assertEquals(-1025., output.getFunctionalCost(AFTER_CRA), DOUBLE_TOLERANCE);
+        assertEquals(-1025., output.getFunctionalCost(AFTER_ARA), DOUBLE_TOLERANCE);
+        assertEquals(-1030., output.getFunctionalCost(AFTER_CRA), DOUBLE_TOLERANCE);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix

**What is the current behavior?** *(You can also link to an open issue here)*
- 1 - When no AUTO perimeter is optimized, the returned FunctionalCost in the RAO output is the after CRA cost
- 2 - AFTER_PRA cost result does not take into account post-outage CNECs
- 3 - LoopFlow computation is slowed by "main component" filter

**What is the new behavior (if this is a feature change)?**
- 1 - The cost returned is the after PRA cost
- 2 - AFTER_PRA cost takes into account post-outage CNECs
- 3 - LoopFlow computation has been optimized


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
