### PR TITLE
Fix multithreading

### DIFF
--- a/data/crac-creation/crac-creator-cim/src/main/java/com/farao_community/farao/data/crac_creation/creator/cim/crac_creator/CimCracCreator.java
+++ b/data/crac-creation/crac-creator-cim/src/main/java/com/farao_community/farao/data/crac_creation/creator/cim/crac_creator/CimCracCreator.java
@@ -22,6 +22,7 @@ import com.google.auto.service.AutoService;
 import com.powsybl.iidm.network.Network;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -45,7 +46,7 @@ public class CimCracCreator implements CracCreator<CimCrac, CimCracCreationConte
         // Set attributes
         this.crac = parameters.getCracFactory().create(cimCrac.getCracDocument().getMRID());
         this.network = network;
-        this.cimTimeSeries = cimCrac.getCracDocument().getTimeSeries();
+        this.cimTimeSeries = new ArrayList<>(cimCrac.getCracDocument().getTimeSeries());
         this.creationContext = new CimCracCreationContext(crac, offsetDateTime);
 
         // Get warning messages from parameters parsing

--- a/data/crac-creation/crac-creator-cim/src/test/java/com/farao_community/farao/data/crac_creation/creator/cim/crac_creator/CimCracCreatorTest.java
+++ b/data/crac-creation/crac-creator-cim/src/test/java/com/farao_community/farao/data/crac_creation/creator/cim/crac_creator/CimCracCreatorTest.java
@@ -876,4 +876,28 @@ public class CimCracCreatorTest {
         assertHasOneThreshold("OJLJJ_5_400_220 - CO_2 - curative", Side.RIGHT, Unit.AMPERE, -2000., 2000.);
         assertHasOneThreshold("OJLJJ_5_400_220 - CO_3 - curative", Side.RIGHT, Unit.AMPERE, -2000., 2000.);
     }
+
+    @Test
+    public void testCreateTwiceWithSameNativeCrac() {
+        // Check that CracCreator does not consume CimCrac and make it unusable again
+        InputStream is = getClass().getResourceAsStream("/cracs/CIM_2_timeseries.xml");
+        CimCracImporter cracImporter = new CimCracImporter();
+        CimCrac cimCrac = cracImporter.importNativeCrac(is);
+
+        CracCreationParameters cracCreationParameters = new CracCreationParameters();
+        cracCreationParameters.setDefaultMonitoredLineSide(CracCreationParameters.MonitoredLineSide.MONITOR_LINES_ON_LEFT_SIDE);
+        cracCreationParameters = Mockito.spy(cracCreationParameters);
+        CimCracCreationParameters cimCracCreationParameters = Mockito.mock(CimCracCreationParameters.class);
+        Mockito.when(cracCreationParameters.getExtension(CimCracCreationParameters.class)).thenReturn(cimCracCreationParameters);
+
+        Mockito.when(cimCracCreationParameters.getTimeseriesMrids()).thenReturn(Set.of("TimeSeries1"));
+        Crac crac1 = new CimCracCreator().createCrac(cimCrac, baseNetwork, OffsetDateTime.parse("2021-04-01T23:00Z"), cracCreationParameters).getCrac();
+        assertEquals(1, crac1.getContingencies().size());
+        assertNotNull(crac1.getContingency("Co-1"));
+
+        Mockito.when(cimCracCreationParameters.getTimeseriesMrids()).thenReturn(Set.of("TimeSeries2"));
+        Crac crac2 = new CimCracCreator().createCrac(cimCrac, baseNetwork, OffsetDateTime.parse("2021-04-01T23:00Z"), cracCreationParameters).getCrac();
+        assertEquals(1, crac2.getContingencies().size());
+        assertNotNull(crac2.getContingency("Co-2"));
+    }
 }

