### PR TITLE
Fix sensitivity adapter with applied RAs

### DIFF
--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityAdapter.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityAdapter.java
@@ -71,6 +71,7 @@ final class SystematicSensitivityAdapter {
         List<Contingency> contingenciesWithoutRa = statesWithoutRa.stream()
             .filter(state -> state.getContingency().isPresent())
             .map(state -> convertCracContingencyToPowsybl(state.getContingency().get(), network))
+            .distinct()
             .collect(Collectors.toList());
 
         SystematicSensitivityResult result = new SystematicSensitivityResult();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
In 2nd preventive RAO, the SystematicSensitivityAdapter can ask for sensitivities multiple times on the same contingency. This can cause Hades2 to fail 


**What is the new behavior (if this is a feature change)?**
Ask for distinct contingencies

