### PR TITLE
Fix CIM HVDC import

### DIFF
--- a/data/crac-creation/crac-creator-cim/src/main/java/com/farao_community/farao/data/crac_creation/creator/cim/crac_creator/remedial_action/HvdcRangeActionCreator.java
+++ b/data/crac-creation/crac-creator-cim/src/main/java/com/farao_community/farao/data/crac_creation/creator/cim/crac_creator/remedial_action/HvdcRangeActionCreator.java
@@ -367,8 +367,8 @@ public class HvdcRangeActionCreator {
             hvdcRemedialActionSeriesCreationContexts.add(RemedialActionSeriesCreationContext.notImported(cimSerieId, ImportStatus.ELEMENT_NOT_FOUND_IN_NETWORK, "Not a HVDC line"));
             return Pair.of(List.of(false, false), List.of(0, 0));
         }
-        String from = hvdcLine.getConverterStation1().getTerminal().getBusBreakerView().getBus().getId();
-        String to = hvdcLine.getConverterStation2().getTerminal().getBusBreakerView().getBus().getId();
+        String from = hvdcLine.getConverterStation1().getTerminal().getVoltageLevel().getId();
+        String to = hvdcLine.getConverterStation2().getTerminal().getVoltageLevel().getId();
 
         if (Objects.isNull(inNode) || Objects.isNull(outNode)) {
             hvdcRemedialActionSeriesCreationContexts.add(RemedialActionSeriesCreationContext.notImported(cimSerieId, ImportStatus.INCOMPLETE_DATA, "Missing HVDC in or out aggregate nodes"));

--- a/data/crac-creation/crac-creator-cim/src/test/resources/cracs/CIM_21_6_1.xml
+++ b/data/crac-creation/crac-creator-cim/src/test/resources/cracs/CIM_21_6_1.xml
@@ -82,8 +82,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -104,8 +104,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -133,8 +133,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">BBE2AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">FFR3AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">BBE2AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">FFR3AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1000.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -155,8 +155,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">BBE2AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">FFR3AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">BBE2AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">FFR3AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1000.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -200,8 +200,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -222,8 +222,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -251,8 +251,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -273,8 +273,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -302,8 +302,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">BBE2AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">FFR3AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">BBE2AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">FFR3AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1000.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -324,8 +324,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">BBE2AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">FFR3AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">BBE2AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">FFR3AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1000.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -377,8 +377,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -399,8 +399,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -428,8 +428,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">BBE2AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">FFR3AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">BBE2AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">FFR3AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1000.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -450,8 +450,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">BBE2AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">FFR3AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">BBE2AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">FFR3AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1000.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -495,8 +495,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -517,8 +517,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">BBE2AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">FFR3AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">BBE2AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">FFR3AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -546,8 +546,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">BBE2AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">FFR3AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">BBE2AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">FFR3AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1000.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -568,8 +568,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">BBE2AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">FFR3AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">BBE2AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">FFR3AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1000.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -613,8 +613,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>200</resourceCapacity.minimumCapacity>
@@ -635,8 +635,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>200</resourceCapacity.minimumCapacity>
@@ -664,8 +664,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">BBE2AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">FFR3AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">BBE2AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">FFR3AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1000.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -686,8 +686,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">BBE2AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">FFR3AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">BBE2AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">FFR3AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1000.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -731,8 +731,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -753,8 +753,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -782,8 +782,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">BBE2AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">FFR3AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">BBE2AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">FFR3AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1000.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -804,8 +804,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">BBE2AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">FFR3AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">BBE2AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">FFR3AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1000.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -849,8 +849,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -871,8 +871,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -900,8 +900,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">BBE2AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">FFR3AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">BBE2AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">FFR3AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1000.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -922,8 +922,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">BBE2AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">FFR3AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">BBE2AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">FFR3AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1000.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -967,8 +967,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -989,8 +989,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -1018,8 +1018,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">BBE2AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">FFR3AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">BBE2AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">FFR3AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1000.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -1040,8 +1040,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">BBE2AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">FFR3AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">BBE2AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">FFR3AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1000.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -1085,8 +1085,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A23</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -1107,8 +1107,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -1203,8 +1203,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA11</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA11</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>
@@ -1225,8 +1225,8 @@
               <pSRType.psrType>B22</pSRType.psrType>
               <in_Domain.mRID codingScheme="A01">1------C</in_Domain.mRID>
               <out_Domain.mRID codingScheme="A01">1------C</out_Domain.mRID>
-              <in_AggregateNode.mRID codingScheme="A02">FFR3AA12</in_AggregateNode.mRID>
-              <out_AggregateNode.mRID codingScheme="A02">BBE2AA12</out_AggregateNode.mRID>
+              <in_AggregateNode.mRID codingScheme="A02">FFR3AA1</in_AggregateNode.mRID>
+              <out_AggregateNode.mRID codingScheme="A02">BBE2AA1</out_AggregateNode.mRID>
               <marketObjectStatus.status>A26</marketObjectStatus.status>
               <resourceCapacity.maximumCapacity>1500.0</resourceCapacity.maximumCapacity>
               <resourceCapacity.minimumCapacity>0</resourceCapacity.minimumCapacity>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The CIM importer detects the direction of the HVDC using its bus ids


**What is the new behavior (if this is a feature change)?**
It should use the voltage level ID of the VSC station