--- a/loopflow-computation/pom.xml
+++ b/loopflow-computation/pom.xml
@@ -103,6 +103,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-open-loadflow</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/loopflow-computation/src/main/java/com/farao_community/farao/loopflow_computation/LoopFlowComputation.java
+++ b/loopflow-computation/src/main/java/com/farao_community/farao/loopflow_computation/LoopFlowComputation.java
@@ -21,5 +21,5 @@ public interface LoopFlowComputation {
 
     LoopFlowResult calculateLoopFlows(Network network, String sensitivityProvider, SensitivityAnalysisParameters sensitivityAnalysisParameters, Set<FlowCnec> cnecs);
 
-    LoopFlowResult buildLoopFlowsFromReferenceFlowAndPtdf(SystematicSensitivityResult alreadyCalculatedPtdfAndFlows, Set<FlowCnec> cnecs);
+    LoopFlowResult buildLoopFlowsFromReferenceFlowAndPtdf(SystematicSensitivityResult alreadyCalculatedPtdfAndFlows, Set<FlowCnec> cnecs, Network network);
 }

--- a/loopflow-computation/src/main/java/com/farao_community/farao/loopflow_computation/LoopFlowComputationWithXnodeGlskHandler.java
+++ b/loopflow-computation/src/main/java/com/farao_community/farao/loopflow_computation/LoopFlowComputationWithXnodeGlskHandler.java
@@ -26,12 +26,12 @@ public class LoopFlowComputationWithXnodeGlskHandler extends LoopFlowComputation
     private final XnodeGlskHandler xnodeGlskHandler;
 
     public LoopFlowComputationWithXnodeGlskHandler(ZonalData<SensitivityVariableSet> glsk, ReferenceProgram referenceProgram, Set<Contingency> contingencies, Network network) {
-        super(glsk, referenceProgram, network);
+        super(glsk, referenceProgram);
         xnodeGlskHandler = new XnodeGlskHandler(glsk, contingencies, network);
     }
 
     LoopFlowComputationWithXnodeGlskHandler(ZonalData<SensitivityVariableSet> glsk, ReferenceProgram referenceProgram, XnodeGlskHandler xnodeGlskHandler) {
-        super(glsk, referenceProgram, xnodeGlskHandler.getNetwork());
+        super(glsk, referenceProgram);
         this.xnodeGlskHandler = xnodeGlskHandler;
     }
 

--- a/loopflow-computation/src/test/java/com/farao_community/farao/loopflow_computation/LoopFlowComputationImplTest.java
+++ b/loopflow-computation/src/test/java/com/farao_community/farao/loopflow_computation/LoopFlowComputationImplTest.java
@@ -14,6 +14,7 @@ import com.farao_community.farao.data.crac_loopflow_extension.LoopFlowThresholdI
 import com.farao_community.farao.data.refprog.reference_program.ReferenceProgram;
 import com.farao_community.farao.sensitivity_analysis.SystematicSensitivityResult;
 import com.powsybl.iidm.network.*;
+import com.powsybl.sensitivity.SensitivityAnalysisParameters;
 import com.powsybl.sensitivity.SensitivityVariableSet;
 import com.powsybl.sensitivity.WeightedSensitivityVariable;
 import org.junit.Before;
