### PR TITLE
Virtual hubs 0.0.7 + allow partial computation of zToz PTDF when some hubs are missing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <assertj.version>3.17.2</assertj.version>
         <commons.cli.version>1.3.1</commons.cli.version>
         <ejml.version>0.39</ejml.version>
-        <farao.virtualhubs.version>0.0.6</farao.virtualhubs.version>
+        <farao.virtualhubs.version>0.0.7</farao.virtualhubs.version>
         <google.autoservice.version>1.0-rc7</google.autoservice.version>
         <google.guava.version>29.0-jre</google.guava.version>
         <google.ortools.version>7.8.7959</google.ortools.version>

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/AbsolutePtdfSumsComputation.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/AbsolutePtdfSumsComputation.java
@@ -74,9 +74,17 @@ public class AbsolutePtdfSumsComputation {
     }
 
     private double computeZToZPtdf(ZoneToZonePtdfDefinition zToz, Map<EICode, Double> zToSlackPtdfMap) {
-        return zToz.getZoneToSlackPtdfs().stream()
+
+        List<Double> zoneToSlackPtdf =  zToz.getZoneToSlackPtdfs().stream()
             .filter(zToS -> zToSlackPtdfMap.containsKey(zToS.getEiCode()))
-            .mapToDouble(zToS -> zToS.getWeight() * zToSlackPtdfMap.get(zToS.getEiCode()))
-            .sum();
+            .map(zToS -> zToS.getWeight() * zToSlackPtdfMap.get(zToS.getEiCode()))
+            .collect(Collectors.toList());
+
+        if (zoneToSlackPtdf.size() < 2) {
+            // the boundary should at least contains two zoneToSlack PTDFs
+            return 0.0;
+        } else {
+            return zoneToSlackPtdf.stream().mapToDouble(v -> v).sum();
+        }
     }
 }

--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/AbsolutePtdfSumsComputation.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/AbsolutePtdfSumsComputation.java
@@ -74,12 +74,8 @@ public class AbsolutePtdfSumsComputation {
     }
 
     private double computeZToZPtdf(ZoneToZonePtdfDefinition zToz, Map<EICode, Double> zToSlackPtdfMap) {
-        if (zToz.getZoneToSlackPtdfs().stream().anyMatch(zToS -> !zToSlackPtdfMap.containsKey(zToS.getEiCode()))) {
-            // If one zone is missing its PTDF, ignore the boundary
-            return 0;
-        }
-
         return zToz.getZoneToSlackPtdfs().stream()
+            .filter(zToS -> zToSlackPtdfMap.containsKey(zToS.getEiCode()))
             .mapToDouble(zToS -> zToS.getWeight() * zToSlackPtdfMap.get(zToS.getEiCode()))
             .sum();
     }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/AbsolutePtdfSumsComputationTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/AbsolutePtdfSumsComputationTest.java
@@ -115,7 +115,7 @@ public class AbsolutePtdfSumsComputationTest {
     }
 
     @Test
-    public void testIgnoreAbsentGlsk() {
+    public void testIgnoreZtoZWithLessThan2ZtoS() {
 
         // prepare data
         Network network = NetworkImportsUtil.import12NodesNetwork();
@@ -126,18 +126,17 @@ public class AbsolutePtdfSumsComputationTest {
                 new ZoneToZonePtdfDefinition("{FR}-{BE}"),
                 new ZoneToZonePtdfDefinition("{FR}-{DE}"),
                 new ZoneToZonePtdfDefinition("{DE}-{BE}"),
-                new ZoneToZonePtdfDefinition("{BE}-{22Y201903144---9}-{DE}+{22Y201903145---4}"),
-                new ZoneToZonePtdfDefinition("{FR}-{ES}"), // ES doesn't exist in GLSK map
-                new ZoneToZonePtdfDefinition("{ES}-{DE}"), // ES doesn't exist in GLSK map
-                new ZoneToZonePtdfDefinition("{22Y201903144---0}-{22Y201903144---1}")); // EICodes that don't exist in GLSK map
+                new ZoneToZonePtdfDefinition("{BE}-{22Y201903144---0}-{DE}+{22Y201903144---1}"), // wrong EIC for Alegro, only {BE}-{DE} will be taken into account
+                new ZoneToZonePtdfDefinition("{FR}-{ES}"), // ES doesn't exist in GLSK map, must be filtered
+                new ZoneToZonePtdfDefinition("{ES}-{DE}")); // ES doesn't exist in GLSK map, muste be filtered
 
         // compute zToz PTDF sum
         AbsolutePtdfSumsComputation absolutePtdfSumsComputation = new AbsolutePtdfSumsComputation(glskProvider, boundaries, network);
         Map<FlowCnec, Double> ptdfSums = absolutePtdfSumsComputation.computeAbsolutePtdfSums(crac.getFlowCnecs(), systematicSensitivityResult);
 
         // Test that these 3 new boundaries are ignored (results should be the same as previous test)
-        assertEquals(0.6, ptdfSums.get(crac.getFlowCnec("cnec1basecase")), DOUBLE_TOLERANCE);
-        assertEquals(0.9, ptdfSums.get(crac.getFlowCnec("cnec2basecase")), DOUBLE_TOLERANCE);
+        assertEquals(0.5, ptdfSums.get(crac.getFlowCnec("cnec1basecase")), DOUBLE_TOLERANCE); // abs(0.1 - 0.2) + abs(0.1 - 0.3) + abs(0.3 - 0.2) + abs(0.2 - 0.3) = 0.1 + 0.2 + 0.1 + 0.1
+        assertEquals(0.3, ptdfSums.get(crac.getFlowCnec("cnec2basecase")), DOUBLE_TOLERANCE); // abs(0.3 - 0.3) + abs(0.3 - 0.2) + abs(0.2 - 0.3) + abs(0.3 - 0.2) = 0 + 0.1 + 0.1 + 0.1
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Change how zToz PTDF when some hubs are missing (typically, disconnected virtual hubs can be missing)


**What is the current behavior?** *(You can also link to an open issue here)*
zToz PTDF with at least one missing zTos is considered invalid


**What is the new behavior (if this is a feature change)?**
zToz PTDF with at least two zTos is considered valid.
For instance, zToz between BE and DE : BE - BE_AL - DE - DE_AL, is still considered a valid zToz even if BE_AL and DE_AL are missing.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
NO
