### PR TITLE
Store range actions in TreeSets for fillers instead of HashSets

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblemBuilder.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblemBuilder.java
@@ -222,7 +222,9 @@ public class LinearProblemBuilder {
         Map<State, Set<RangeAction<?>>> outRangeActions = new HashMap<>();
         inRangeActions.forEach((state, rangeActions) -> {
             if (rangeActions.stream().anyMatch(ra -> !(ra instanceof PstRangeAction))) {
-                outRangeActions.put(state, rangeActions.stream().filter(ra -> !(ra instanceof PstRangeAction)).collect(Collectors.toSet()));
+                outRangeActions.put(state, rangeActions.stream().filter(ra -> !(ra instanceof PstRangeAction)).collect(Collectors.toCollection(
+                    () -> new TreeSet<>(Comparator.comparing(RangeAction::getId))
+                )));
             }
         });
         return outRangeActions;
@@ -232,7 +234,9 @@ public class LinearProblemBuilder {
         Map<State, Set<PstRangeAction>> outRangeActions = new TreeMap<>(Comparator.comparing(State::getId));
         inRangeActions.forEach((state, rangeActions) -> {
             if (rangeActions.stream().anyMatch(PstRangeAction.class::isInstance)) {
-                outRangeActions.put(state, rangeActions.stream().filter(PstRangeAction.class::isInstance).map(PstRangeAction.class::cast).collect(Collectors.toSet()));
+                outRangeActions.put(state, rangeActions.stream().filter(PstRangeAction.class::isInstance).map(PstRangeAction.class::cast).collect(Collectors.toCollection(
+                    () -> new TreeSet<>(Comparator.comparing(PstRangeAction::getId))
+                )));
             }
         });
         return outRangeActions;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The range actions are stored in a HashSet for a couple fillers, which means the LP's constraints are not always ordered in the same way, making it non reproducible.


**What is the new behavior (if this is a feature change)?**
They are now stored in a TreeSet, fixing the issue.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
