### PR TITLE
Add an epsilon to range action min and max setpoint in LP to avoid rounding issues

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFiller.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFiller.java
@@ -37,6 +37,7 @@ public class CoreProblemFiller implements ProblemFiller {
     private final double hvdcSensitivityThreshold;
     private final double injectionSensitivityThreshold;
     private final boolean relativePositiveMargins;
+    private static final double RANGE_ACTION_SETPOINT_EPSILON = 1e-5;
 
     public CoreProblemFiller(Network network,
                              Set<FlowCnec> flowCnecs,
@@ -110,7 +111,7 @@ public class CoreProblemFiller implements ProblemFiller {
     private void buildRangeActionSetPointVariables(LinearProblem linearProblem, RangeAction<?> rangeAction, double prePerimeterValue) {
         double minSetPoint = rangeAction.getMinAdmissibleSetpoint(prePerimeterValue);
         double maxSetPoint = rangeAction.getMaxAdmissibleSetpoint(prePerimeterValue);
-        linearProblem.addRangeActionSetpointVariable(minSetPoint, maxSetPoint, rangeAction);
+        linearProblem.addRangeActionSetpointVariable(minSetPoint - RANGE_ACTION_SETPOINT_EPSILON, maxSetPoint + RANGE_ACTION_SETPOINT_EPSILON, rangeAction);
     }
 
     /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
In the mip version of the LP, we round the boundaries of the setpoint of psts, and also the angle variation per tap of psts. The issue is that the rounding can mean that the max setpoint is no longer attainable because the rounding can make it smaller than maxTap * angleVariationPerTap.


**What is the new behavior (if this is a feature change)?**
To solve the issue we add a small epsilon (1e-5) to maxSetpoint and substract it to minSetpoint.
This guarantees that maxTap * angleVariationPerTap < maxSetpoint + epsilong (and same thing for minSetpoint), even after rounding.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
