### PR TITLE
add provider in sensi with applied RA

### DIFF
--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityAdapter.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityAdapter.java
@@ -68,7 +68,7 @@ final class SystematicSensitivityAdapter {
             .collect(Collectors.toList());
 
         SystematicSensitivityResult result = new SystematicSensitivityResult();
-        result.completeData(SensitivityAnalysis.run(network, cnecSensitivityProvider, contingenciesWithoutRa, sensitivityComputationParameters), false);
+        result.completeData(SensitivityAnalysis.find(sensitivityProvider).run(network, cnecSensitivityProvider, contingenciesWithoutRa, sensitivityComputationParameters), false);
 
         // systematic analyses for states with RA
         cnecSensitivityProvider.disableFactorsForBaseCaseSituation();
@@ -92,7 +92,7 @@ final class SystematicSensitivityAdapter {
 
             List<Contingency> contingencyList = Collections.singletonList(convertCracContingencyToPowsybl(optContingency.get(), network));
 
-            result.completeData(SensitivityAnalysis.run(network, variantForState, cnecSensitivityProvider, contingencyList, sensitivityComputationParameters), true);
+            result.completeData(SensitivityAnalysis.find(sensitivityProvider).run(network, variantForState, cnecSensitivityProvider, contingencyList, sensitivityComputationParameters), true);
             network.getVariantManager().removeVariant(variantForState);
             counterForLogs++;
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
sensitivityProvider parameter is not transmitted in sensi computation with applied RA. Which can cause a crash of the RAO in 2nd preventive, if several sensitivity engines are in the dependencies.


**What is the new behavior (if this is a feature change)?**
now it is transmitted
