### PR TITLE
Fix InjectionRa sensitivity computation post-contingency

### DIFF
--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/RangeActionSensitivityProvider.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/RangeActionSensitivityProvider.java
@@ -27,12 +27,12 @@ import java.util.*;
  */
 public class RangeActionSensitivityProvider extends LoadflowProvider {
     private final Set<RangeAction<?>> rangeActions;
-    private List<SensitivityVariableSet> glsks;
+    private final Map<String, SensitivityVariableSet> glsks;
 
     RangeActionSensitivityProvider(Set<RangeAction<?>> rangeActions, Set<FlowCnec> cnecs, Set<Unit> units) {
         super(cnecs, units);
         this.rangeActions = rangeActions;
-        glsks = new ArrayList<>();
+        glsks = new HashMap<>();
     }
 
     @Override
@@ -107,23 +107,24 @@ public class RangeActionSensitivityProvider extends LoadflowProvider {
         Map<String, Float> positiveGlskMap = injectionRangeActionSensiHandler.getPositiveGlskMap();
         Map<String, Float> negativeGlskMap = injectionRangeActionSensiHandler.getNegativeGlskMap();
 
-        if (!positiveGlskMap.isEmpty() && glsks.stream().noneMatch(variable -> variable.getId().equals(injectionRangeActionSensiHandler.getPositiveGlskMapId()))) {
+        if (!positiveGlskMap.isEmpty()) {
             List<WeightedSensitivityVariable> positiveGlsk = injectionRangeActionSensiHandler.rescaleGlskMap(positiveGlskMap);
             sensitivityVariables.put(injectionRangeActionSensiHandler.getPositiveGlskMapId(), SensitivityVariableType.INJECTION_ACTIVE_POWER);
-            glsks.add(new SensitivityVariableSet(injectionRangeActionSensiHandler.getPositiveGlskMapId(), positiveGlsk));
+            glsks.putIfAbsent(injectionRangeActionSensiHandler.getPositiveGlskMapId(), new SensitivityVariableSet(injectionRangeActionSensiHandler.getPositiveGlskMapId(), positiveGlsk));
             glskIds.add(injectionRangeActionSensiHandler.getPositiveGlskMapId());
+
         }
 
-        if (!negativeGlskMap.isEmpty() && glsks.stream().noneMatch(variable -> variable.getId().equals(injectionRangeActionSensiHandler.getNegativeGlskMapId()))) {
+        if (!negativeGlskMap.isEmpty()) {
             List<WeightedSensitivityVariable> negativeGlsk = injectionRangeActionSensiHandler.rescaleGlskMap(negativeGlskMap);
             sensitivityVariables.put(injectionRangeActionSensiHandler.getNegativeGlskMapId(), SensitivityVariableType.INJECTION_ACTIVE_POWER);
-            glsks.add(new SensitivityVariableSet(injectionRangeActionSensiHandler.getNegativeGlskMapId(), negativeGlsk));
+            glsks.putIfAbsent(injectionRangeActionSensiHandler.getNegativeGlskMapId(), new SensitivityVariableSet(injectionRangeActionSensiHandler.getNegativeGlskMapId(), negativeGlsk));
             glskIds.add(injectionRangeActionSensiHandler.getNegativeGlskMapId());
         }
     }
 
     @Override
     public List<SensitivityVariableSet> getVariableSets() {
-        return glsks;
+        return new ArrayList<>(glsks.values());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Pull request #656 introduced a new bug : computing injection RA sensitivities in contingency contexts was deactivated


**What is the new behavior (if this is a feature change)?**
This resolves the issue by limiting the fix from #656 to only preventing double GLSKs

