### PR TITLE
Extra slack on loopflow threshold in LP to avoid infeasibility due to rounding

### DIFF
--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxLoopFlowFiller.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxLoopFlowFiller.java
@@ -165,7 +165,8 @@ public class MaxLoopFlowFiller implements ProblemFiller {
     private double getLoopFlowUpperBound(FlowCnec loopFlowCnec) {
         double loopFlowThreshold = loopFlowCnec.getExtension(LoopFlowThreshold.class).getThresholdWithReliabilityMargin(Unit.MEGAWATT);
         double initialLoopFlow = initialFlowResult.getLoopFlow(loopFlowCnec, Unit.MEGAWATT);
+        //add a tiny bit of slack to the threshold to avoid the rounding causing infeasibilities
         return Math.max(Math.abs(initialLoopFlow),
-            Math.max(loopFlowThreshold, Math.abs(initialLoopFlow) + loopFlowAcceptableAugmentation) - loopFlowConstraintAdjustmentCoefficient);
+            Math.max(loopFlowThreshold, Math.abs(initialLoopFlow) + loopFlowAcceptableAugmentation) - loopFlowConstraintAdjustmentCoefficient) + 0.01;
     }
 }

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/AbstractFillerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/AbstractFillerTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.*;
 @PrepareForTest(MPSolver.class)
 @PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 abstract class AbstractFillerTest {
-    static final double DOUBLE_TOLERANCE = 0.01;
+    static final double DOUBLE_TOLERANCE = 0.1;
 
     // data related to the two Cnecs
     static final double MIN_FLOW_1 = -750.0;

--- a/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxLoopFlowFillerTest.java
+++ b/ra-optimisation/rao-commons/src/test/java/com/farao_community/farao/rao_commons/linear_optimisation/fillers/MaxLoopFlowFillerTest.java
@@ -130,8 +130,8 @@ public class MaxLoopFlowFillerTest extends AbstractFillerTest {
         assertEquals((110 - 5.) + 49.0, loopFlowConstraintUb.ub(), DOUBLE_TOLERANCE);
 
         MPVariable flowVariable = linearProblem.getFlowVariable(cnec1);
-        assertEquals(1, loopFlowConstraintUb.getCoefficient(flowVariable), 0.1);
-        assertEquals(1, loopFlowConstraintLb.getCoefficient(flowVariable), 0.1);
+        assertEquals(1, loopFlowConstraintUb.getCoefficient(flowVariable), DOUBLE_TOLERANCE);
+        assertEquals(1, loopFlowConstraintLb.getCoefficient(flowVariable), DOUBLE_TOLERANCE);
     }
 
     @Test
@@ -157,8 +157,8 @@ public class MaxLoopFlowFillerTest extends AbstractFillerTest {
         assertEquals((100 - 5.) + 67.0, loopFlowConstraintUb.ub(), DOUBLE_TOLERANCE);
 
         MPVariable flowVariable = linearProblem.getFlowVariable(cnec1);
-        assertEquals(1, loopFlowConstraintUb.getCoefficient(flowVariable), 0.1);
-        assertEquals(1, loopFlowConstraintLb.getCoefficient(flowVariable), 0.1);
+        assertEquals(1, loopFlowConstraintUb.getCoefficient(flowVariable), DOUBLE_TOLERANCE);
+        assertEquals(1, loopFlowConstraintLb.getCoefficient(flowVariable), DOUBLE_TOLERANCE);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix? 


**What is the current behavior?** *(You can also link to an open issue here)*
The rounding in the LP sometimes causes some loopflows to not be under thresholds in the LP with the PSTs in their original position, so the LP tries to solve those constraints, sometimes activating many psts for just about no gain


**What is the new behavior (if this is a feature change)?**
We now have a tiny slack on loopflows (0.01MW) to make sure the initial solution is always "good".


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
