### PR TITLE
Attempt to render MIP results completely reproducible 

### DIFF
--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/FaraoMPConstraint.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/FaraoMPConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/FaraoMPConstraint.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/FaraoMPConstraint.java
@@ -14,7 +14,7 @@ import com.google.ortools.linearsolver.MPVariable;
  * @author Philippe Edwards {@literal <philippe.edwards at rte-international.com>}
  */
 public class FaraoMPConstraint extends MPConstraint {
-    double precision;
+    private final double precision;
 
     protected FaraoMPConstraint(long cPtr, boolean cMemoryOwn, double precision) {
         super(cPtr, cMemoryOwn);

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/FaraoMPConstraint.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/FaraoMPConstraint.java
@@ -22,8 +22,8 @@ public class FaraoMPConstraint extends MPConstraint {
     }
 
     @Override
-    public void setCoefficient(MPVariable var, double coeff) {
-        super.setCoefficient(var, Math.round(coeff * precision) / precision);
+    public void setCoefficient(MPVariable variable, double coeff) {
+        super.setCoefficient(variable, Math.round(coeff * precision) / precision);
     }
 
     @Override

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/FaraoMPConstraint.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/FaraoMPConstraint.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.farao_community.farao.rao_commons.linear_optimisation;
+
+import com.google.ortools.linearsolver.MPConstraint;
+import com.google.ortools.linearsolver.MPVariable;
+
+/**
+ * @author Philippe Edwards {@literal <philippe.edwards at rte-international.com>}
+ */
+public class FaraoMPConstraint extends MPConstraint {
+    double precision;
+
+    protected FaraoMPConstraint(long cPtr, boolean cMemoryOwn, double precision) {
+        super(cPtr, cMemoryOwn);
+        this.precision = precision;
+    }
+
+    @Override
+    public void setCoefficient(MPVariable var, double coeff) {
+        super.setCoefficient(var, Math.round(coeff * precision) / precision);
+    }
+
+    @Override
+    public void setLb(double lb) {
+        super.setLb(Math.round(lb * precision) / precision);
+    }
+
+    @Override
+    public void setUb(double ub) {
+        super.setUb(Math.round(ub * precision) / precision);
+    }
+
+    @Override
+    public void setBounds(double lb, double ub) {
+        super.setBounds(Math.round(lb * precision) / precision, Math.round(ub * precision) / precision);
+    }
+}

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/FaraoMPSolver.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/FaraoMPSolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/FaraoMPSolver.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/FaraoMPSolver.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.farao_community.farao.rao_commons.linear_optimisation;
+
+import com.google.ortools.linearsolver.MPConstraint;
+import com.google.ortools.linearsolver.MPSolver;
+import com.google.ortools.linearsolver.MPVariable;
+import com.google.ortools.linearsolver.mainJNI;
+
+/**
+ * @author Philippe Edwards {@literal <philippe.edwards at rte-international.com>}
+ */
+public class FaraoMPSolver extends MPSolver {
+
+    private static final double PRECISION = 1048576; //2^20
+
+    public FaraoMPSolver(String name, OptimizationProblemType problemType) {
+        super(name, problemType);
+    }
+
+    @Override
+    public MPVariable makeNumVar(double lb, double ub, String name) {
+        long cPtr = mainJNI.MPSolver_makeNumVar(getCPtr(this), this, lb, ub, name);
+        return cPtr == 0L ? null : new FaraoMPVariable(cPtr, false, PRECISION);
+    }
+
+    @Override
+    public MPVariable makeIntVar(double lb, double ub, String name) {
+        long cPtr = mainJNI.MPSolver_makeIntVar(getCPtr(this), this, lb, ub, name);
+        return cPtr == 0L ? null : new FaraoMPVariable(cPtr, false, PRECISION);
+    }
+
+    @Override
+    public MPConstraint makeConstraint(double lb, double ub, String name) {
+        long cPtr = mainJNI.MPSolver_makeConstraint__SWIG_2(getCPtr(this), this, lb, ub, name);
+        return cPtr == 0L ? null : new FaraoMPConstraint(cPtr, false, PRECISION);
+    }
+}

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/FaraoMPVariable.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/FaraoMPVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/FaraoMPVariable.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/FaraoMPVariable.java
@@ -13,7 +13,7 @@ import com.google.ortools.linearsolver.MPVariable;
  * @author Philippe Edwards {@literal <philippe.edwards at rte-international.com>}
  */
 public class FaraoMPVariable extends MPVariable {
-    double precision;
+    private final double precision;
 
     protected FaraoMPVariable(long cPtr, boolean cMemoryOwn, double precision) {
         super(cPtr, cMemoryOwn);

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/FaraoMPVariable.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/FaraoMPVariable.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.farao_community.farao.rao_commons.linear_optimisation;
+
+import com.google.ortools.linearsolver.MPVariable;
+
+/**
+ * @author Philippe Edwards {@literal <philippe.edwards at rte-international.com>}
+ */
+public class FaraoMPVariable extends MPVariable {
+    double precision;
+
+    protected FaraoMPVariable(long cPtr, boolean cMemoryOwn, double precision) {
+        super(cPtr, cMemoryOwn);
+        this.precision = precision;
+    }
+
+    @Override
+    public void setLb(double lb) {
+        super.setLb(Math.round(lb * precision) / precision);
+    }
+
+    @Override
+    public void setUb(double ub) {
+        super.setUb(Math.round(ub * precision) / precision);
+    }
+
+    @Override
+    public void setBounds(double lb, double ub) {
+        super.setBounds(Math.round(lb * precision) / precision, Math.round(ub * precision) / precision);
+    }
+}

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/IteratingLinearOptimizer.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/IteratingLinearOptimizer.java
@@ -54,7 +54,7 @@ public class IteratingLinearOptimizer {
 
         for (int iteration = 1; iteration <= maxIterations; iteration++) {
             solveLinearProblem(linearProblem, iteration);
-            if (linearProblem.getStatus() != LinearProblemStatus.OPTIMAL) {
+            if (linearProblem.getStatus() != LinearProblemStatus.OPTIMAL && linearProblem.getStatus() != LinearProblemStatus.FEASIBLE) {
                 LOGGER.error(LINEAR_OPTIMIZATION_FAILED, iteration);
                 if (iteration == 1) {
                     return new FailedLinearOptimizationResult();

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/LinearProblem.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/LinearProblem.java
@@ -360,6 +360,7 @@ public final class LinearProblem {
         if (solverSpecificParameters != null) {
             this.solver.setSolverSpecificParametersAsString(solverSpecificParameters);
         }
+        this.solver.enableOutput();
         status = convertResultStatus(solver.solve(solveConfiguration));
         return status;
     }

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/LinearProblem.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/LinearProblem.java
@@ -360,17 +360,9 @@ public final class LinearProblem {
     public LinearProblemStatus solve() {
         MPSolverParameters solveConfiguration = new MPSolverParameters();
         solveConfiguration.setDoubleParam(MPSolverParameters.DoubleParam.RELATIVE_MIP_GAP, relativeMipGap);
-        /*if (solverSpecificParameters != null) {
+        if (solverSpecificParameters != null) {
             this.solver.setSolverSpecificParametersAsString(solverSpecificParameters);
-        }*/
-        int i = Instant.now().getNano();
-        try (BufferedWriter writer = new BufferedWriter(new FileWriter("mip" + i + ".mps"))) {
-            writer.write(solver.exportModelAsMpsFormat());
-        } catch (Exception e) {
-            e.printStackTrace();
         }
-        this.solver.enableOutput();
-        this.solver.setSolverSpecificParametersAsString("THREADS 1 MAXNODE 100 MAXTIME 100");
         status = convertResultStatus(solver.solve(solveConfiguration));
         return status;
     }

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/LinearProblem.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/LinearProblem.java
@@ -23,9 +23,6 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedWriter;
-import java.io.FileWriter;
-import java.time.Instant;
 import java.util.*;
 
 import static com.farao_community.farao.rao_commons.linear_optimisation.LinearProblemIdGenerator.*;

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/LinearProblemResult.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/LinearProblemResult.java
@@ -29,7 +29,7 @@ public class LinearProblemResult implements RangeActionResult {
     private final Map<RangeAction, Double> setPointPerRangeAction = new HashMap<>();
 
     public LinearProblemResult(LinearProblem linearProblem) {
-        if (linearProblem.getStatus() != LinearProblemStatus.OPTIMAL) {
+        if (linearProblem.getStatus() != LinearProblemStatus.OPTIMAL && linearProblem.getStatus() != LinearProblemStatus.FEASIBLE) {
             throw new FaraoException("Impossible to define results on non-optimal Linear problem.");
         }
 

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/LinearProblemResult.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/LinearProblemResult.java
@@ -30,7 +30,7 @@ public class LinearProblemResult implements RangeActionResult {
 
     public LinearProblemResult(LinearProblem linearProblem) {
         if (linearProblem.getStatus() != LinearProblemStatus.OPTIMAL && linearProblem.getStatus() != LinearProblemStatus.FEASIBLE) {
-            throw new FaraoException("Impossible to define results on non-optimal Linear problem.");
+            throw new FaraoException("Impossible to define results on non-optimal and non-feasible Linear problem.");
         }
 
         linearProblem.getRangeActions().forEach(rangeAction ->

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/ContinuousRangeActionGroupFiller.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/ContinuousRangeActionGroupFiller.java
@@ -6,6 +6,7 @@
  */
 package com.farao_community.farao.rao_commons.linear_optimisation.fillers;
 
+import com.farao_community.farao.data.crac_api.Identifiable;
 import com.farao_community.farao.data.crac_api.range_action.RangeAction;
 import com.farao_community.farao.rao_commons.linear_optimisation.LinearProblem;
 import com.farao_community.farao.rao_commons.result_api.FlowResult;
@@ -13,8 +14,10 @@ import com.farao_community.farao.rao_commons.result_api.RangeActionResult;
 import com.farao_community.farao.rao_commons.result_api.SensitivityResult;
 import com.google.ortools.linearsolver.MPConstraint;
 
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * @author Peter Mitri {@literal <peter.mitri at rte-france.com>}
@@ -25,7 +28,8 @@ public class ContinuousRangeActionGroupFiller implements ProblemFiller {
     private final Set<RangeAction> rangeActions;
 
     public ContinuousRangeActionGroupFiller(Set<RangeAction> rangeActions) {
-        this.rangeActions = rangeActions;
+        this.rangeActions = new TreeSet<>(Comparator.comparing(Identifiable::getId));
+        this.rangeActions.addAll(rangeActions);
     }
 
     @Override

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/CoreProblemFiller.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/CoreProblemFiller.java
@@ -9,6 +9,7 @@ package com.farao_community.farao.rao_commons.linear_optimisation.fillers;
 
 import com.farao_community.farao.commons.FaraoException;
 import com.farao_community.farao.commons.Unit;
+import com.farao_community.farao.data.crac_api.Identifiable;
 import com.farao_community.farao.data.crac_api.cnec.FlowCnec;
 import com.farao_community.farao.data.crac_api.range_action.HvdcRangeAction;
 import com.farao_community.farao.data.crac_api.range_action.PstRangeAction;
@@ -46,8 +47,12 @@ public class CoreProblemFiller implements ProblemFiller {
                              double hvdcSensitivityThreshold,
                              boolean relativePositiveMargins) {
         this.network = network;
-        this.flowCnecs = flowCnecs;
-        this.rangeActions = rangeActions;
+        this.flowCnecs = new TreeSet<>(Comparator.comparing(Identifiable::getId));
+        this.flowCnecs.addAll(flowCnecs);
+        this.rangeActions = new TreeSet<>(Comparator.comparing(Identifiable::getId));
+        this.rangeActions.addAll(rangeActions);
+        /*this.flowCnecs = flowCnecs;
+        this.rangeActions = rangeActions;*/
         this.prePerimeterRangeActionResult = prePerimeterRangeActionResult;
         this.pstSensitivityThreshold = pstSensitivityThreshold;
         this.hvdcSensitivityThreshold = hvdcSensitivityThreshold;

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/CoreProblemFiller.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/CoreProblemFiller.java
@@ -51,8 +51,6 @@ public class CoreProblemFiller implements ProblemFiller {
         this.flowCnecs.addAll(flowCnecs);
         this.rangeActions = new TreeSet<>(Comparator.comparing(Identifiable::getId));
         this.rangeActions.addAll(rangeActions);
-        /*this.flowCnecs = flowCnecs;
-        this.rangeActions = rangeActions;*/
         this.prePerimeterRangeActionResult = prePerimeterRangeActionResult;
         this.pstSensitivityThreshold = pstSensitivityThreshold;
         this.hvdcSensitivityThreshold = hvdcSensitivityThreshold;

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/DiscretePstGroupFiller.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/DiscretePstGroupFiller.java
@@ -7,6 +7,7 @@
 
 package com.farao_community.farao.rao_commons.linear_optimisation.fillers;
 
+import com.farao_community.farao.data.crac_api.Identifiable;
 import com.farao_community.farao.data.crac_api.range_action.PstRangeAction;
 import com.farao_community.farao.rao_commons.linear_optimisation.LinearProblem;
 import com.farao_community.farao.rao_commons.result_api.FlowResult;
@@ -15,8 +16,10 @@ import com.farao_community.farao.rao_commons.result_api.SensitivityResult;
 import com.google.ortools.linearsolver.MPConstraint;
 import com.powsybl.iidm.network.Network;
 
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com>}
@@ -27,7 +30,8 @@ public class DiscretePstGroupFiller implements ProblemFiller {
     private final Network network;
 
     public DiscretePstGroupFiller(Network network, Set<PstRangeAction> pstRangeActions) {
-        this.pstRangeActions = pstRangeActions;
+        this.pstRangeActions = new TreeSet<>(Comparator.comparing(Identifiable::getId));
+        this.pstRangeActions.addAll(pstRangeActions);
         this.network = network;
     }
 

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/DiscretePstTapFiller.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/DiscretePstTapFiller.java
@@ -8,6 +8,7 @@
 package com.farao_community.farao.rao_commons.linear_optimisation.fillers;
 
 import com.farao_community.farao.commons.FaraoException;
+import com.farao_community.farao.data.crac_api.Identifiable;
 import com.farao_community.farao.data.crac_api.range_action.PstRangeAction;
 import com.farao_community.farao.data.crac_api.range_action.RangeAction;
 import com.farao_community.farao.rao_commons.linear_optimisation.LinearProblem;
@@ -18,8 +19,10 @@ import com.google.ortools.linearsolver.MPConstraint;
 import com.google.ortools.linearsolver.MPVariable;
 import com.powsybl.iidm.network.Network;
 
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import static com.farao_community.farao.rao_commons.linear_optimisation.LinearProblem.VariationExtension.DOWNWARD;
 import static com.farao_community.farao.rao_commons.linear_optimisation.LinearProblem.VariationExtension.UPWARD;
@@ -37,7 +40,8 @@ public class DiscretePstTapFiller implements ProblemFiller {
                                 Set<RangeAction> rangeActions,
                                 RangeActionResult prePerimeterRangeActionResult) {
         this.network = network;
-        this.rangeActions = rangeActions;
+        this.rangeActions = new TreeSet<>(Comparator.comparing(Identifiable::getId));
+        this.rangeActions.addAll(rangeActions);
         this.prePerimeterRangeActionResult = prePerimeterRangeActionResult;
     }
 

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxLoopFlowFiller.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxLoopFlowFiller.java
@@ -8,6 +8,7 @@ package com.farao_community.farao.rao_commons.linear_optimisation.fillers;
 
 import com.farao_community.farao.commons.FaraoException;
 import com.farao_community.farao.commons.Unit;
+import com.farao_community.farao.data.crac_api.Identifiable;
 import com.farao_community.farao.data.crac_api.cnec.FlowCnec;
 import com.farao_community.farao.data.crac_loopflow_extension.LoopFlowThreshold;
 import com.farao_community.farao.rao_api.parameters.RaoParameters;
@@ -19,8 +20,10 @@ import com.farao_community.farao.rao_commons.result_api.SensitivityResult;
 import com.google.ortools.linearsolver.MPConstraint;
 import com.google.ortools.linearsolver.MPVariable;
 
+import java.util.Comparator;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * @author Pengbo Wang {@literal <pengbo.wang at rte-international.com>}
@@ -34,7 +37,8 @@ public class MaxLoopFlowFiller implements ProblemFiller {
     private final double loopFlowConstraintAdjustmentCoefficient;
 
     public MaxLoopFlowFiller(Set<FlowCnec> loopFlowCnecs, FlowResult initialFlowResult, LoopFlowParameters loopFlowParameters) {
-        this.loopFlowCnecs = loopFlowCnecs;
+        this.loopFlowCnecs = new TreeSet<>(Comparator.comparing(Identifiable::getId));
+        this.loopFlowCnecs.addAll(loopFlowCnecs);
         this.initialFlowResult = initialFlowResult;
         this.loopFlowApproximationLevel = loopFlowParameters.getLoopFlowApproximationLevel();
         this.loopFlowAcceptableAugmentation = loopFlowParameters.getLoopFlowAcceptableAugmentation();

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxMinMarginFiller.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxMinMarginFiller.java
@@ -9,6 +9,7 @@ package com.farao_community.farao.rao_commons.linear_optimisation.fillers;
 
 import com.farao_community.farao.commons.FaraoException;
 import com.farao_community.farao.commons.Unit;
+import com.farao_community.farao.data.crac_api.Identifiable;
 import com.farao_community.farao.data.crac_api.cnec.FlowCnec;
 import com.farao_community.farao.data.crac_api.cnec.Side;
 import com.farao_community.farao.data.crac_api.range_action.HvdcRangeAction;
@@ -23,8 +24,10 @@ import com.farao_community.farao.rao_commons.result_api.SensitivityResult;
 import com.google.ortools.linearsolver.MPConstraint;
 import com.google.ortools.linearsolver.MPVariable;
 
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 
 import static com.farao_community.farao.commons.Unit.MEGAWATT;
 
@@ -40,8 +43,10 @@ public class MaxMinMarginFiller implements ProblemFiller {
     protected double hvdcPenaltyCost;
 
     public MaxMinMarginFiller(Set<FlowCnec> optimizedCnecs, Set<RangeAction> rangeActions, Unit unit, MaxMinMarginParameters maxMinMarginParameters) {
-        this.optimizedCnecs = optimizedCnecs;
-        this.rangeActions = rangeActions;
+        this.optimizedCnecs = new TreeSet<>(Comparator.comparing(Identifiable::getId));
+        this.optimizedCnecs.addAll(optimizedCnecs);
+        this.rangeActions = new TreeSet<>(Comparator.comparing(Identifiable::getId));
+        this.rangeActions.addAll(rangeActions);
         this.unit = unit;
         this.pstPenaltyCost = maxMinMarginParameters.getPstPenaltyCost();
         this.hvdcPenaltyCost = maxMinMarginParameters.getHvdcPenaltyCost();

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MnecFiller.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MnecFiller.java
@@ -8,6 +8,7 @@ package com.farao_community.farao.rao_commons.linear_optimisation.fillers;
 
 import com.farao_community.farao.commons.FaraoException;
 import com.farao_community.farao.commons.Unit;
+import com.farao_community.farao.data.crac_api.Identifiable;
 import com.farao_community.farao.data.crac_api.cnec.FlowCnec;
 import com.farao_community.farao.data.crac_api.cnec.Side;
 import com.farao_community.farao.rao_commons.RaoUtil;
@@ -19,8 +20,10 @@ import com.farao_community.farao.rao_commons.result_api.SensitivityResult;
 import com.google.ortools.linearsolver.MPConstraint;
 import com.google.ortools.linearsolver.MPVariable;
 
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 
 import static com.farao_community.farao.commons.Unit.MEGAWATT;
 
@@ -37,7 +40,8 @@ public class MnecFiller implements ProblemFiller {
 
     public MnecFiller(FlowResult initialFlowResult, Set<FlowCnec> monitoredCnecs, Unit unit, MnecParameters mnecParameters) {
         this.initialFlowResult = initialFlowResult;
-        this.monitoredCnecs = monitoredCnecs;
+        this.monitoredCnecs = new TreeSet<>(Comparator.comparing(Identifiable::getId));
+        this.monitoredCnecs.addAll(monitoredCnecs);
         this.unit = unit;
         this.mnecViolationCost = mnecParameters.getMnecViolationCost();
         this.mnecAcceptableMarginDiminution = mnecParameters.getMnecAcceptableMarginDiminution();

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/UnoptimizedCnecFiller.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/UnoptimizedCnecFiller.java
@@ -8,6 +8,7 @@
 package com.farao_community.farao.rao_commons.linear_optimisation.fillers;
 
 import com.farao_community.farao.commons.FaraoException;
+import com.farao_community.farao.data.crac_api.Identifiable;
 import com.farao_community.farao.data.crac_api.cnec.FlowCnec;
 import com.farao_community.farao.data.crac_api.cnec.Side;
 import com.farao_community.farao.rao_commons.linear_optimisation.LinearProblem;
@@ -40,7 +41,8 @@ public class UnoptimizedCnecFiller implements ProblemFiller {
     public UnoptimizedCnecFiller(Set<FlowCnec> flowCnecs,
                                  FlowResult prePerimeterFlowResult,
                                  UnoptimizedCnecParameters unoptimizedCnecParameters) {
-        this.flowCnecs = flowCnecs;
+        this.flowCnecs = new TreeSet<>(Comparator.comparing(Identifiable::getId));
+        this.flowCnecs.addAll(flowCnecs);
         this.prePerimeterFlowResult = prePerimeterFlowResult;
         this.operatorsNotToOptimize = unoptimizedCnecParameters.getOperatorsNotToOptimize();
         this.highestThresholdValue = unoptimizedCnecParameters.getHighestThresholdValue();

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/objective_function_evaluator/LoopFlowViolationCostEvaluator.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/objective_function_evaluator/LoopFlowViolationCostEvaluator.java
@@ -47,6 +47,11 @@ public class LoopFlowViolationCostEvaluator implements CostEvaluator {
 
     @Override
     public double computeCost(FlowResult flowResult, ComputationStatus sensitivityStatus) {
+        Map<FlowCnec, Double> loopflowCosts = new HashMap<>();
+        loopflowCnecs.forEach(flowCnec -> loopflowCosts.put(flowCnec, getLoopFlowExcess(flowResult, flowCnec) * loopFlowViolationCost));
+        Set<FlowCnec> sortedLoopflows = new TreeSet<>((c1, c2) -> -loopflowCosts.get(c1).compareTo(loopflowCosts.get(c2)));
+        sortedLoopflows.addAll(loopflowCnecs);
+
         double cost = loopflowCnecs
                 .stream()
                 .mapToDouble(cnec -> getLoopFlowExcess(flowResult, cnec) * loopFlowViolationCost)

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityResult.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityResult.java
@@ -170,7 +170,7 @@ public class SystematicSensitivityResult {
             return 0.0;
         }
         Map<String, Double> sensitivities = stateResult.getFlowSensitivities().get(cnec.getNetworkElement().getId());
-        return sensitivities.get(variableId);
+        return sensitivities.getOrDefault(variableId, 0.0);
     }
 
     public double getSensitivityOnIntensity(RangeAction rangeAction, Cnec<?> cnec) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Running the same RAO twice in a row can give slightly different results


**What is the new behavior (if this is a feature change)?**
Running the same RAO should now give exactly the same results.
To do so we sort the sets of cnecs and range actions in the LP fillers, and round some values to a value representable with a double.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
