### PR TITLE
Change behaviour of the sensitivity threshold in relative margin

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeProblem.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeProblem.java
@@ -65,9 +65,7 @@ public class SearchTreeProblem {
                 prePerimeterSetPoints,
                 linearOptimizerParameters.getPstSensitivityThreshold(),
                 linearOptimizerParameters.getHvdcSensitivityThreshold(),
-                linearOptimizerParameters.getInjectionSensitivityThreshold(),
-                linearOptimizerParameters.getObjectiveFunction().relativePositiveMargins()
-        );
+                linearOptimizerParameters.getInjectionSensitivityThreshold());
     }
 
     protected ProblemFiller createMaxMinRelativeMarginFiller(Set<FlowCnec> flowCnecs, Set<RangeAction<?>> rangeActions, FlowResult preOptimFlowResult) {

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/ContinuousRangeActionGroupFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/ContinuousRangeActionGroupFillerTest.java
@@ -51,9 +51,7 @@ public class ContinuousRangeActionGroupFillerTest extends AbstractFillerTest {
                 initialRangeActionResult,
                 0.,
                 0.,
-                0.,
-                false
-        );
+                0.);
 
         ContinuousRangeActionGroupFiller continuousRangeActionGroupFiller = new ContinuousRangeActionGroupFiller(
                 Set.of(pstRa1, pstRa2)

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFillerTest.java
@@ -59,14 +59,14 @@ public class CoreProblemFillerTest extends AbstractFillerTest {
     }
 
     private void initializeForPreventive(double pstSensitivityThreshold, double hvdcSensitivityThreshold, double injectionSensitivityThreshold) {
-        initialize(cnec1, pstSensitivityThreshold, hvdcSensitivityThreshold, injectionSensitivityThreshold, false);
+        initialize(cnec1, pstSensitivityThreshold, hvdcSensitivityThreshold, injectionSensitivityThreshold);
     }
 
     private void initializeForCurative() {
-        initialize(cnec2, 0, 0, 0, false);
+        initialize(cnec2, 0, 0, 0);
     }
 
-    private void initialize(FlowCnec cnec, double pstSensitivityThreshold, double hvdcSensitivityThreshold, double injectionSensitivityThreshold, boolean relativePositiveMargins) {
+    private void initialize(FlowCnec cnec, double pstSensitivityThreshold, double hvdcSensitivityThreshold, double injectionSensitivityThreshold) {
         coreProblemFiller = new CoreProblemFiller(
                 network,
                 Set.of(cnec),
@@ -74,9 +74,7 @@ public class CoreProblemFillerTest extends AbstractFillerTest {
                 initialRangeActionResult,
                 pstSensitivityThreshold,
                 hvdcSensitivityThreshold,
-                injectionSensitivityThreshold,
-                relativePositiveMargins
-        );
+                injectionSensitivityThreshold);
         buildLinearProblem();
     }
 
@@ -368,9 +366,7 @@ public class CoreProblemFillerTest extends AbstractFillerTest {
                 initialRangeActionResult,
                 0.,
                 0.,
-                0.,
-                false
-        );
+                0.);
         linearProblem = new LinearProblem(List.of(coreProblemFiller), mpSolver);
         try {
             updateLinearProblem();
@@ -389,7 +385,7 @@ public class CoreProblemFillerTest extends AbstractFillerTest {
 
         // (sensi = 2) < 2.5 should be filtered
         when(flowResult.getMargin(cnec1, Unit.MEGAWATT)).thenReturn(-1.0);
-        initialize(cnec1, 2.5, 2.5, 2.5, true);
+        initialize(cnec1, 2.5, 2.5, 2.5);
         flowConstraint = linearProblem.getFlowConstraint(cnec1);
         rangeActionSetpoint = linearProblem.getRangeActionSetpointVariable(pstRangeAction);
         assertEquals(0, flowConstraint.getCoefficient(rangeActionSetpoint), DOUBLE_TOLERANCE);
@@ -406,7 +402,7 @@ public class CoreProblemFillerTest extends AbstractFillerTest {
 
         // (sensi = 2) > 1/.5 should not be filtered
         when(flowResult.getMargin(cnec1, Unit.MEGAWATT)).thenReturn(-1.0);
-        initialize(cnec1, 1.5, 1.5, 1.5, true);
+        initialize(cnec1, 1.5, 1.5, 1.5);
         flowConstraint = linearProblem.getFlowConstraint(cnec1);
         rangeActionSetpoint = linearProblem.getRangeActionSetpointVariable(pstRangeAction);
         assertEquals(-2, flowConstraint.getCoefficient(rangeActionSetpoint), DOUBLE_TOLERANCE);

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/DiscretePstGroupFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/DiscretePstGroupFillerTest.java
@@ -51,9 +51,7 @@ public class DiscretePstGroupFillerTest extends AbstractFillerTest {
                 initialRangeActionResult,
                 0.,
                 0.,
-                0.,
-                false
-        );
+                0.);
 
         DiscretePstTapFiller discretePstTapFiller = new DiscretePstTapFiller(
                 network,

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/DiscretePstTapFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/DiscretePstTapFillerTest.java
@@ -46,8 +46,7 @@ public class DiscretePstTapFillerTest extends AbstractFillerTest {
                 initialRangeActionResult,
                 0.,
                 0.,
-                0.,
-                false);
+                0.);
 
         DiscretePstTapFiller discretePstTapFiller = new DiscretePstTapFiller(
                 network,

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/MaxLoopFlowFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/MaxLoopFlowFillerTest.java
@@ -54,9 +54,7 @@ public class MaxLoopFlowFillerTest extends AbstractFillerTest {
                 initialRangeActionResult,
                 0.,
                 0.,
-                0.,
-                false
-        );
+                0.);
         cnec1.newExtension(LoopFlowThresholdAdder.class).withValue(100.).withUnit(Unit.MEGAWATT).add();
     }
 

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/MaxMinMarginFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/MaxMinMarginFillerTest.java
@@ -50,9 +50,7 @@ public class MaxMinMarginFillerTest extends AbstractFillerTest {
                 initialRangeActionResult,
                 0.,
                 0.,
-                0.,
-                false
-        );
+                0.);
         maxMinMarginParameters = new MaxMinMarginParameters(0.01, 0.01, 0.01);
     }
 

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/MaxMinRelativeMarginFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/MaxMinRelativeMarginFillerTest.java
@@ -57,9 +57,7 @@ public class MaxMinRelativeMarginFillerTest extends AbstractFillerTest {
                 initialRangeActionResult,
                 0.,
                 0.,
-                0.,
-                false
-        );
+                0.);
         parameters = new MaxMinRelativeMarginParameters(0.01, 0.01, 0.01, 1000, 0.01);
     }
 

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/MnecFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/MnecFillerTest.java
@@ -82,9 +82,7 @@ public class MnecFillerTest extends AbstractFillerTest {
                 new RangeActionResultImpl(Collections.emptyMap()),
                 0.,
                 0.,
-                0.,
-                false
-        );
+                0.);
     }
 
     private void fillProblemWithFiller(Unit unit) {

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/UnoptimizedCnecFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/UnoptimizedCnecFillerTest.java
@@ -71,9 +71,7 @@ public class UnoptimizedCnecFillerTest extends AbstractFillerTest {
                 new RangeActionResultImpl(Collections.emptyMap()),
                 0.,
                 0.,
-                0.,
-                false
-        );
+                0.);
     }
 
     private void buildLinearProblemWithMaxMinMargin() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Behavior change


**What is the current behavior?** *(You can also link to an open issue here)*

Previously, in relative margin mode, when the margin was positive, the sensitivity threshold was divided by the sum of PTDFs

So to say, it was used to unconsider the PSTs whose impact on the objective function is below the threshold.

**What is the new behavior (if this is a feature change)?**

Now the sensitivity threshold is considered as is.

The motivation of this change is to keep the same approximation of the flows, whatever the PTDF sum, so that all loop-flows are estimated in a consistent way.
