### PR TITLE
fix infinity in curative costs - moved no glsk to technical logs

### DIFF
--- a/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/ToolProvider.java
+++ b/ra-optimisation/rao-commons/src/main/java/com/farao_community/farao/rao_commons/ToolProvider.java
@@ -174,7 +174,7 @@ public final class ToolProvider {
         for (String eiCode : listEicCode) {
             LinearGlsk linearGlsk = glskProvider.getData(eiCode);
             if (Objects.isNull(linearGlsk)) {
-                FaraoLoggerProvider.BUSINESS_WARNS.warn("No GLSK found for CountryEICode {}", eiCode);
+                FaraoLoggerProvider.TECHNICAL_LOGS.warn("No GLSK found for CountryEICode {}", eiCode);
             } else {
                 glskBoundaries.put(eiCode, linearGlsk);
             }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoLogger.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/SearchTreeRaoLogger.java
@@ -208,7 +208,8 @@ final class SearchTreeRaoLogger {
             raResult = String.format("%s %s network action(s) and %s %s range action(s) activated", activatedNetworkActions, raType, activatedRangeActions, raType);
         }
         String initialCostString = initialFunctionalCost == null || initialVirtualCost == null ? "" :
-            String.format(Locale.ENGLISH, "initial cost = %.2f (functional: %.2f, virtual: %.2f), ", initialFunctionalCost + initialVirtualCost, initialFunctionalCost, initialVirtualCost);
+            String.format("initial cost = %s (functional: %s, virtual: %s), ", formatDouble(initialFunctionalCost + initialVirtualCost), formatDouble(initialFunctionalCost), formatDouble(initialVirtualCost));
+
         logger.info("Scenario \"{}\": {}{}, cost {} = {} (functional: {}, virtual: {})", scenarioName, initialCostString, raResult, OptimizationState.afterOptimizing(optimizedState),
             formatDouble(finalObjective.getCost()), formatDouble(finalObjective.getFunctionalCost()), formatDouble(finalObjective.getVirtualCost()));
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The curative perimeter logs the java value of - infinity instead of "-infinity".
Also the "No GLSK" log pollutes the business warns by being printed every leaf.


**What is the new behavior (if this is a feature change)?**
Now log "infinity", and "No GLSK" log moved to technical logs.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
