### PR TITLE
Cnec on dangling line

### DIFF
--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/NetworkElementImpl.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/NetworkElementImpl.java
@@ -71,7 +71,7 @@ public class NetworkElementImpl extends AbstractIdentifiable<NetworkElement> imp
             return Set.of(getSubstationCountry(((Switch) ne).getVoltageLevel().getSubstation()));
         } else if (ne instanceof Injection) {
             return Set.of(getSubstationCountry(((Injection<?>) ne).getTerminal().getVoltageLevel().getSubstation()));
-        } else if (ne instanceof  Bus) {
+        } else if (ne instanceof Bus) {
             return Set.of(getSubstationCountry(((Bus) ne).getVoltageLevel().getSubstation()));
         } else if (ne instanceof VoltageLevel) {
             return Set.of(getSubstationCountry(((VoltageLevel) ne).getSubstation()));
@@ -79,7 +79,7 @@ public class NetworkElementImpl extends AbstractIdentifiable<NetworkElement> imp
             return Set.of(((Substation) ne).getCountry());
         } else if (ne instanceof HvdcLine) {
             return Set.of(getSubstationCountry(((HvdcLine) ne).getConverterStation1().getTerminal().getVoltageLevel().getSubstation()), getSubstationCountry(((HvdcLine) ne).getConverterStation2().getTerminal().getVoltageLevel().getSubstation()));
-        }  else {
+        } else {
             throw new NotImplementedException("Don't know how to figure out the location of " + ne.getId() + " of type " + ne.getClass());
         }
     }

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/LoadflowProvider.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/LoadflowProvider.java
@@ -152,6 +152,11 @@ public class LoadflowProvider extends AbstractSimpleSensitivityProvider {
                 }
             }
             return sensitivityFunctions;
+        } else if (networkIdentifiable instanceof DanglingLine) {
+            // Sensitivity computers do not handle DanglingLines
+            // DanglingLines should be considered as disconnected lines, so we just have to ignore them and the
+            // SystematicSensitivityResult will return a flow and a sensitivity equal to 0
+            return Collections.emptyList();
         } else {
             throw new FaraoException("Unable to create sensitivity function for " + id);
         }

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/PtdfSensitivityProvider.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/PtdfSensitivityProvider.java
@@ -13,6 +13,7 @@ import com.powsybl.contingency.ContingencyContext;
 import com.powsybl.contingency.ContingencyContextType;
 import com.powsybl.glsk.commons.ZonalData;
 import com.farao_community.farao.data.crac_api.cnec.FlowCnec;
+import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.sensitivity.SensitivityFactor;
 import com.powsybl.sensitivity.SensitivityFunctionType;
@@ -56,6 +57,7 @@ public class PtdfSensitivityProvider extends AbstractSimpleSensitivityProvider {
             .filter(cnec -> cnec.getState().getContingency().isEmpty())
             .map(FlowCnec::getNetworkElement)
             .distinct()
+            .filter(networkElement -> network.getIdentifiable(networkElement.getId()) instanceof Branch)
             .forEach(ne -> mapCountryLinearGlsk.values().stream()
                 .map(linearGlsk -> new SensitivityFactor(SensitivityFunctionType.BRANCH_ACTIVE_POWER_1, ne.getId(),
                     SensitivityVariableType.INJECTION_ACTIVE_POWER, linearGlsk.getId(),
@@ -77,6 +79,7 @@ public class PtdfSensitivityProvider extends AbstractSimpleSensitivityProvider {
                 .filter(cnec -> cnec.getState().getContingency().isPresent() && cnec.getState().getContingency().get().getId().equals(contingency.getId()))
                 .map(FlowCnec::getNetworkElement)
                 .distinct()
+                .filter(networkElement -> network.getIdentifiable(networkElement.getId()) instanceof Branch)
                 .forEach(ne -> mapCountryLinearGlsk.values().stream()
                     .map(linearGlsk -> new SensitivityFactor(SensitivityFunctionType.BRANCH_ACTIVE_POWER_1, ne.getId(),
                         SensitivityVariableType.INJECTION_ACTIVE_POWER, linearGlsk.getId(),

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityResult.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityResult.java
@@ -165,8 +165,7 @@ public class SystematicSensitivityResult {
     public double getSensitivityOnFlow(String variableId, FlowCnec cnec) {
         StateResult stateResult = getCnecStateResult(cnec);
         if (stateResult == null ||
-            !stateResult.getFlowSensitivities().containsKey(cnec.getNetworkElement().getId()) ||
-            !stateResult.getFlowSensitivities().get(cnec.getNetworkElement().getId()).containsKey(variableId)) {
+            !stateResult.getFlowSensitivities().containsKey(cnec.getNetworkElement().getId())) {
             return 0.0;
         }
         Map<String, Double> sensitivities = stateResult.getFlowSensitivities().get(cnec.getNetworkElement().getId());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
The sensitivity providers cannot compute flows and sensitivities on dangling lines. Thus CNECs defined on dangling lines cause the RAO to crash.


**What is the new behavior (if this is a feature change)?**
Now, these CNECs are filtered out of the sensitivity computation and their flows and sensitivities are implicitly considered equal to zero. This is okay because when only a dangling line exists (instead of being part of a tie line), it should be considered as a disconnected tie line.