@@ -228,5 +229,33 @@ public class LoopFlowComputationImplTest {
         assertEquals(30., loopFlowResult.getReferenceFlow(crac.getFlowCnec("BE2-NL"), Side.LEFT), DOUBLE_TOLERANCE);
         assertEquals(170., loopFlowResult.getReferenceFlow(crac.getFlowCnec("FR-DE"), Side.RIGHT), DOUBLE_TOLERANCE);
         assertEquals(170., loopFlowResult.getReferenceFlow(crac.getFlowCnec("DE-NL"), Side.RIGHT), DOUBLE_TOLERANCE);
+    }
+
+    @Test
+    public void testCalculateLoopFlows() {
+        ZonalData<SensitivityVariableSet> glsk = ExampleGenerator.glskProvider();
+        ReferenceProgram referenceProgram = ExampleGenerator.referenceProgram();
+        Network network = ExampleGenerator.network();
+        SensitivityAnalysisParameters sensitivityAnalysisParameters = new SensitivityAnalysisParameters();
+        sensitivityAnalysisParameters.getLoadFlowParameters().setDc(true);
+        LoopFlowResult loopFlowResult = new LoopFlowComputationImpl(glsk, referenceProgram).calculateLoopFlows(network, "OpenLoadFlow", sensitivityAnalysisParameters, crac.getFlowCnecs());
+
+        assertEquals(-25., loopFlowResult.getLoopFlow(crac.getFlowCnec("FR-BE1"), Side.LEFT), DOUBLE_TOLERANCE);
+        assertEquals(100., loopFlowResult.getLoopFlow(crac.getFlowCnec("BE1-BE2"), Side.LEFT), DOUBLE_TOLERANCE);
+        assertEquals(-25., loopFlowResult.getLoopFlow(crac.getFlowCnec("BE2-NL"), Side.LEFT), DOUBLE_TOLERANCE);
+        assertEquals(25., loopFlowResult.getLoopFlow(crac.getFlowCnec("FR-DE"), Side.RIGHT), DOUBLE_TOLERANCE);
+        assertEquals(25., loopFlowResult.getLoopFlow(crac.getFlowCnec("DE-NL"), Side.RIGHT), DOUBLE_TOLERANCE);
+
+        assertEquals(40, loopFlowResult.getCommercialFlow(crac.getFlowCnec("FR-BE1"), Side.LEFT), DOUBLE_TOLERANCE);
+        assertEquals(40., loopFlowResult.getCommercialFlow(crac.getFlowCnec("BE1-BE2"), Side.LEFT), DOUBLE_TOLERANCE);
+        assertEquals(40., loopFlowResult.getCommercialFlow(crac.getFlowCnec("BE2-NL"), Side.LEFT), DOUBLE_TOLERANCE);
+        assertEquals(60., loopFlowResult.getCommercialFlow(crac.getFlowCnec("FR-DE"), Side.RIGHT), DOUBLE_TOLERANCE);
+        assertEquals(60., loopFlowResult.getCommercialFlow(crac.getFlowCnec("DE-NL"), Side.RIGHT), DOUBLE_TOLERANCE);
+
+        assertEquals(15., loopFlowResult.getReferenceFlow(crac.getFlowCnec("FR-BE1"), Side.LEFT), DOUBLE_TOLERANCE);
+        assertEquals(140., loopFlowResult.getReferenceFlow(crac.getFlowCnec("BE1-BE2"), Side.LEFT), DOUBLE_TOLERANCE);
+        assertEquals(15., loopFlowResult.getReferenceFlow(crac.getFlowCnec("BE2-NL"), Side.LEFT), DOUBLE_TOLERANCE);
+        assertEquals(85., loopFlowResult.getReferenceFlow(crac.getFlowCnec("FR-DE"), Side.RIGHT), DOUBLE_TOLERANCE);
+        assertEquals(85., loopFlowResult.getReferenceFlow(crac.getFlowCnec("DE-NL"), Side.RIGHT), DOUBLE_TOLERANCE);
     }
 }

