### PR TITLE
if virtual cost is positive, stop criterion returns false

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -422,6 +422,9 @@ public class SearchTree {
      * @return True if the stop criterion has been reached on this leaf.
      */
     private boolean stopCriterionReached(Leaf leaf) {
+        if (leaf.getVirtualCost() > 1e-6) {
+            return false;
+        }
         if (purelyVirtual && leaf.getVirtualCost() < 1e-6) {
             TECHNICAL_LOGS.debug("Perimeter is purely virtual and virtual cost is zero. Exiting search tree.");
             return true;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix?


**What is the current behavior?** *(You can also link to an open issue here)*
The stop criterion can be satisfied even if mnec or LF constraints are violated as long as the total cost (functional cost + virtual cost) is low enough.


**What is the new behavior (if this is a feature change)?**
We want to always try to satisfy mnecs and LF constraints.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
