### PR TITLE
SearchTree: prioritize network action combinations

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -314,7 +314,11 @@ public class SearchTree {
 
     private int arbitraryNetworkActionCombinationComparison(NetworkActionCombination ra1, NetworkActionCombination ra2) {
         if (ra1.isDetectedDuringRao() == ra2.isDetectedDuringRao()) {
-            return Hashing.crc32().hashString(ra1.getConcatenatedId(), StandardCharsets.UTF_8).hashCode() - Hashing.crc32().hashString(ra2.getConcatenatedId(), StandardCharsets.UTF_8).hashCode();
+            if (ra1.getNetworkActionSet().size() == ra2.getNetworkActionSet().size()) {
+                return Hashing.crc32().hashString(ra1.getConcatenatedId(), StandardCharsets.UTF_8).hashCode() - Hashing.crc32().hashString(ra2.getConcatenatedId(), StandardCharsets.UTF_8).hashCode();
+            } else {
+                return Integer.compare(ra2.getNetworkActionSet().size(), ra1.getNetworkActionSet().size());
+            }
         } else if (ra1.isDetectedDuringRao()) {
             return -1;
         } else {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Performance boost


**What is the current behavior?** *(You can also link to an open issue here)*
Search tree tests network actions in an aribitrary order


**What is the new behavior (if this is a feature change)?**
Prioritize network action combinations, in the hopes that they allow achieving the stop criterion faster

