### PR TITLE
Fix PST & RangeAction result import from JSON

### DIFF
--- a/data/rao-result/rao-result-impl/src/main/java/com/farao_community/farao/data/rao_result_impl/PstRangeActionResult.java
+++ b/data/rao-result/rao-result-impl/src/main/java/com/farao_community/farao/data/rao_result_impl/PstRangeActionResult.java
@@ -18,26 +18,24 @@ import java.util.Objects;
  */
 public class PstRangeActionResult extends RangeActionResult {
 
-    private Integer preOptimTap;
+    private int initialTap;
+    private Integer postPraTap;
     private final Map<State, Integer> tapPerState;
 
     public PstRangeActionResult() {
         super();
-        preOptimTap = null;
         tapPerState = new HashMap<>();
-    }
-
-    public int getPreOptimTap() {
-        return preOptimTap;
     }
 
     public int getPreOptimizedTapOnState(State state) {
         // does not handle RA applicable on OUTAGE instant
         // does only handle RA applicable in PREVENTIVE and CURATIVE instant
-        if (!state.getInstant().equals(Instant.PREVENTIVE) && Objects.nonNull(preventiveState)) {
+        if (!state.getInstant().equals(Instant.PREVENTIVE) && Objects.nonNull(preventiveState) && tapPerState.containsKey(preventiveState)) {
             return tapPerState.get(preventiveState);
+        } else if (!state.getInstant().equals(Instant.PREVENTIVE) && postPraTap != null) {
+            return postPraTap;
         }
-        return preOptimTap;
+        return initialTap;
     }
 
     public int getOptimizedTapOnState(State state) {
@@ -45,14 +43,12 @@ public class PstRangeActionResult extends RangeActionResult {
         // does only handle RA applicable in PREVENTIVE and CURATIVE instant
         if (tapPerState.containsKey(state)) {
             return tapPerState.get(state);
-        } else if (!state.getInstant().equals(Instant.PREVENTIVE) && Objects.nonNull(preventiveState)) {
+        } else if (!state.getInstant().equals(Instant.PREVENTIVE) && Objects.nonNull(preventiveState) && tapPerState.containsKey(preventiveState)) {
             return tapPerState.get(preventiveState);
+        } else if (postPraTap != null) {
+            return postPraTap;
         }
-        return preOptimTap;
-    }
-
-    public void setPreOptimTap(int preOptimTap) {
-        this.preOptimTap = preOptimTap;
+        return initialTap;
     }
 
     public void addActivationForState(State state, int tap, double setpoint) {
@@ -61,5 +57,13 @@ public class PstRangeActionResult extends RangeActionResult {
         if (state.isPreventive()) {
             preventiveState = state;
         }
+    }
+
+    public void setInitialTap(int initialTap) {
+        this.initialTap = initialTap;
+    }
+
+    public void setPostPraTap(int postPraTap) {
+        this.postPraTap = postPraTap;
     }
 }

--- a/data/rao-result/rao-result-impl/src/test/java/com/farao_community/farao/data/rao_result_impl/PstRangeActionResultTest.java
+++ b/data/rao-result/rao-result-impl/src/test/java/com/farao_community/farao/data/rao_result_impl/PstRangeActionResultTest.java
@@ -50,32 +50,30 @@ public class PstRangeActionResultTest {
     public void defaultValuesTest() {
         PstRangeActionResult pstRangeActionResult = new PstRangeActionResult();
 
-        assertEquals(Double.NaN, pstRangeActionResult.getPreOptimSetpoint());
-
         assertFalse(pstRangeActionResult.isActivatedDuringState(crac.getPreventiveState()));
         assertFalse(pstRangeActionResult.isActivatedDuringState(crac.getState("Contingency FR1 FR2", OUTAGE)));
         assertFalse(pstRangeActionResult.isActivatedDuringState(crac.getState("Contingency FR1 FR3", OUTAGE)));
         assertFalse(pstRangeActionResult.isActivatedDuringState(crac.getState("Contingency FR1 FR2", CURATIVE)));
         assertFalse(pstRangeActionResult.isActivatedDuringState(crac.getState("Contingency FR1 FR3", CURATIVE)));
 
+        assertEquals(Double.NaN, pstRangeActionResult.getPreOptimizedSetpointOnState(crac.getPreventiveState()));
+        assertEquals(Double.NaN, pstRangeActionResult.getPreOptimizedSetpointOnState(crac.getState("Contingency FR1 FR2", OUTAGE)));
+        assertEquals(Double.NaN, pstRangeActionResult.getPreOptimizedSetpointOnState(crac.getState("Contingency FR1 FR3", OUTAGE)));
+        assertEquals(Double.NaN, pstRangeActionResult.getPreOptimizedSetpointOnState(crac.getState("Contingency FR1 FR2", CURATIVE)));
+        assertEquals(Double.NaN, pstRangeActionResult.getPreOptimizedSetpointOnState(crac.getState("Contingency FR1 FR3", CURATIVE)));
+
         assertEquals(Double.NaN, pstRangeActionResult.getOptimizedSetpointOnState(crac.getPreventiveState()));
         assertEquals(Double.NaN, pstRangeActionResult.getPreOptimizedSetpointOnState(crac.getState("Contingency FR1 FR3", CURATIVE)));
-    }
-
-    @Test (expected = NullPointerException.class)
-    public void defaultValuesGetTapTest() {
-        PstRangeActionResult pstRangeActionResult = new PstRangeActionResult();
-
-        // no default value possible, as a int is expected in all the methods of a RaoResult expecting a tap
-        pstRangeActionResult.getPreOptimTap();
     }
 
     @Test
     public void pstActivatedInPreventiveTest() {
         PstRangeActionResult pstRangeActionResult = new PstRangeActionResult();
 
-        pstRangeActionResult.setPreOptimTap(3);
-        pstRangeActionResult.setPreOptimSetPoint(0.3);
+        pstRangeActionResult.setInitialTap(3);
+        pstRangeActionResult.setInitialSetpoint(0.3);
+        pstRangeActionResult.setPostPraTap(33);
+        pstRangeActionResult.setPostPraSetpoint(0.33);
         pstRangeActionResult.addActivationForState(crac.getPreventiveState(), 16, 1.6);
 
         //is activated
@@ -85,9 +83,6 @@ public class PstRangeActionResultTest {
         assertFalse(pstRangeActionResult.isActivatedDuringState(crac.getState("Contingency FR1 FR3", CURATIVE)));
 
         // initial values
-
-        assertEquals(3, pstRangeActionResult.getPreOptimTap());
-        assertEquals(0.3, pstRangeActionResult.getPreOptimSetpoint(), 1e-3);
 
         // preventive state
         assertEquals(3, pstRangeActionResult.getPreOptimizedTapOnState(crac.getPreventiveState()));
@@ -112,8 +107,10 @@ public class PstRangeActionResultTest {
     public void pstActivatedInCurativeTest() {
         PstRangeActionResult pstRangeActionResult = new PstRangeActionResult();
 
-        pstRangeActionResult.setPreOptimTap(3);
-        pstRangeActionResult.setPreOptimSetPoint(0.3);
+        pstRangeActionResult.setInitialTap(3);
+        pstRangeActionResult.setInitialSetpoint(0.3);
+        pstRangeActionResult.setPostPraTap(33);
+        pstRangeActionResult.setPostPraSetpoint(0.33);
         pstRangeActionResult.addActivationForState(crac.getState("Contingency FR1 FR2", CURATIVE), -16, -1.6);
 
         //is activated
@@ -122,42 +119,39 @@ public class PstRangeActionResultTest {
         assertTrue(pstRangeActionResult.isActivatedDuringState(crac.getState("Contingency FR1 FR2", CURATIVE)));
         assertFalse(pstRangeActionResult.isActivatedDuringState(crac.getState("Contingency FR1 FR3", CURATIVE)));
 
-        // initial values
-
-        assertEquals(3, pstRangeActionResult.getPreOptimTap());
-        assertEquals(0.3, pstRangeActionResult.getPreOptimSetpoint(), 1e-3);
-
         // preventive state
         assertEquals(3, pstRangeActionResult.getPreOptimizedTapOnState(crac.getPreventiveState()));
         assertEquals(0.3, pstRangeActionResult.getPreOptimizedSetpointOnState(crac.getPreventiveState()), 1e-3);
-        assertEquals(3, pstRangeActionResult.getOptimizedTapOnState(crac.getPreventiveState()));
-        assertEquals(0.3, pstRangeActionResult.getOptimizedSetpointOnState(crac.getPreventiveState()), 1e-3);
+        assertEquals(33, pstRangeActionResult.getOptimizedTapOnState(crac.getPreventiveState()));
+        assertEquals(0.33, pstRangeActionResult.getOptimizedSetpointOnState(crac.getPreventiveState()), 1e-3);
 
         // outage state
-        assertEquals(3, pstRangeActionResult.getPreOptimizedTapOnState(crac.getState("Contingency FR1 FR2", OUTAGE)));
-        assertEquals(0.3, pstRangeActionResult.getPreOptimizedSetpointOnState(crac.getState("Contingency FR1 FR2", OUTAGE)), 1e-3);
-        assertEquals(3, pstRangeActionResult.getOptimizedTapOnState(crac.getState("Contingency FR1 FR2", OUTAGE)));
-        assertEquals(0.3, pstRangeActionResult.getOptimizedSetpointOnState(crac.getState("Contingency FR1 FR2", OUTAGE)), 1e-3);
+        assertEquals(33, pstRangeActionResult.getPreOptimizedTapOnState(crac.getState("Contingency FR1 FR2", OUTAGE)));
+        assertEquals(0.33, pstRangeActionResult.getPreOptimizedSetpointOnState(crac.getState("Contingency FR1 FR2", OUTAGE)), 1e-3);
+        assertEquals(33, pstRangeActionResult.getOptimizedTapOnState(crac.getState("Contingency FR1 FR2", OUTAGE)));
+        assertEquals(0.33, pstRangeActionResult.getOptimizedSetpointOnState(crac.getState("Contingency FR1 FR2", OUTAGE)), 1e-3);
 
         // curative state
-        assertEquals(3, pstRangeActionResult.getPreOptimizedTapOnState(crac.getState("Contingency FR1 FR2", CURATIVE)));
-        assertEquals(0.3, pstRangeActionResult.getPreOptimizedSetpointOnState(crac.getState("Contingency FR1 FR2", CURATIVE)), 1e-3);
+        assertEquals(33, pstRangeActionResult.getPreOptimizedTapOnState(crac.getState("Contingency FR1 FR2", CURATIVE)));
+        assertEquals(0.33, pstRangeActionResult.getPreOptimizedSetpointOnState(crac.getState("Contingency FR1 FR2", CURATIVE)), 1e-3);
         assertEquals(-16, pstRangeActionResult.getOptimizedTapOnState(crac.getState("Contingency FR1 FR2", CURATIVE)));
         assertEquals(-1.6, pstRangeActionResult.getOptimizedSetpointOnState(crac.getState("Contingency FR1 FR2", CURATIVE)), 1e-3);
 
         // other curative state (not activated
-        assertEquals(3, pstRangeActionResult.getPreOptimizedTapOnState(crac.getState("Contingency FR1 FR3", CURATIVE)));
-        assertEquals(0.3, pstRangeActionResult.getPreOptimizedSetpointOnState(crac.getState("Contingency FR1 FR3", CURATIVE)), 1e-3);
-        assertEquals(3, pstRangeActionResult.getOptimizedTapOnState(crac.getState("Contingency FR1 FR3", CURATIVE)));
-        assertEquals(0.3, pstRangeActionResult.getOptimizedSetpointOnState(crac.getState("Contingency FR1 FR3", CURATIVE)), 1e-3);
+        assertEquals(33, pstRangeActionResult.getPreOptimizedTapOnState(crac.getState("Contingency FR1 FR3", CURATIVE)));
+        assertEquals(0.33, pstRangeActionResult.getPreOptimizedSetpointOnState(crac.getState("Contingency FR1 FR3", CURATIVE)), 1e-3);
+        assertEquals(33, pstRangeActionResult.getOptimizedTapOnState(crac.getState("Contingency FR1 FR3", CURATIVE)));
+        assertEquals(0.33, pstRangeActionResult.getOptimizedSetpointOnState(crac.getState("Contingency FR1 FR3", CURATIVE)), 1e-3);
     }
 
     @Test
     public void pstActivatedInPreventiveAndCurative() {
         PstRangeActionResult pstRangeActionResult = new PstRangeActionResult();
 
-        pstRangeActionResult.setPreOptimTap(3);
-        pstRangeActionResult.setPreOptimSetPoint(0.3);
+        pstRangeActionResult.setInitialTap(3);
+        pstRangeActionResult.setInitialSetpoint(0.3);
+        pstRangeActionResult.setPostPraTap(33);
+        pstRangeActionResult.setPostPraSetpoint(0.33);
         pstRangeActionResult.addActivationForState(crac.getPreventiveState(), 16, 1.6);
         pstRangeActionResult.addActivationForState(crac.getState("Contingency FR1 FR2", CURATIVE), -16, -1.6);
 
@@ -167,11 +161,6 @@ public class PstRangeActionResultTest {
         assertTrue(pstRangeActionResult.isActivatedDuringState(crac.getState("Contingency FR1 FR2", CURATIVE)));
         assertFalse(pstRangeActionResult.isActivatedDuringState(crac.getState("Contingency FR1 FR3", CURATIVE)));
         assertEquals(2, pstRangeActionResult.getStatesWithActivation().size());
-
-        // initial values
-
-        assertEquals(3, pstRangeActionResult.getPreOptimTap());
-        assertEquals(0.3, pstRangeActionResult.getPreOptimSetpoint(), 1e-3);
 
         // preventive state
         assertEquals(3, pstRangeActionResult.getPreOptimizedTapOnState(crac.getPreventiveState()));

--- a/data/rao-result/rao-result-impl/src/test/java/com/farao_community/farao/data/rao_result_impl/RaoResultImplTest.java
+++ b/data/rao-result/rao-result-impl/src/test/java/com/farao_community/farao/data/rao_result_impl/RaoResultImplTest.java
@@ -90,8 +90,10 @@ public class RaoResultImplTest {
         raoResult.getAndCreateIfAbsentNetworkActionResult(na).addActivationForState(crac.getState("Contingency FR1 FR2", Instant.CURATIVE));
 
         PstRangeActionResult pstRangeActionResult = (PstRangeActionResult) raoResult.getAndCreateIfAbsentRangeActionResult(pst);
-        pstRangeActionResult.setPreOptimTap(3);
-        pstRangeActionResult.setPreOptimSetPoint(2.3);
+        pstRangeActionResult.setInitialTap(3);
+        pstRangeActionResult.setInitialSetpoint(2.3);
+        pstRangeActionResult.setPostPraTap(33);
+        pstRangeActionResult.setPostPraSetpoint(32.3);
         pstRangeActionResult.addActivationForState(crac.getPreventiveState(), -7, -3.2);
 
         CostResult costResult = raoResult.getAndCreateIfAbsentCostResult(INITIAL);

--- a/data/rao-result/rao-result-impl/src/test/java/com/farao_community/farao/data/rao_result_impl/utils/ExhaustiveRaoResultCreation.java
+++ b/data/rao-result/rao-result-impl/src/test/java/com/farao_community/farao/data/rao_result_impl/utils/ExhaustiveRaoResultCreation.java
@@ -145,19 +145,19 @@ public final class ExhaustiveRaoResultCreation {
             switch (pstRangeAction.getId()) {
                 case "pstRange1Id":
                     // free to use preventive, activated
-                    prar.setPreOptimTap(0);
-                    prar.setPreOptimSetPoint(0);
+                    prar.setInitialTap(0);
+                    prar.setInitialSetpoint(0);
                     prar.addActivationForState(crac.getPreventiveState(), -7, -3.2);
                     break;
                 case "pstRange2Id":
                     // on flow in preventive state, not activated
-                    prar.setPreOptimTap(3);
-                    prar.setPreOptimSetPoint(1.7);
+                    prar.setInitialTap(3);
+                    prar.setInitialSetpoint(1.7);
                     break;
                 case "pstRange3Id":
                     // on angle in curative state, not activated
-                    prar.setPreOptimTap(2);
-                    prar.setPreOptimSetPoint(1.3);
+                    prar.setInitialTap(2);
+                    prar.setInitialSetpoint(1.3);
                     break;
                 default:
                     // do nothing
@@ -174,12 +174,12 @@ public final class ExhaustiveRaoResultCreation {
             switch (hvdcRangeAction.getId()) {
                 case "hvdcRange1Id":
                     // free to use preventive, activated
-                    hrar.setPreOptimSetPoint(0);
+                    hrar.setInitialSetpoint(0);
                     hrar.addActivationForState(crac.getPreventiveState(), -1000);
                     break;
                 case "hvdcRange2Id":
                     // activated for two curative states
-                    hrar.setPreOptimSetPoint(-100);
+                    hrar.setInitialSetpoint(-100);
                     hrar.addActivationForState(crac.getState("contingency1Id", Instant.CURATIVE), 100);
                     hrar.addActivationForState(crac.getState("contingency2Id", Instant.CURATIVE), 400);
                     break;
@@ -192,7 +192,7 @@ public final class ExhaustiveRaoResultCreation {
         // --- InjectionRangeAction results ---
         // ------------------------------------
         RangeActionResult irar = raoResult.getAndCreateIfAbsentRangeActionResult(crac.getInjectionRangeAction("injectionRange1Id"));
-        irar.setPreOptimSetPoint(100);
+        irar.setInitialSetpoint(100);
         irar.addActivationForState(crac.getState("contingency1Id", Instant.CURATIVE), -300);
 
         return raoResult;

--- a/data/rao-result/rao-result-json/src/main/java/com/farao_community/farao/data/rao_result_json/deserializers/PstRangeActionResultArrayDeserializer.java
+++ b/data/rao-result/rao-result-json/src/main/java/com/farao_community/farao/data/rao_result_json/deserializers/PstRangeActionResultArrayDeserializer.java
@@ -44,8 +44,6 @@ final class PstRangeActionResultArrayDeserializer {
             }
 
             PstRangeActionResult pstRangeActionResult = (PstRangeActionResult) raoResult.getAndCreateIfAbsentRangeActionResult(pstRangeAction);
-            Integer afterPraTap = null;
-            Double afterPraSetpoint = null;
             while (!jsonParser.nextToken().isStructEnd()) {
                 switch (jsonParser.getCurrentName()) {
 
@@ -55,22 +53,22 @@ final class PstRangeActionResultArrayDeserializer {
 
                     case INITIAL_TAP:
                         jsonParser.nextToken();
-                        pstRangeActionResult.setPreOptimTap(jsonParser.getIntValue());
+                        pstRangeActionResult.setInitialTap(jsonParser.getIntValue());
                         break;
 
                     case INITIAL_SETPOINT:
                         jsonParser.nextToken();
-                        pstRangeActionResult.setPreOptimSetPoint(jsonParser.getDoubleValue());
+                        pstRangeActionResult.setInitialSetpoint(jsonParser.getDoubleValue());
                         break;
 
                     case AFTER_PRA_TAP:
                         jsonParser.nextToken();
-                        afterPraTap = jsonParser.getIntValue();
+                        pstRangeActionResult.setPostPraTap(jsonParser.getIntValue());
                         break;
 
                     case AFTER_PRA_SETPOINT:
                         jsonParser.nextToken();
-                        afterPraSetpoint = jsonParser.getDoubleValue();
+                        pstRangeActionResult.setPostPraSetpoint(jsonParser.getDoubleValue());
                         break;
 
                     case STATES_ACTIVATED:
@@ -81,11 +79,6 @@ final class PstRangeActionResultArrayDeserializer {
                     default:
                         throw new FaraoException(String.format("Cannot deserialize RaoResult: unexpected field in %s (%s)", PSTRANGEACTION_RESULTS, jsonParser.getCurrentName()));
                 }
-            }
-            // Do this at the end: for PSTs with afterPraTap and afterPraSetpoint, initial tap/setpoint should be set to afterPra values
-            if (afterPraTap != null && afterPraSetpoint != null) {
-                pstRangeActionResult.setPreOptimTap(afterPraTap);
-                pstRangeActionResult.setPreOptimSetPoint(afterPraSetpoint);
             }
         }
     }

--- a/data/rao-result/rao-result-json/src/main/java/com/farao_community/farao/data/rao_result_json/deserializers/StandardRangeActionResultArrayDeserializer.java
+++ b/data/rao-result/rao-result-json/src/main/java/com/farao_community/farao/data/rao_result_json/deserializers/StandardRangeActionResultArrayDeserializer.java
@@ -49,7 +49,6 @@ final class StandardRangeActionResultArrayDeserializer {
             }
 
             RangeActionResult rangeActionResult = raoResult.getAndCreateIfAbsentRangeActionResult(rangeAction);
-            Double afterPraSetpoint = null;
             while (!jsonParser.nextToken().isStructEnd()) {
                 switch (jsonParser.getCurrentName()) {
 
@@ -59,12 +58,12 @@ final class StandardRangeActionResultArrayDeserializer {
 
                     case INITIAL_SETPOINT:
                         jsonParser.nextToken();
-                        rangeActionResult.setPreOptimSetPoint(jsonParser.getDoubleValue());
+                        rangeActionResult.setInitialSetpoint(jsonParser.getDoubleValue());
                         break;
 
                     case AFTER_PRA_SETPOINT:
                         jsonParser.nextToken();
-                        afterPraSetpoint = jsonParser.getDoubleValue();
+                        rangeActionResult.setPostPraSetpoint(jsonParser.getDoubleValue());
                         break;
 
                     case STATES_ACTIVATED:
@@ -75,10 +74,6 @@ final class StandardRangeActionResultArrayDeserializer {
                     default:
                         throw new FaraoException(String.format("Cannot deserialize RaoResult: unexpected field in %s (%s)", STANDARDRANGEACTION_RESULTS, jsonParser.getCurrentName()));
                 }
-            }
-            // Do this at the end: for rangeAction with afterPraSetpoint, initial setpoint should be set to afterPra values
-            if (afterPraSetpoint != null) {
-                rangeActionResult.setPreOptimSetPoint(afterPraSetpoint);
             }
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The RaoResult json importer does not handle RangeAction results properly


**What is the new behavior (if this is a feature change)?**
Now results are handled properly in order to be able to access pre-optim values at all times

