### PR TITLE
Bug fix refine tap method

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/DiscretePstTapFiller.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/DiscretePstTapFiller.java
@@ -136,7 +136,7 @@ public class DiscretePstTapFiller implements ProblemFiller {
         double newAngle = rangeActionActivationResult.getOptimizedSetpoint(pstRangeAction, optimizedState);
         int newTapPosition = rangeActionActivationResult.getOptimizedTap(pstRangeAction, optimizedState);
 
-        double prePerimeterAngle = prePerimeterRangeActionSetpoints.getTap(pstRangeAction);
+        double prePerimeterAngle = prePerimeterRangeActionSetpoints.getSetpoint(pstRangeAction);
         int minAdmissibleTap = Math.min(pstRangeAction.convertAngleToTap(pstRangeAction.getMinAdmissibleSetpoint(prePerimeterAngle)), pstRangeAction.convertAngleToTap(pstRangeAction.getMaxAdmissibleSetpoint(prePerimeterAngle)));
         int maxAdmissibleTap = Math.max(pstRangeAction.convertAngleToTap(pstRangeAction.getMinAdmissibleSetpoint(prePerimeterAngle)), pstRangeAction.convertAngleToTap(pstRangeAction.getMaxAdmissibleSetpoint(prePerimeterAngle)));
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The refine method can crash because we get a tap instead of an angle. In most cases the method will not behave as intended.


**What is the new behavior (if this is a feature change)?**
We use getSetpoint to get the angle.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No


**Other information**:
Added a cucumber test
(if any of the questions/checkboxes don't apply, please delete them entirely)
