### PR TITLE
replaced comparator lambda by stocking some values in a map

### DIFF
--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/objective_function_evaluator/MinMarginEvaluator.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/objective_function_evaluator/MinMarginEvaluator.java
@@ -42,10 +42,14 @@ public class MinMarginEvaluator implements CostEvaluator {
 
     @Override
     public List<FlowCnec> getCostlyElements(FlowResult flowResult, int numberOfElements) {
+        Map<FlowCnec, Double> margins = new HashMap<>();
+        flowCnecs.stream().filter(Cnec::isOptimized).forEach(flowCnec -> {
+            margins.put(flowCnec, marginEvaluator.getMargin(flowResult, flowCnec, unit));
+        });
         List<FlowCnec> sortedElements = flowCnecs.stream()
-                .filter(Cnec::isOptimized)
-                .sorted(Comparator.comparing(flowCnec -> marginEvaluator.getMargin(flowResult, flowCnec, unit)))
-                .collect(Collectors.toList());
+            .filter(Cnec::isOptimized)
+            .sorted(Comparator.comparing(margins::get))
+            .collect(Collectors.toList());
 
         return sortedElements.subList(0, Math.min(sortedElements.size(), numberOfElements));
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Perf increase


**What is the current behavior?** *(You can also link to an open issue here)*
When computing most limiting elements, the comparator used by the stream.sorted() method has to recompute the margin for every comparison done.


**What is the new behavior (if this is a feature change)?**
We now store the margin for each flowCnec in a map, and use that map in the comparator.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
