### PR TITLE
Cse hybrid gsk and fix on reserve blocks

### DIFF
--- a/data/glsk/glsk-document-api/src/main/java/com/farao_community/farao/data/glsk/api/AbstractGlskShiftKey.java
+++ b/data/glsk/glsk-document-api/src/main/java/com/farao_community/farao/data/glsk/api/AbstractGlskShiftKey.java
@@ -15,6 +15,8 @@ import java.util.List;
  * @author Pengbo Wang {@literal <pengbo.wang@rte-international.com>}
  */
 public abstract class AbstractGlskShiftKey {
+    private static final double DEFAULT_QUANTITY = 1.0;
+    private static final double DEFAULT_MAXIMUM_SHIFT = Double.MAX_VALUE;
 
     /**
      * business type of shift key. B42, B43, B45
@@ -27,7 +29,7 @@ public abstract class AbstractGlskShiftKey {
     /**
      * explicit shift key factor
      */
-    protected Double quantity;
+    protected Double quantity = DEFAULT_QUANTITY;
     /**
      * list of registered resources
      */
@@ -49,6 +51,10 @@ public abstract class AbstractGlskShiftKey {
      * merit order direction
      */
     protected String flowDirection;
+    /**
+     * Maximum shift
+     */
+    protected double maximumShift = DEFAULT_MAXIMUM_SHIFT;
 
     /**
      * @return debug to string
@@ -132,4 +138,7 @@ public abstract class AbstractGlskShiftKey {
         return flowDirection;
     }
 
+    public double getMaximumShift() {
+        return maximumShift;
+    }
 }

--- a/data/glsk/glsk-document-api/src/main/java/com/farao_community/farao/data/glsk/api/util/converters/GlskPointScalableConverter.java
+++ b/data/glsk/glsk-document-api/src/main/java/com/farao_community/farao/data/glsk/api/util/converters/GlskPointScalableConverter.java
@@ -88,9 +88,9 @@ public final class GlskPointScalableConverter {
         double totalFactor = generatorResources.stream().mapToDouble(resource -> remainingCapacityFunction.apply(resource, network)).sum();
         generatorResources.forEach(generatorResource -> {
             percentages.add((float) (100 * glskShiftKey.getQuantity().floatValue() * remainingCapacityFunction.apply(generatorResource, network) / totalFactor));
-            scalables.add(Scalable.onGenerator(generatorResource.getGeneratorId()));
+            scalables.add(getGeneratorScalableWithLimits(network, generatorResource));
         });
-        return Scalable.proportional(percentages, scalables);
+        return Scalable.proportional(percentages, scalables, true);
     }
 
     private static double getRemainingCapacityUp(AbstractGlskRegisteredResource resource, Network network) {

--- a/data/glsk/glsk-document-api/src/main/java/com/farao_community/farao/data/glsk/api/util/converters/GlskPointScalableConverter.java
+++ b/data/glsk/glsk-document-api/src/main/java/com/farao_community/farao/data/glsk/api/util/converters/GlskPointScalableConverter.java
@@ -38,32 +38,36 @@ public final class GlskPointScalableConverter {
     public static Scalable convert(Network network, AbstractGlskPoint glskPoint) {
         Objects.requireNonNull(glskPoint.getGlskShiftKeys());
         if (!glskPoint.getGlskShiftKeys().get(0).getBusinessType().equals("B45")) {
-            //B42 and B43 proportional
-            List<Float> percentages = new ArrayList<>();
-            List<Scalable> scalables = new ArrayList<>();
-
-            for (AbstractGlskShiftKey glskShiftKey : glskPoint.getGlskShiftKeys()) {
-                if (glskShiftKey.getBusinessType().equals("B42") && glskShiftKey.getRegisteredResourceArrayList().isEmpty()) {
-                    //B42 country
-                    convertCountryProportional(network, glskShiftKey, percentages, scalables);
-                } else if (glskShiftKey.getBusinessType().equals("B42") && !glskShiftKey.getRegisteredResourceArrayList().isEmpty()) {
-                    //B42 explicit
-                    convertExplicitProportional(network, glskShiftKey, percentages, scalables);
-                } else if (glskShiftKey.getBusinessType().equals("B43") && !glskShiftKey.getRegisteredResourceArrayList().isEmpty()) {
-                    //B43 participation factor
-                    convertParticipationFactor(network, glskShiftKey, percentages, scalables);
-                } else if (glskShiftKey.getBusinessType().equals("B44") && !glskShiftKey.getRegisteredResourceArrayList().isEmpty()) {
-                    //B44 remaining capacity
-                    convertRemainingCapacity(network, glskShiftKey, percentages, scalables);
-                } else {
-                    throw new GlskException("In convert glskShiftKey business type not supported");
-                }
-            }
-            return Scalable.proportional(percentages, scalables, true);
+            return convert(network, glskPoint.getGlskShiftKeys());
         } else {
             //B45 merit order
             return convertMeritOrder(network, glskPoint);
         }
+    }
+
+    public static Scalable convert(Network network, List<AbstractGlskShiftKey> shiftKeys) {
+        Objects.requireNonNull(shiftKeys);
+        List<Float> percentages = new ArrayList<>();
+        List<Scalable> scalables = new ArrayList<>();
+
+        for (AbstractGlskShiftKey glskShiftKey : shiftKeys) {
+            if (glskShiftKey.getBusinessType().equals("B42") && glskShiftKey.getRegisteredResourceArrayList().isEmpty()) {
+                //B42 country
+                convertCountryProportional(network, glskShiftKey, percentages, scalables);
+            } else if (glskShiftKey.getBusinessType().equals("B42") && !glskShiftKey.getRegisteredResourceArrayList().isEmpty()) {
+                //B42 explicit
+                convertExplicitProportional(network, glskShiftKey, percentages, scalables);
+            } else if (glskShiftKey.getBusinessType().equals("B43") && !glskShiftKey.getRegisteredResourceArrayList().isEmpty()) {
+                //B43 participation factor
+                convertParticipationFactor(network, glskShiftKey, percentages, scalables);
+            } else if (glskShiftKey.getBusinessType().equals("B44") && !glskShiftKey.getRegisteredResourceArrayList().isEmpty()) {
+                //B44 remaining capacity
+                convertRemainingCapacity(network, glskShiftKey, percentages, scalables);
+            } else {
+                throw new GlskException("In convert glskShiftKey business type not supported");
+            }
+        }
+        return Scalable.proportional(percentages, scalables, true);
     }
 
     private static void convertRemainingCapacity(Network network, AbstractGlskShiftKey glskShiftKey, List<Float> percentages, List<Scalable> scalables) {
@@ -207,9 +211,15 @@ public final class GlskPointScalableConverter {
                     .collect(Collectors.toList());
             double totalP = generators.stream().mapToDouble(NetworkUtil::pseudoTargetP).sum();
 
-            //calculate factor of each generator
-            generators.forEach(generator -> percentages.add(100 * glskShiftKey.getQuantity().floatValue() * (float) NetworkUtil.pseudoTargetP(generator) / (float) totalP));
-            generators.forEach(generator -> scalables.add(Scalable.onGenerator(generator.getId())));
+            generators.forEach(generator -> {
+                // Calculate factor of each generator
+                float factor = glskShiftKey.getQuantity().floatValue() * (float) NetworkUtil.pseudoTargetP(generator) / (float) totalP;
+                percentages.add(100 * factor);
+                // In case of global shift key limitation we will limit the generator proportionally to
+                // its participation in the global proportional scalable
+                double maxGeneratorValue = NetworkUtil.pseudoTargetP(generator) + factor * glskShiftKey.getMaximumShift();
+                scalables.add(Scalable.onGenerator(generator.getId(), -Double.MAX_VALUE, maxGeneratorValue));
+            });
         } else if (glskShiftKey.getPsrType().equals("A05")) {
             TECHNICAL_LOGS.debug("GLSK Type B42, not empty registered resources list --> (explicit/manual) proportional LSK");
             List<Load> loads = glskShiftKey.getRegisteredResourceArrayList().stream()
@@ -220,6 +230,7 @@ public final class GlskPointScalableConverter {
                     .collect(Collectors.toList());
             double totalP = loads.stream().mapToDouble(NetworkUtil::pseudoP0).sum();
 
+            // For now glsk shift key maximum shift is not handled for loads by lack of specification
             loads.forEach(load -> percentages.add(100 * glskShiftKey.getQuantity().floatValue() * (float) NetworkUtil.pseudoP0(load) / (float) totalP));
             loads.forEach(load -> scalables.add(Scalable.onLoad(load.getId(), -Double.MAX_VALUE, Double.MAX_VALUE)));
         }

--- a/data/glsk/glsk-document-cse/src/main/java/com/farao_community/farao/data/glsk/cse/CseGlskDocument.java
+++ b/data/glsk/glsk-document-cse/src/main/java/com/farao_community/farao/data/glsk/cse/CseGlskDocument.java
@@ -6,9 +6,17 @@
  */
 package com.farao_community.farao.data.glsk.cse;
 
+import com.farao_community.farao.commons.ZonalData;
+import com.farao_community.farao.commons.ZonalDataChronology;
+import com.farao_community.farao.commons.ZonalDataImpl;
 import com.farao_community.farao.data.glsk.api.AbstractGlskPoint;
 import com.farao_community.farao.data.glsk.api.GlskDocument;
 import com.farao_community.farao.data.glsk.api.GlskException;
+import com.farao_community.farao.data.glsk.api.util.converters.GlskPointScalableConverter;
+import com.powsybl.action.util.Scalable;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.sensitivity.factors.variables.LinearGlsk;
+import org.apache.commons.lang3.NotImplementedException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -20,12 +28,16 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
  */
 public final class CseGlskDocument implements GlskDocument {
+    private static final String LINEAR_GLSK_NOT_HANDLED = "CSE GLSK document does not handle Linear GLSK conversion";
+
     /**
      * list of GlskPoint in the given Glsk document
      */
@@ -71,5 +83,57 @@ public final class CseGlskDocument implements GlskDocument {
     @Override
     public List<AbstractGlskPoint> getGlskPoints(String zone) {
         return cseGlskPoints.getOrDefault(zone, Collections.emptyList());
+    }
+
+    @Override
+    public ZonalData<LinearGlsk> getZonalGlsks(Network network) {
+        throw new NotImplementedException(LINEAR_GLSK_NOT_HANDLED);
+    }
+
+    @Override
+    public ZonalData<LinearGlsk> getZonalGlsks(Network network, Instant instant) {
+        throw new NotImplementedException(LINEAR_GLSK_NOT_HANDLED);
+    }
+
+    @Override
+    public ZonalDataChronology<LinearGlsk> getZonalGlsksChronology(Network network) {
+        throw new NotImplementedException(LINEAR_GLSK_NOT_HANDLED);
+    }
+
+    @Override
+    public ZonalData<Scalable> getZonalScalable(Network network) {
+        Map<String, Scalable> zonalData = new HashMap<>();
+        for (Map.Entry<String, List<AbstractGlskPoint>> entry : cseGlskPoints.entrySet()) {
+            String area = entry.getKey();
+            // There is always only one GlskPoint for a zone
+            AbstractGlskPoint zonalGlskPoint = entry.getValue().get(0);
+            if (isHybridCseGlskPoint(zonalGlskPoint)) {
+                List<Scalable> scalables = zonalGlskPoint.getGlskShiftKeys().stream()
+                    .sorted(Comparator.comparingInt(sk -> ((CseGlskShiftKey) sk).getOrder()))
+                    .map(sk -> GlskPointScalableConverter.convert(network, List.of(sk)))
+                    .collect(Collectors.toList());
+                zonalData.put(area, Scalable.upDown(Scalable.stack(scalables.get(0), scalables.get(1)), scalables.get(1)));
+            } else {
+                zonalData.put(area, GlskPointScalableConverter.convert(network, zonalGlskPoint));
+            }
+        }
+        return new ZonalDataImpl<>(zonalData);
+    }
+
+    private boolean isHybridCseGlskPoint(AbstractGlskPoint zonalGlskPoint) {
+        // If 2 shift keys have different orders, this is a hybrid glsk for Swiss's ID CSE GSK.
+        return zonalGlskPoint.getGlskShiftKeys().size() == 2 &&
+            ((CseGlskShiftKey) zonalGlskPoint.getGlskShiftKeys().get(0)).getOrder() !=
+                ((CseGlskShiftKey) zonalGlskPoint.getGlskShiftKeys().get(1)).getOrder();
+    }
+
+    @Override
+    public ZonalData<Scalable> getZonalScalable(Network network, Instant instant) {
+        throw new NotImplementedException("CSE GLSK document does only support hourly data");
+    }
+
+    @Override
+    public ZonalDataChronology<Scalable> getZonalScalableChronology(Network network) {
+        throw new NotImplementedException("CSE GLSK document does only support hourly data");
     }
 }

--- a/data/glsk/glsk-document-cse/src/main/java/com/farao_community/farao/data/glsk/cse/CseGlskShiftKey.java
+++ b/data/glsk/glsk-document-cse/src/main/java/com/farao_community/farao/data/glsk/cse/CseGlskShiftKey.java
@@ -20,6 +20,9 @@ import java.util.Optional;
  * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
  */
 public class CseGlskShiftKey extends AbstractGlskShiftKey {
+    private static final int DEFAULT_ORDER = 0;
+
+    private int order = DEFAULT_ORDER;
 
     public CseGlskShiftKey(Element glskBlockElement, String businessType, Interval pointInterval, String subjectDomainmRID) {
         initCommonMemberVariables(glskBlockElement, businessType, pointInterval, subjectDomainmRID);
@@ -99,10 +102,38 @@ public class CseGlskShiftKey extends AbstractGlskShiftKey {
         } else {
             throw new GlskException("in GlskShiftKey UCTE constructor: unknown ucteBusinessType: " + businessType);
         }
-        this.quantity = Double.valueOf(((Element) glskBlockElement.getElementsByTagName("Factor").item(0)).getAttribute("v"));
         this.glskShiftKeyInterval = pointInterval;
         this.subjectDomainmRID = subjectDomainmRID;
         this.registeredResourceArrayList = new ArrayList<>();
+        if (isPartOfHybridShiftKey(glskBlockElement)) {
+            this.order = getOrder(glskBlockElement);
+            if (hasMaximumShift(glskBlockElement)) {
+                this.maximumShift = getMaximumShift(glskBlockElement);
+            }
+        } else {
+            this.quantity = getFactor(glskBlockElement);
+        }
+    }
+
+    private static boolean isPartOfHybridShiftKey(Element glskBlockElement) {
+        return glskBlockElement.getElementsByTagName("Order").getLength() != 0;
+    }
+
+    private static int getOrder(Element glskBlockElement) {
+        return Integer.parseInt((glskBlockElement.getElementsByTagName("Order").item(0)).getTextContent());
+    }
+
+    private static boolean hasMaximumShift(Element glskBlockElement) {
+        return glskBlockElement.getElementsByTagName("MaximumShift").getLength() != 0;
+    }
+
+    private static double getMaximumShift(Element glskBlockElement) {
+        //maximum shift in hybrid cse glsk
+        return Double.parseDouble(((Element) glskBlockElement.getElementsByTagName("MaximumShift").item(0)).getAttribute("v"));
+    }
+
+    private static double getFactor(Element glskBlockElement) {
+        return Double.parseDouble(((Element) glskBlockElement.getElementsByTagName("Factor").item(0)).getAttribute("v"));
     }
 
     private void importImplicitProportionalBlock(Element glskBlockElement, String businessType) {
@@ -114,5 +145,9 @@ public class CseGlskShiftKey extends AbstractGlskShiftKey {
             CseGlskRegisteredResource cseRegisteredResource = new CseGlskRegisteredResource(nodeElement);
             registeredResourceArrayList.add(cseRegisteredResource);
         }
+    }
+
+    public int getOrder() {
+        return order;
     }
 }

--- a/data/glsk/glsk-document-cse/src/test/java/com/farao_community/farao/data/glsk/cse/CseGlskDocumentImporterTest.java
+++ b/data/glsk/glsk-document-cse/src/test/java/com/farao_community/farao/data/glsk/cse/CseGlskDocumentImporterTest.java
@@ -66,12 +66,28 @@ public class CseGlskDocumentImporterTest {
         Scalable reserveScalable = glskDocument.getZonalScalable(network).getData("FR_RESERVE");
 
         assertNotNull(reserveScalable);
-        assertEquals(2000., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
-        assertEquals(2000., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
 
-        reserveScalable.scale(network, -900.);
-        assertEquals(1400., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
-        assertEquals(1700., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(-900, reserveScalable.scale(network, -900), EPSILON);
+        assertEquals(1400, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(1700, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+    }
+
+    @Test
+    public void checkCseGlskDocumentImporterCorrectlyConvertReserveGskBlocksDownWithReachingLimits() {
+        Network network = Importers.loadNetwork("testCase.xiidm", getClass().getResourceAsStream("/testCase.xiidm"));
+        GlskDocument glskDocument = GlskDocumentImporters.importGlsk(getClass().getResourceAsStream("/testGlsk.xml"));
+        Scalable reserveScalable = glskDocument.getZonalScalable(network).getData("FR_RESERVE");
+
+        assertNotNull(reserveScalable);
+        assertEquals(2000, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+
+        // 1000 MW missing for down-scaling
+        assertEquals(-3000, reserveScalable.scale(network, -4000), EPSILON);
+        assertEquals(0, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(1000, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
     }
 
     @Test
@@ -81,12 +97,28 @@ public class CseGlskDocumentImporterTest {
         Scalable reserveScalable = glskDocument.getZonalScalable(network).getData("FR_RESERVE");
 
         assertNotNull(reserveScalable);
-        assertEquals(2000., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
-        assertEquals(2000., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
 
-        reserveScalable.scale(network, 1000.);
-        assertEquals(2600., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
-        assertEquals(2400., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(1000, reserveScalable.scale(network, 1000), EPSILON);
+        assertEquals(2600, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2400, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+    }
+
+    @Test
+    public void checkCseGlskDocumentImporterCorrectlyConvertReserveGskBlocksUpWithReachingLimits() {
+        Network network = Importers.loadNetwork("testCase.xiidm", getClass().getResourceAsStream("/testCase.xiidm"));
+        GlskDocument glskDocument = GlskDocumentImporters.importGlsk(getClass().getResourceAsStream("/testGlsk.xml"));
+        Scalable reserveScalable = glskDocument.getZonalScalable(network).getData("FR_RESERVE");
+
+        assertNotNull(reserveScalable);
+        assertEquals(2000, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+
+        // 1000 MW missing for up-scaling
+        assertEquals(5000, reserveScalable.scale(network, 6000), EPSILON);
+        assertEquals(5000, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(4000, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
     }
 
     @Test

--- a/data/glsk/glsk-document-cse/src/test/java/com/farao_community/farao/data/glsk/cse/CseGlskDocumentImporterTest.java
+++ b/data/glsk/glsk-document-cse/src/test/java/com/farao_community/farao/data/glsk/cse/CseGlskDocumentImporterTest.java
@@ -12,6 +12,7 @@ import com.farao_community.farao.data.glsk.api.io.GlskDocumentImporters;
 import com.powsybl.action.util.Scalable;
 import com.powsybl.iidm.import_.Importers;
 import com.powsybl.iidm.network.Network;
+import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Test;
 
 import java.util.List;
@@ -313,5 +314,19 @@ public class CseGlskDocumentImporterTest {
         assertEquals(2000., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
         assertEquals(2000., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
         assertEquals(2500., network.getGenerator("FFR3AA1 _generator").getTargetP(), EPSILON);
+    }
+
+    @Test
+    public void checkConversionToLinearGlskFails() {
+        Network network = Importers.loadNetwork("testCase.xiidm", getClass().getResourceAsStream("/testCase.xiidm"));
+        GlskDocument glskDocument = GlskDocumentImporters.importGlsk(getClass().getResourceAsStream("/testGlsk.xml"));
+        assertThrows(NotImplementedException.class, () -> glskDocument.getZonalGlsks(network));
+    }
+
+    @Test
+    public void checkConversionToChronologicalScalableFails() {
+        Network network = Importers.loadNetwork("testCase.xiidm", getClass().getResourceAsStream("/testCase.xiidm"));
+        GlskDocument glskDocument = GlskDocumentImporters.importGlsk(getClass().getResourceAsStream("/testGlsk.xml"));
+        assertThrows(NotImplementedException.class, () -> glskDocument.getZonalScalableChronology(network));
     }
 }

--- a/data/glsk/glsk-document-cse/src/test/java/com/farao_community/farao/data/glsk/cse/CseGlskDocumentImporterTest.java
+++ b/data/glsk/glsk-document-cse/src/test/java/com/farao_community/farao/data/glsk/cse/CseGlskDocumentImporterTest.java
@@ -264,4 +264,54 @@ public class CseGlskDocumentImporterTest {
         assertEquals(6000., network.getGenerator("FFR3AA1 _generator").getTargetP(), EPSILON);
     }
 
+    @Test
+    public void checkCseGlskDocumentImporterWithHybridGskBelowMaximumShift() {
+        Network network = Importers.loadNetwork("testCase.xiidm", getClass().getResourceAsStream("/testCase.xiidm"));
+        GlskDocument glskDocument = GlskDocumentImporters.importGlsk(getClass().getResourceAsStream("/testGlskHybrid.xml"));
+        Scalable meritOrderGskScalable = glskDocument.getZonalScalable(network).getData("10YCH-SWISSGRIDZ");
+
+        assertNotNull(meritOrderGskScalable);
+        assertEquals(2000., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(3000., network.getGenerator("FFR3AA1 _generator").getTargetP(), EPSILON);
+
+        meritOrderGskScalable.scale(network, 1000.);
+        assertEquals(2500., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2500., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(3000., network.getGenerator("FFR3AA1 _generator").getTargetP(), EPSILON);
+    }
+
+    @Test
+    public void checkCseGlskDocumentImporterWithHybridGskAboveMaximumShift() {
+        Network network = Importers.loadNetwork("testCase.xiidm", getClass().getResourceAsStream("/testCase.xiidm"));
+        GlskDocument glskDocument = GlskDocumentImporters.importGlsk(getClass().getResourceAsStream("/testGlskHybrid.xml"));
+        Scalable meritOrderGskScalable = glskDocument.getZonalScalable(network).getData("10YCH-SWISSGRIDZ");
+
+        assertNotNull(meritOrderGskScalable);
+        assertEquals(2000., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(3000., network.getGenerator("FFR3AA1 _generator").getTargetP(), EPSILON);
+
+        meritOrderGskScalable.scale(network, 1500.);
+        assertEquals(2500., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2500., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(3500., network.getGenerator("FFR3AA1 _generator").getTargetP(), EPSILON);
+    }
+
+    @Test
+    public void checkCseGlskDocumentImporterWithHybridGskGoingDown() {
+        Network network = Importers.loadNetwork("testCase.xiidm", getClass().getResourceAsStream("/testCase.xiidm"));
+        GlskDocument glskDocument = GlskDocumentImporters.importGlsk(getClass().getResourceAsStream("/testGlskHybrid.xml"));
+        Scalable meritOrderGskScalable = glskDocument.getZonalScalable(network).getData("10YCH-SWISSGRIDZ");
+
+        assertNotNull(meritOrderGskScalable);
+        assertEquals(2000., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(3000., network.getGenerator("FFR3AA1 _generator").getTargetP(), EPSILON);
+
+        meritOrderGskScalable.scale(network, -500.);
+        assertEquals(2000., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2500., network.getGenerator("FFR3AA1 _generator").getTargetP(), EPSILON);
+    }
 }

--- a/data/glsk/glsk-document-cse/src/test/resources/testGlskHybrid.xml
+++ b/data/glsk/glsk-document-cse/src/test/resources/testGlskHybrid.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GSKDocument DtdVersion="5" DtdRelease="0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="gsk-document.xsd">
+    <DocumentIdentification v="testGlsk"/>
+    <DocumentVersion v="1"/>
+    <DocumentType v="Z02"/>
+    <ProcessType v="Z02"/>
+    <SenderIdentification v="XXXXXXXXXXXXXXXX" codingScheme="A01"/>
+    <SenderRole v="A36"/>
+    <ReceiverIdentification v="XXXXXXXXXXXXXXXX" codingScheme="A01"/>
+    <ReceiverRole v="A04"/>
+    <CreationDateTime v="2020-09-15T17:59:09Z"/>
+    <GSKTimeInterval v="2020-09-16T22:00Z/2020-09-16T23:00Z"/>
+    <Domain v="10YDOM-1001A061T" codingScheme="A01"/>
+    <TimeSeries>
+        <TimeSeriesIdentification v="1"/>
+        <BusinessType v="Z02"/>
+        <Area v="10YCH-SWISSGRIDZ" codingScheme="A01" />
+        <Name v="CH" />
+        <TimeInterval v="2020-09-16T22:00Z/2020-09-16T22:59Z"/>
+        <PropGSKBlock>
+            <Order>1</Order>
+            <MaximumShift v="1000" />
+<!--            <Factor v="1"/>-->
+            <Node>
+                <Name v="FFR1AA1 "/>
+            </Node>
+            <Node>
+                <Name v="FFR2AA1 "/>
+            </Node>
+        </PropGSKBlock>
+        <ReserveGSKBlock>
+            <Order>2</Order>
+<!--            <Factor v="1"/>-->
+            <Node>
+                <Name v="FFR3AA1 "/>
+                <Pmin v="0"/>
+                <Pmax v="-5000"/>
+            </Node>
+        </ReserveGSKBlock>
+    </TimeSeries>
+    <TimeSeries>
+        <TimeSeriesIdentification v="1"/>
+        <BusinessType v="Z02"/>
+        <Area v="FR_MANUAL" codingScheme="A01"/>
+        <Name v="FR_MANUAL"/>
+        <TimeInterval v="2020-09-16T22:00Z/2020-09-16T22:59Z"/>
+        <ManualGSKBlock>
+            <Factor v="1"/>
+            <Node>
+                <Name v="FFR1AA1 "/>
+                <Factor v="70"/>
+            </Node>
+            <Node>
+                <Name v="FFR3AA1 "/>
+                <Factor v="30"/>
+            </Node>
+        </ManualGSKBlock>
+    </TimeSeries>
+</GSKDocument>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Change on how to interpret CSE GLSK in the special case of what we call "hybrid GLSK". For one area there are 2 GLSKs that are stacked, first one is a proportional limited by a maximum value and second one is a reserve block. Fix on reserve blocks where scalable on generator must be limited by the Pmin/Pmax values present in the block for each generator, and the global proportional scalable must be iterative to be able to reach the target properly.


**What is the current behavior?** *(You can also link to an open issue here)*
Hybrid GSK is not handled and there is a bug on scalables from reserve blocks.


**What is the new behavior (if this is a feature change)?**
Handle hybrid GSK and fix reserve blocks