### PR TITLE
Fix sign on PST ranges during CSE import

### DIFF
--- a/data/crac-creation/crac-creator-cse/src/main/java/com/farao_community/farao/data/crac_creation/creator/cse/remedial_action/TRemedialActionAdder.java
+++ b/data/crac-creation/crac-creator-cse/src/main/java/com/farao_community/farao/data/crac_creation/creator/cse/remedial_action/TRemedialActionAdder.java
@@ -171,11 +171,6 @@ public class TRemedialActionAdder {
             int pstInitialTap = pstHelper.getInitialTap();
             Map<Integer, Double> conversionMap = pstHelper.getTapToAngleConversionMap();
 
-            // Check if transformer is inverted in network, and invert range
-            boolean isInverted = !pstHelper.isInvertedInNetwork(); // POWSYBL actually inverts transformers usually
-            int minTap = isInverted ? -tRemedialAction.getPstRange().getMax().getV() : tRemedialAction.getPstRange().getMin().getV();
-            int maxTap = isInverted ? -tRemedialAction.getPstRange().getMin().getV() : tRemedialAction.getPstRange().getMax().getV();
-
             PstRangeActionAdder pstRangeActionAdder = crac.newPstRangeAction()
                 .withId(id)
                 .withName(tRemedialAction.getName().getV())
@@ -184,14 +179,17 @@ public class TRemedialActionAdder {
                 .withInitialTap(pstInitialTap)
                 .withTapToAngleConversionMap(conversionMap)
                 .newTapRange()
-                .withMinTap(minTap)
-                .withMaxTap(maxTap)
+                .withMinTap(tRemedialAction.getPstRange().getMin().getV())
+                .withMaxTap(tRemedialAction.getPstRange().getMax().getV())
                 .withRangeType(convertRangeType(tRemedialAction.getPstRange().getVariationType()))
                 .add();
 
             addUsageRules(pstRangeActionAdder, tRemedialAction);
             pstRangeActionAdder.add();
             String nativeNetworkElementId = String.format("%1$-8s %2$-8s %3$s", pstHelper.getOriginalFrom(), pstHelper.getOriginalTo(), pstHelper.getSuffix());
+
+            // Check if transformer is inverted in network
+            boolean isInverted = !pstHelper.isInvertedInNetwork(); // POWSYBL actually inverts transformers usually
             String inversionDetail = isInverted ? "PST was inverted to match POWSYBL convention" : null;
             cseCracCreationContext.addRemedialActionCreationContext(CsePstCreationContext.imported(tRemedialAction, nativeNetworkElementId, id, isInverted, inversionDetail));
         });

--- a/data/crac-creation/crac-creator-cse/src/main/java/com/farao_community/farao/data/crac_creation/creator/cse/remedial_action/TRemedialActionAdder.java
+++ b/data/crac-creation/crac-creator-cse/src/main/java/com/farao_community/farao/data/crac_creation/creator/cse/remedial_action/TRemedialActionAdder.java
@@ -187,11 +187,7 @@ public class TRemedialActionAdder {
             addUsageRules(pstRangeActionAdder, tRemedialAction);
             pstRangeActionAdder.add();
             String nativeNetworkElementId = String.format("%1$-8s %2$-8s %3$s", pstHelper.getOriginalFrom(), pstHelper.getOriginalTo(), pstHelper.getSuffix());
-
-            // Check if transformer is inverted in network
-            boolean isInverted = !pstHelper.isInvertedInNetwork(); // POWSYBL actually inverts transformers usually
-            String inversionDetail = isInverted ? "PST was inverted to match POWSYBL convention" : null;
-            cseCracCreationContext.addRemedialActionCreationContext(CsePstCreationContext.imported(tRemedialAction, nativeNetworkElementId, id, isInverted, inversionDetail));
+            cseCracCreationContext.addRemedialActionCreationContext(CsePstCreationContext.imported(tRemedialAction, nativeNetworkElementId, id, false, null));
         });
     }
 

--- a/data/crac-creation/crac-creator-cse/src/test/java/com/farao_community/farao/data/crac_creation/creator/cse/CseCracCreatorTest.java
+++ b/data/crac-creation/crac-creator-cse/src/test/java/com/farao_community/farao/data/crac_creation/creator/cse/CseCracCreatorTest.java
@@ -416,7 +416,7 @@ public class CseCracCreatorTest {
         assertTrue(pstContext.isImported());
         assertEquals("ra_2", pstContext.getNativeId());
         assertEquals("PST_ra_2_BBE2AA1  BBE3AA1  1", pstContext.getCreatedRAId());
-        assertTrue(pstContext.isInverted());
+        assertFalse(pstContext.isInverted());
         assertFalse(pstContext.isAltered());
         assertEquals("BBE3AA1  BBE2AA1  1", pstContext.getNativeNetworkElementId());
         pstRangeAction = importedCrac.getPstRangeAction(pstContext.getCreatedRAId());

--- a/data/crac-creation/crac-creator-cse/src/test/java/com/farao_community/farao/data/crac_creation/creator/cse/CseCracCreatorTest.java
+++ b/data/crac-creation/crac-creator-cse/src/test/java/com/farao_community/farao/data/crac_creation/creator/cse/CseCracCreatorTest.java
@@ -410,7 +410,7 @@ public class CseCracCreatorTest {
         assertEquals(-2, pstRangeAction.getRanges().get(0).getMinTap());
         assertEquals(10, pstRangeAction.getRanges().get(0).getMaxTap());
 
-        // ra_2 should be inverted
+        // ra_2 should be inverted but range remains the same (just aligns on network direction)
         assertTrue(cracCreationContext.getRemedialActionCreationContext("ra_2") instanceof CsePstCreationContext);
         pstContext = (CsePstCreationContext) cracCreationContext.getRemedialActionCreationContext("ra_2");
         assertTrue(pstContext.isImported());
@@ -423,8 +423,8 @@ public class CseCracCreatorTest {
         assertEquals("BBE2AA1  BBE3AA1  1", pstRangeAction.getNetworkElement().getId());
         assertEquals(3, pstRangeAction.getInitialTap());
         assertEquals(RangeType.ABSOLUTE, pstRangeAction.getRanges().get(0).getRangeType());
-        assertEquals(-10, pstRangeAction.getRanges().get(0).getMinTap());
-        assertEquals(2, pstRangeAction.getRanges().get(0).getMaxTap());
+        assertEquals(-2, pstRangeAction.getRanges().get(0).getMinTap());
+        assertEquals(10, pstRangeAction.getRanges().get(0).getMaxTap());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
As angles of taps are inverted during PowSyBl import we should not invert taps of the CRAC ranges. The same way initial tap is not inverted from what is present in the UCTE.
