### PR TITLE
fix CRA PST in second preventive rao result

### DIFF
--- a/data/rao-result/rao-result-json/src/main/java/com/farao_community/farao/data/rao_result_json/serializers/PstRangeActionResultArraySerializer.java
+++ b/data/rao-result/rao-result-json/src/main/java/com/farao_community/farao/data/rao_result_json/serializers/PstRangeActionResultArraySerializer.java
@@ -100,8 +100,7 @@ final class PstRangeActionResultArraySerializer {
         // isActivatedDuringState might throw an exception, for instance if the RAO was run on one state only, and the
         // state in argument of this method is not the same state.
         try {
-            return raoResult.isActivatedDuringState(state, pstRangeAction)
-                    && raoResult.getOptimizedTapOnState(state, pstRangeAction) != raoResult.getPreOptimizationTapOnState(state, pstRangeAction);
+            return raoResult.isActivatedDuringState(state, pstRangeAction);
         } catch (FaraoException e) {
             return false;
         }

--- a/data/rao-result/rao-result-json/src/main/java/com/farao_community/farao/data/rao_result_json/serializers/PstRangeActionResultArraySerializer.java
+++ b/data/rao-result/rao-result-json/src/main/java/com/farao_community/farao/data/rao_result_json/serializers/PstRangeActionResultArraySerializer.java
@@ -97,10 +97,11 @@ final class PstRangeActionResultArraySerializer {
     }
 
     private static boolean safeIsActivatedDuringState(RaoResult raoResult, State state, PstRangeAction pstRangeAction) {
-        // isActivatedDuringState might throw an exception, for instance if the RAO was run one one state only, and the
+        // isActivatedDuringState might throw an exception, for instance if the RAO was run on one state only, and the
         // state in argument of this method is not the same state.
         try {
-            return raoResult.isActivatedDuringState(state, pstRangeAction);
+            return raoResult.isActivatedDuringState(state, pstRangeAction)
+                    && raoResult.getOptimizedTapOnState(state, pstRangeAction) != raoResult.getPreOptimizationTapOnState(state, pstRangeAction);
         } catch (FaraoException e) {
             return false;
         }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/PerimeterOutput.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/PerimeterOutput.java
@@ -109,7 +109,6 @@ public class PerimeterOutput implements PerimeterResult {
     @Override
     public int getOptimizedTap(PstRangeAction pstRangeAction) {
 
-        //test without try catch, if its not working, use a try/catch over a FaraoException instead
         if (optimizationResult.getRangeActions().contains(pstRangeAction)) {
             return optimizationResult.getOptimizedTap(pstRangeAction);
         }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/PerimeterOutput.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/PerimeterOutput.java
@@ -7,7 +7,6 @@
 
 package com.farao_community.farao.search_tree_rao;
 
-import com.farao_community.farao.commons.FaraoException;
 import com.farao_community.farao.commons.Unit;
 import com.farao_community.farao.data.crac_api.NetworkElement;
 import com.farao_community.farao.data.crac_api.cnec.FlowCnec;
@@ -109,10 +108,28 @@ public class PerimeterOutput implements PerimeterResult {
 
     @Override
     public int getOptimizedTap(PstRangeAction pstRangeAction) {
-        // TODO: better handling in case of accessing of a tap that is not present in the results
-        try {
+
+        //test without try catch, if its not working, use a try/catch over a FaraoException instead
+        if (optimizationResult.getRangeActions().contains(pstRangeAction)) {
             return optimizationResult.getOptimizedTap(pstRangeAction);
-        } catch (FaraoException e) {
+        }
+
+        // if pstRangeAction is not in perimeter, check if there is not another rangeAction
+        // on the same network element.
+        PstRangeAction pstRangeActionOnSameElement = null;
+        NetworkElement networkElement = pstRangeAction.getNetworkElement();
+
+        for (RangeAction rangeAction : optimizationResult.getRangeActions()) {
+            if (rangeAction instanceof PstRangeAction && ((PstRangeAction) rangeAction).getNetworkElement() != null
+                    &&  ((PstRangeAction) rangeAction).getNetworkElement().equals(networkElement)) {
+                pstRangeActionOnSameElement = (PstRangeAction) rangeAction;
+                break;
+            }
+        }
+
+        if (pstRangeActionOnSameElement != null) {
+            return optimizationResult.getOptimizedTap(pstRangeActionOnSameElement);
+        } else {
             return prePerimeterRangeActionResult.getOptimizedTap(pstRangeAction);
         }
     }
@@ -131,6 +148,7 @@ public class PerimeterOutput implements PerimeterResult {
             for (RangeAction ra : optimizationResult.getRangeActions()) {
                 if (ra.getNetworkElements().contains(networkElement)) {
                     rangeActionOnSameElement = ra;
+                    break;
                 }
             }
         }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/output/SecondPreventiveAndCurativesRaoOutput.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/output/SecondPreventiveAndCurativesRaoOutput.java
@@ -64,9 +64,9 @@ public class SecondPreventiveAndCurativesRaoOutput implements SearchTreeRaoResul
         if (!postCurativeResults.containsKey(state) || !postCurativeResults.get(state).getRangeActions().contains(rangeAction)) {
             return false;
         } else if (postFirstPreventiveResult.getRangeActions().contains(rangeAction)) {
-            return postCurativeResults.get(state).getOptimizedSetPoint(rangeAction) != postFirstPreventiveResult.getOptimizedSetPoint(rangeAction);
+            return Math.abs(postCurativeResults.get(state).getOptimizedSetPoint(rangeAction) - postFirstPreventiveResult.getOptimizedSetPoint(rangeAction)) > 1e-6;
         } else {
-            return postCurativeResults.get(state).getOptimizedSetPoint(rangeAction) != initialResult.getOptimizedSetPoint(rangeAction);
+            return Math.abs(postCurativeResults.get(state).getOptimizedSetPoint(rangeAction) - initialResult.getOptimizedSetPoint(rangeAction)) > 1e-6;
         }
     }
 

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/PerimeterOutputTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/PerimeterOutputTest.java
@@ -9,6 +9,7 @@ package com.farao_community.farao.search_tree_rao;
 
 import com.farao_community.farao.commons.FaraoException;
 import com.farao_community.farao.commons.Unit;
+import com.farao_community.farao.data.crac_api.NetworkElement;
 import com.farao_community.farao.data.crac_api.cnec.FlowCnec;
 import com.farao_community.farao.data.crac_api.network_action.NetworkAction;
 import com.farao_community.farao.data.crac_api.range_action.PstRangeAction;
@@ -19,6 +20,7 @@ import com.farao_community.farao.rao_commons.result_api.RangeActionResult;
 import com.powsybl.sensitivity.factors.variables.LinearGlsk;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
@@ -170,12 +172,28 @@ public class PerimeterOutputTest {
 
     @Test
     public void testGetOptimizedTap() {
+        when(optimizationResult.getRangeActions()).thenReturn(Set.of(pst1));
+
         when(optimizationResult.getOptimizedTap(pst1)).thenReturn(10);
         when(optimizationResult.getOptimizedTap(pst2)).thenThrow(new FaraoException("absent mock"));
         when(prePerimeterRangeActionResult.getOptimizedTap(pst2)).thenReturn(3);
 
         assertEquals(10, perimeterOutput.getOptimizedTap(pst1));
         assertEquals(3, perimeterOutput.getOptimizedTap(pst2));
+    }
+
+    @Test
+    public void testGetOptimizedTapOfRaOnSamePst() {
+        when(optimizationResult.getRangeActions()).thenReturn(Set.of(pst1));
+
+        when(optimizationResult.getOptimizedTap(pst1)).thenReturn(-10);
+        when(optimizationResult.getOptimizedTap(pst2)).thenThrow(new FaraoException("absent mock"));
+        NetworkElement ne = Mockito.mock(NetworkElement.class);
+        when(pst1.getNetworkElement()).thenReturn(ne);
+        when(pst2.getNetworkElement()).thenReturn(ne);
+
+        assertEquals(-10, perimeterOutput.getOptimizedTap(pst1));
+        assertEquals(-10, perimeterOutput.getOptimizedTap(pst2));
     }
 
     @Test
@@ -186,6 +204,20 @@ public class PerimeterOutputTest {
 
         assertEquals(10.7, perimeterOutput.getOptimizedSetPoint(ra1), DOUBLE_TOLERANCE);
         assertEquals(3.5, perimeterOutput.getOptimizedSetPoint(ra2), DOUBLE_TOLERANCE);
+    }
+
+    @Test
+    public void testGetOptimizedSetPointOfRaOnSamePst() {
+        when(optimizationResult.getRangeActions()).thenReturn(Set.of(pst1));
+
+        when(optimizationResult.getOptimizedSetPoint(pst1)).thenReturn(5.2);
+        when(optimizationResult.getOptimizedSetPoint(pst2)).thenThrow(new FaraoException("absent mock"));
+        NetworkElement ne = Mockito.mock(NetworkElement.class);
+        when(pst1.getNetworkElements()).thenReturn(Set.of(ne));
+        when(pst2.getNetworkElements()).thenReturn(Set.of(ne));
+
+        assertEquals(5.2, perimeterOutput.getOptimizedSetPoint(pst1), 1e-4);
+        assertEquals(5.2, perimeterOutput.getOptimizedSetPoint(pst2), 1e-4);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** *(You can also link to an open issue here)*
In RaoResult with second preventive optimization, PSTs are sometimes counted as activated in curative, while they are not.

For instance, if there are two RAs on the same PST, one preventive, and one curative. And the taps of the PST are:
* initial: 0
* afterPRA: 10
* afterCRA: 10

Both the RAs, preventive and curative, are considered activated.


**What is the new behavior (if this is a feature change)?**

In the example above, only the PRA appears activated


