### PR TITLE
Correctly handle curative perimeters with only unoptimized CNECs

### DIFF
--- a/data/crac/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Crac.java
+++ b/data/crac/crac-api/src/main/java/com/farao_community/farao/data/crac_api/Crac.java
@@ -233,6 +233,11 @@ public interface Crac extends Identifiable<Crac> {
      */
     void removeFlowCnec(String flowCnecId);
 
+    /**
+     * Remove a set of FlowCnecs - identified by their id - from the Crac
+     */
+    void removeFlowCnecs(Set<String> flowCnecsIds);
+
     // Remedial actions management
 
     /**

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/CracImpl.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/CracImpl.java
@@ -338,15 +338,19 @@ public class CracImpl extends AbstractIdentifiable<Crac> implements Crac {
 
     @Override
     public void removeFlowCnec(String flowCnecId) {
-        FlowCnec flowCnecToRemove = flowCnecs.get(flowCnecId);
-        if (Objects.isNull(flowCnecToRemove)) {
-            return;
-        }
-        String neId = flowCnecToRemove.getNetworkElement().getId();
-        String stateId = flowCnecToRemove.getState().getId();
-        flowCnecs.remove(flowCnecId);
-        safeRemoveNetworkElements(Collections.singleton(neId));
-        safeRemoveStates(Collections.singleton(stateId));
+        removeFlowCnecs(Collections.singleton(flowCnecId));
+    }
+
+    @Override
+    public void removeFlowCnecs(Set<String> flowCnecsIds) {
+        Set<FlowCnec> flowCnecsToRemove = flowCnecsIds.stream().map(flowCnecs::get).filter(Objects::nonNull).collect(Collectors.toSet());
+        Set<String> networkElementsToRemove = flowCnecsToRemove.stream().map(Cnec::getNetworkElement).map(Identifiable::getId).collect(Collectors.toSet());
+        Set<String> statesToRemove = flowCnecsToRemove.stream().map(Cnec::getState).map(State::getId).collect(Collectors.toSet());
+        flowCnecsToRemove.forEach(flowCnecToRemove ->
+            flowCnecs.remove(flowCnecToRemove.getId())
+        );
+        safeRemoveNetworkElements(networkElementsToRemove);
+        safeRemoveStates(statesToRemove);
     }
 
     void addFlowCnec(FlowCnec flowCnec) {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/RaoLogger.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/RaoLogger.java
@@ -95,7 +95,7 @@ public final class RaoLogger {
 
             String isRelativeMargin = (relativePositiveMargins && cnecMargin > 0) ? " relative" : "";
             String ptdfIfRelative = (relativePositiveMargins && cnecMargin > 0) ? format(" (PTDF %f)", flowResult.getPtdfZonalSum(cnec)) : "";
-            summary.add(String.format(Locale.ENGLISH, "Limiting element #%s:%s margin = %.2f %s%s, element %s at state %s, CNEC ID = \"%s\"",
+            summary.add(String.format(Locale.ENGLISH, "Limiting element #%02d:%s margin = %.2f %s%s, element %s at state %s, CNEC ID = \"%s\"",
                 i + 1,
                 isRelativeMargin,
                 cnecMargin,
@@ -154,7 +154,7 @@ public final class RaoLogger {
             double cnecMargin = mostLimitingElementsAndMargins.get(cnec);
 
             String isRelativeMargin = (relativePositiveMargins && cnecMargin > 0) ? " relative" : "";
-            summary.add(String.format(Locale.ENGLISH, "Limiting element #%s:%s margin = %.2f %s, element %s at state %s, CNEC ID = \"%s\"",
+            summary.add(String.format(Locale.ENGLISH, "Limiting element #%02d:%s margin = %.2f %s, element %s at state %s, CNEC ID = \"%s\"",
                 i + 1,
                 isRelativeMargin,
                 cnecMargin,

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/commons/RaoLoggerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/commons/RaoLoggerTest.java
@@ -115,7 +115,7 @@ public class RaoLoggerTest {
         String relativeMargin = relative ? " relative" : "";
         String ptdfString = (ptdf != null) ? format(" (PTDF %f)", ptdf) : "";
         String descriptor = format("%s at state %s", cnec.getNetworkElement().getName(), cnec.getState().getId());
-        return format(Locale.ENGLISH, "Limiting element #%d:%s margin = %.2f %s%s, element %s, CNEC ID = \"%s\"", order, relativeMargin, margin, unit, ptdfString, descriptor, cnec.getId());
+        return format(Locale.ENGLISH, "Limiting element #%02d:%s margin = %.2f %s%s, element %s, CNEC ID = \"%s\"", order, relativeMargin, margin, unit, ptdfString, descriptor, cnec.getId());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix + minor feature


**What is the current behavior?** *(You can also link to an open issue here)*
When a curative perimeter only contains unoptimized CNECs for which the margins are not decreased, the functional cost is -infinity. This may hide the virtual cost and prevent the RAO from trying to remove it.


**What is the new behavior (if this is a feature change)?**
The functional cost is now finite
Also, a new Crac.removeFlowCnecs method makes it easier to remove CNECs in batches