--- a/loopflow-computation/src/test/java/com/farao_community/farao/loopflow_computation/LoopFlowComputationImplTest.java
+++ b/loopflow-computation/src/test/java/com/farao_community/farao/loopflow_computation/LoopFlowComputationImplTest.java
@@ -72,7 +72,7 @@ public class LoopFlowComputationImplTest {
         Mockito.doReturn(mockInjection(true)).when(load).getTerminal();
 
         LoopFlowComputation loopFlowComputation = new LoopFlowComputationImpl(glsk, referenceProgram);
-        LoopFlowResult loopFlowResult = loopFlowComputation.buildLoopFlowsFromReferenceFlowAndPtdf(ptdfsAndFlows, crac.getFlowCnecs());
+        LoopFlowResult loopFlowResult = loopFlowComputation.buildLoopFlowsFromReferenceFlowAndPtdf(ptdfsAndFlows, crac.getFlowCnecs(), network);
 
         assertEquals(-50., loopFlowResult.getLoopFlow(crac.getFlowCnec("FR-BE1"), Side.LEFT), DOUBLE_TOLERANCE);
         assertEquals(200., loopFlowResult.getLoopFlow(crac.getFlowCnec("BE1-BE2"), Side.LEFT), DOUBLE_TOLERANCE);
@@ -209,7 +209,7 @@ public class LoopFlowComputationImplTest {
         Mockito.doReturn(mockInjection(false)).when(loadBe).getTerminal();
 
         LoopFlowComputation loopFlowComputation = new LoopFlowComputationImpl(glsk, referenceProgram);
-        LoopFlowResult loopFlowResult = loopFlowComputation.buildLoopFlowsFromReferenceFlowAndPtdf(ptdfsAndFlows, crac.getFlowCnecs());
+        LoopFlowResult loopFlowResult = loopFlowComputation.buildLoopFlowsFromReferenceFlowAndPtdf(ptdfsAndFlows, crac.getFlowCnecs(), network);
 
         assertEquals(30., loopFlowResult.getLoopFlow(crac.getFlowCnec("FR-BE1"), Side.LEFT), DOUBLE_TOLERANCE);
         assertEquals(280., loopFlowResult.getLoopFlow(crac.getFlowCnec("BE1-BE2"), Side.LEFT), DOUBLE_TOLERANCE);

--- a/loopflow-computation/src/test/java/com/farao_community/farao/loopflow_computation/LoopFlowComputationImplTest.java
+++ b/loopflow-computation/src/test/java/com/farao_community/farao/loopflow_computation/LoopFlowComputationImplTest.java
@@ -71,7 +71,7 @@ public class LoopFlowComputationImplTest {
         Mockito.doReturn(mockInjection(true)).when(gen).getTerminal();
         Mockito.doReturn(mockInjection(true)).when(load).getTerminal();
 
-        LoopFlowComputation loopFlowComputation = new LoopFlowComputationImpl(glsk, referenceProgram, network);
+        LoopFlowComputation loopFlowComputation = new LoopFlowComputationImpl(glsk, referenceProgram);
         LoopFlowResult loopFlowResult = loopFlowComputation.buildLoopFlowsFromReferenceFlowAndPtdf(ptdfsAndFlows, crac.getFlowCnecs());
 
         assertEquals(-50., loopFlowResult.getLoopFlow(crac.getFlowCnec("FR-BE1"), Side.LEFT), DOUBLE_TOLERANCE);
@@ -208,7 +208,7 @@ public class LoopFlowComputationImplTest {
         Mockito.doReturn(mockInjection(true)).when(loadFr).getTerminal();
         Mockito.doReturn(mockInjection(false)).when(loadBe).getTerminal();
 
-        LoopFlowComputation loopFlowComputation = new LoopFlowComputationImpl(glsk, referenceProgram, network);
+        LoopFlowComputation loopFlowComputation = new LoopFlowComputationImpl(glsk, referenceProgram);
         LoopFlowResult loopFlowResult = loopFlowComputation.buildLoopFlowsFromReferenceFlowAndPtdf(ptdfsAndFlows, crac.getFlowCnecs());
 
         assertEquals(30., loopFlowResult.getLoopFlow(crac.getFlowCnec("FR-BE1"), Side.LEFT), DOUBLE_TOLERANCE);

--- a/loopflow-computation/src/test/java/com/farao_community/farao/loopflow_computation/LoopFlowComputationWithXnodeGlskHandlerTest.java
+++ b/loopflow-computation/src/test/java/com/farao_community/farao/loopflow_computation/LoopFlowComputationWithXnodeGlskHandlerTest.java
@@ -102,7 +102,8 @@ public class LoopFlowComputationWithXnodeGlskHandlerTest {
 
         LoopFlowResult loopFlowResult = loopFlowComputation.buildLoopFlowsFromReferenceFlowAndPtdf(
                 systematicSensitivityResult,
-                Set.of(preventiveCnec, cnecAfterClassicContingency, cnecAfterDanglingContingency)
+                Set.of(preventiveCnec, cnecAfterClassicContingency, cnecAfterDanglingContingency),
+                network
         );
 
         assertEquals(2000. * 0.5 + 600. * (-1.2), loopFlowResult.getCommercialFlow(preventiveCnec, Side.LEFT), DOUBLE_TOLERANCE);

--- a/monitoring/angle-monitoring/pom.xml
+++ b/monitoring/angle-monitoring/pom.xml
@@ -34,17 +34,14 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-glsk-document-cim</artifactId>
-            <version>${powsybl.glsk.version}</version>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-api</artifactId>
-            <version>${powsybl.core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-loadflow-api</artifactId>
-            <version>${powsybl.core.version}</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -72,13 +69,11 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-xml-converter</artifactId>
-            <version>${powsybl.core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-open-loadflow</artifactId>
-            <version>${powsybl.openloadflow.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -89,17 +84,10 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.farao-community.farao</groupId>
-            <artifactId>farao-crac-creator-cim</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.farao-community.farao</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>farao-crac-creator-cim</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/monitoring/voltage-monitoring/pom.xml
+++ b/monitoring/voltage-monitoring/pom.xml
@@ -34,12 +34,10 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-api</artifactId>
-            <version>${powsybl.core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-loadflow-api</artifactId>
-            <version>${powsybl.core.version}</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -67,13 +65,11 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-xml-converter</artifactId>
-            <version>${powsybl.core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-open-loadflow</artifactId>
-            <version>${powsybl.openloadflow.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -84,7 +80,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <powermock.version>2.0.7</powermock.version>
         <powsybl.core.version>4.10.1</powsybl.core.version>
         <powsybl.glsk.version>1.6.0</powsybl.glsk.version>
-        <powsybl.openloadflow.version>0.23.1</powsybl.openloadflow.version>
+        <powsybl.openloadflow.version>0.23.2</powsybl.openloadflow.version>
         <slf4j.version>1.7.30</slf4j.version>
         <threeten.version>1.5.0</threeten.version>
         <xmlunit.core.version>2.8.1</xmlunit.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -588,6 +588,12 @@
             </dependency>
             <dependency>
                 <groupId>com.powsybl</groupId>
+                <artifactId>powsybl-open-loadflow</artifactId>
+                <version>${powsybl.openloadflow.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.powsybl</groupId>
                 <artifactId>powsybl-ucte-converter</artifactId>
                 <version>${powsybl.core.version}</version>
                 <scope>test</scope>

--- a/ra-optimisation/search-tree-rao/pom.xml
+++ b/ra-optimisation/search-tree-rao/pom.xml
@@ -92,7 +92,6 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-open-loadflow</artifactId>
-            <version>${powsybl.openloadflow.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/PrePerimeterSensitivityAnalysis.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/PrePerimeterSensitivityAnalysis.java
@@ -107,7 +107,7 @@ public class PrePerimeterSensitivityAnalysis {
 
     private PrePerimeterResult runAndGetResult(Network network, ObjectiveFunction objectiveFunction) {
         sensitivityComputer.compute(network);
-        FlowResult flowResult = sensitivityComputer.getBranchResult();
+        FlowResult flowResult = sensitivityComputer.getBranchResult(network);
         SensitivityResult sensitivityResult = sensitivityComputer.getSensitivityResult();
         ObjectiveFunctionResult objectiveFunctionResult = getResult(objectiveFunction, flowResult, sensitivityResult);
         return new PrePerimeterSensitivityResultImpl(

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/SensitivityComputer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/SensitivityComputer.java
@@ -46,8 +46,8 @@ public final class SensitivityComputer {
         }
     }
 
-    public FlowResult getBranchResult() {
-        return branchResultAdapter.getResult(result);
+    public FlowResult getBranchResult(Network network) {
+        return branchResultAdapter.getResult(result, network);
     }
 
     public SensitivityResult getSensitivityResult() {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/adapter/BranchResultAdapter.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/adapter/BranchResultAdapter.java
@@ -9,11 +9,12 @@ package com.farao_community.farao.search_tree_rao.commons.adapter;
 
 import com.farao_community.farao.search_tree_rao.result.api.FlowResult;
 import com.farao_community.farao.sensitivity_analysis.SystematicSensitivityResult;
+import com.powsybl.iidm.network.Network;
 
 /**
  * @author Joris Mancini {@literal <joris.mancini at rte-france.com>}
  */
 public interface BranchResultAdapter {
 
-    FlowResult getResult(SystematicSensitivityResult systematicSensitivityResult);
+    FlowResult getResult(SystematicSensitivityResult systematicSensitivityResult, Network network);
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/adapter/BranchResultAdapterImpl.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/adapter/BranchResultAdapterImpl.java
@@ -18,6 +18,7 @@ import com.farao_community.farao.search_tree_rao.result.impl.FlowResultImpl;
 import com.farao_community.farao.search_tree_rao.result.api.FlowResult;
 import com.farao_community.farao.search_tree_rao.result.impl.EmptyFlowResultImpl;
 import com.farao_community.farao.sensitivity_analysis.SystematicSensitivityResult;
+import com.powsybl.iidm.network.Network;
 import org.apache.commons.lang3.NotImplementedException;
 
 import java.util.Map;
@@ -43,7 +44,7 @@ public final class BranchResultAdapterImpl implements BranchResultAdapter {
     }
 
     @Override
-    public FlowResult getResult(SystematicSensitivityResult systematicSensitivityResult) {
+    public FlowResult getResult(SystematicSensitivityResult systematicSensitivityResult, Network network) {
         FlowResult ptdfs;
         if (absolutePtdfSumsComputation != null) {
             Map<FlowCnec, Map<Side, Double>> ptdfsMap = absolutePtdfSumsComputation.computeAbsolutePtdfSums(flowCnecs, systematicSensitivityResult);
@@ -81,7 +82,8 @@ public final class BranchResultAdapterImpl implements BranchResultAdapter {
         if (loopFlowComputation != null) {
             LoopFlowResult loopFlowResult = loopFlowComputation.buildLoopFlowsFromReferenceFlowAndPtdf(
                     systematicSensitivityResult,
-                    loopFlowCnecs
+                    loopFlowCnecs,
+                    network
             );
             commercialFlows = new FlowResult() {
                 @Override

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
@@ -88,7 +88,7 @@ public class IteratingLinearOptimizer {
             }
 
             IteratingLinearOptimizationResultImpl currentResult = createResult(
-                sensitivityComputer.getBranchResult(),
+                sensitivityComputer.getBranchResult(input.getNetwork()),
                 sensitivityComputer.getSensitivityResult(),
                 currentRangeActionActivationResult,
                 iteration

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/Leaf.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/Leaf.java
@@ -164,7 +164,7 @@ public class Leaf implements OptimizationResult {
             TECHNICAL_LOGS.debug("Evaluating {}", this);
             sensitivityComputer.compute(network);
             preOptimSensitivityResult = sensitivityComputer.getSensitivityResult();
-            preOptimFlowResult = sensitivityComputer.getBranchResult();
+            preOptimFlowResult = sensitivityComputer.getBranchResult(network);
             preOptimObjectiveFunctionResult = objectiveFunction.evaluate(preOptimFlowResult, preOptimSensitivityResult.getSensitivityStatus());
             status = Status.EVALUATED;
         } catch (FaraoException e) {

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/castor/algorithm/CastorFullOptimizationTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/castor/algorithm/CastorFullOptimizationTest.java
@@ -71,7 +71,7 @@ public class CastorFullOptimizationTest {
 
     @Before
     public void setup() {
-        Network network = Importers.loadNetwork("network_with_alegro_hub.xiidm", getClass().getResourceAsStream("/network/network_with_alegro_hub.xiidm"));
+        network = Importers.loadNetwork("network_with_alegro_hub.xiidm", getClass().getResourceAsStream("/network/network_with_alegro_hub.xiidm"));
         crac = CracImporters.importCrac("crac/small-crac.json", getClass().getResourceAsStream("/crac/small-crac.json"));
         RaoInput inputs = Mockito.mock(RaoInput.class);
         when(inputs.getNetwork()).thenReturn(network);
@@ -100,7 +100,7 @@ public class CastorFullOptimizationTest {
         SensitivityResult sensitivityResult = Mockito.mock(SensitivityResult.class);
         when(sensitivityResult.getSensitivityStatus()).thenReturn(ComputationStatus.DEFAULT);
         Mockito.when(sensitivityComputer.getSensitivityResult()).thenReturn(sensitivityResult);
-        Mockito.when(sensitivityComputer.getBranchResult()).thenReturn(Mockito.mock(FlowResult.class));
+        Mockito.when(sensitivityComputer.getBranchResult(network)).thenReturn(Mockito.mock(FlowResult.class));
 
         Leaf leaf = Mockito.mock(Leaf.class);
         when(leaf.getStatus()).thenReturn(Leaf.Status.EVALUATED);

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizerTest.java
@@ -122,8 +122,8 @@ public class IteratingLinearOptimizerTest {
         SystematicSensitivityResult sensi = Mockito.mock(SystematicSensitivityResult.class, "only sensi computation");
         when(systematicSensitivityInterface.run(network)).thenReturn(sensi);
         FlowResult flowResult = Mockito.mock(FlowResult.class);
-        when(branchResultAdapter.getResult(sensi)).thenReturn(flowResult);
-        when(sensitivityComputer.getBranchResult()).thenReturn(flowResult);
+        when(branchResultAdapter.getResult(sensi, network)).thenReturn(flowResult);
+        when(sensitivityComputer.getBranchResult(network)).thenReturn(flowResult);
         when(sensitivityComputer.getSensitivityResult()).thenReturn(sensitivityResult1);
         SensitivityResult sensitivityResult = Mockito.mock(SensitivityResult.class);
         when(sensitivityResult.getSensitivityStatus()).thenReturn(ComputationStatus.DEFAULT);

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
@@ -189,7 +189,7 @@ public class LeafTest {
         SensitivityResult expectedSensitivityResult = Mockito.mock(SensitivityResult.class);
         when(sensitivityComputer.getSensitivityResult()).thenReturn(expectedSensitivityResult);
         when(expectedSensitivityResult.getSensitivityStatus()).thenReturn(expectedSensitivityStatus);
-        when(sensitivityComputer.getBranchResult()).thenReturn(expectedFlowResult);
+        when(sensitivityComputer.getBranchResult(network)).thenReturn(expectedFlowResult);
         ObjectiveFunctionResult expectedObjectiveFunctionResult = Mockito.mock(ObjectiveFunctionResult.class);
         when(costEvaluatorMock.evaluate(any(), any())).thenReturn(expectedObjectiveFunctionResult);
         when(expectedObjectiveFunctionResult.getFunctionalCost()).thenReturn(expectedCost / 2);
@@ -322,7 +322,7 @@ public class LeafTest {
         FlowCnec flowCnec = Mockito.mock(FlowCnec.class);
 
         FlowResult flowResult = Mockito.mock(FlowResult.class);
-        when(sensitivityComputer.getBranchResult()).thenReturn(flowResult);
+        when(sensitivityComputer.getBranchResult(network)).thenReturn(flowResult);
         leaf.evaluate(costEvaluatorMock, sensitivityComputer);
 
         double expectedFlow = 3.;


### PR DESCRIPTION
**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When checking network connexity, the LoopFlow computer actually uses the main instance of the network, instead of using the clone it should be using in a given Leaf. This sometimes causes clashes between threads when Leaf evaluation is multi-threaded.


**What is the new behavior (if this is a feature change)?**
Now the LoopFlow computer uses the correct clone of the network.
