### PR TITLE
Fix bug on null RA operator

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
@@ -212,7 +212,7 @@ public final class SearchTreeBloomer {
 
     private boolean exceedMaxNumberOfRaPerTso(NetworkActionCombination naCombination, Map<String, Integer> maxNaPerTso) {
         return naCombination.getOperators().stream().anyMatch(operator -> {
-            int numberOfActionForTso = (int) naCombination.getNetworkActionSet().stream().filter(na -> na.getOperator().equals(operator)).count();
+            int numberOfActionForTso = (int) naCombination.getNetworkActionSet().stream().filter(na -> Objects.nonNull(na.getOperator()) && na.getOperator().equals(operator)).count();
             return numberOfActionForTso > maxNaPerTso.getOrDefault(operator, Integer.MAX_VALUE);
         });
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The bloomer fails when a NetworkAction has a null operator


**What is the new behavior (if this is a feature change)?**
An extra check is made
