### PR TITLE
SearchTree: retain child leaf if stop criterion reached

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -463,6 +463,10 @@ public class SearchTree {
         double previousDepthBestCost = previousDepthOptimalLeaf.getCost();
         double newCost = leaf.getCost();
 
+        if (previousDepthBestCost > newCost && stopCriterionReached(leaf)) {
+            return true;
+        }
+
         return previousDepthBestCost - absoluteImpact > newCost // enough absolute impact
             && (1 - Math.signum(previousDepthBestCost) * relativeImpact) * previousDepthBestCost > newCost; // enough relative impact
     }

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
@@ -301,6 +301,24 @@ public class SearchTreeTest {
     }
 
     @Test
+    public void runAndIterateOnTreeWithSlightlyBetterChildLeafAndStopCriterionReached() throws Exception {
+        raoWithoutLoopFlowLimitation();
+        when(treeParameters.getStopCriterion()).thenReturn(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE);
+        when(treeParameters.getTargetObjectiveValue()).thenReturn(0.0);
+        searchTreeWithOneChildLeaf();
+        Leaf childLeaf = Mockito.mock(Leaf.class);
+        when(searchTreeParameters.getNetworkActionParameters().getAbsoluteNetworkActionMinimumImpactThreshold()).thenReturn(10.);
+
+        double rootLeafCostAfterOptim = 1.;
+        double childLeafCostAfterOptim = -1.;
+
+        mockLeafsCosts(rootLeafCostAfterOptim, childLeafCostAfterOptim, childLeaf);
+
+        OptimizationResult result = searchTree.run().get();
+        assertEquals(childLeaf, result);
+    }
+
+    @Test
     public void optimizeRootLeafWithRangeActions() throws Exception {
         raoWithoutLoopFlowLimitation();
         setStopCriterionAtMinObjective();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
If a network action does not improve the cost enough, it is not retained


**What is the new behavior (if this is a feature change)?**
If a network action reached the stop criterion, it is retained even if it does not improve the cost enough


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
