### PR TITLE
Small NA-combinations refactoring and fix

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/NetworkActionCombination.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/NetworkActionCombination.java
@@ -64,11 +64,12 @@ public class NetworkActionCombination {
             return false;
         }
         NetworkActionCombination oNetworkActionCombination = (NetworkActionCombination) o;
-        return this.networkActionSet.equals(oNetworkActionCombination.networkActionSet);
+        return (this.detectedDuringRao == oNetworkActionCombination.isDetectedDuringRao())
+                && (this.networkActionSet.equals(oNetworkActionCombination.networkActionSet));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(networkActionSet);
+        return Objects.hash(networkActionSet) + 37 * Objects.hash(detectedDuringRao);
     }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/parameters/NetworkActionParameters.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/parameters/NetworkActionParameters.java
@@ -14,6 +14,7 @@ import com.farao_community.farao.search_tree_rao.commons.NetworkActionCombinatio
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com>}
@@ -74,6 +75,12 @@ public class NetworkActionParameters {
     }
 
     public void addNetworkActionCombination(NetworkActionCombination networkActionCombination) {
+        // It may happen that the 1st preventive RAO finds an optimal combination that was already defined
+        // In this case, remove the old combination and add the new one (marked "detected during RAO")
+        Optional<NetworkActionCombination> alreadyExistingNetworkActionCombination = this.networkActionCombinations
+                .stream().filter(naCombination -> naCombination.getNetworkActionSet().equals(networkActionCombination.getNetworkActionSet()))
+                .findAny();
+        alreadyExistingNetworkActionCombination.ifPresent(this.networkActionCombinations::remove);
         this.networkActionCombinations.add(networkActionCombination);
     }
 

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -259,7 +259,7 @@ public class SearchTree {
     private void updateOptimalLeafWithNextDepthBestLeaf(AbstractNetworkPool networkPool) throws InterruptedException {
 
         final List<NetworkActionCombination> naCombinations = bloomer.bloom(optimalLeaf, input.getOptimizationPerimeter().getNetworkActions());
-        naCombinations.sort(this::arbitraryNetworkActionCombinationComparison);
+        naCombinations.sort(this::deterministicNetworkActionCombinationComparison);
         if (naCombinations.isEmpty()) {
             TECHNICAL_LOGS.info("No more network action available");
             return;
@@ -280,7 +280,7 @@ public class SearchTree {
                 }
                 try {
                     Network networkFinal = networkClone;
-                    if (combinationFulfillingStopCriterion.isEmpty() || arbitraryNetworkActionCombinationComparison(naCombination, combinationFulfillingStopCriterion.get()) < 0) {
+                    if (combinationFulfillingStopCriterion.isEmpty() || deterministicNetworkActionCombinationComparison(naCombination, combinationFulfillingStopCriterion.get()) < 0) {
                         // Apply range actions that has been changed by the previous leaf on the network to start next depth leaves
                         // from previous optimal leaf starting point
                         // TODO: we can wonder if it's better to do this here or at creation of each leaves or at each evaluation/optimization
@@ -314,18 +314,36 @@ public class SearchTree {
         }
     }
 
-    private int arbitraryNetworkActionCombinationComparison(NetworkActionCombination ra1, NetworkActionCombination ra2) {
-        if (ra1.isDetectedDuringRao() == ra2.isDetectedDuringRao()) {
-            if (ra1.getNetworkActionSet().size() == ra2.getNetworkActionSet().size()) {
-                return Hashing.crc32().hashString(ra1.getConcatenatedId(), StandardCharsets.UTF_8).hashCode() - Hashing.crc32().hashString(ra2.getConcatenatedId(), StandardCharsets.UTF_8).hashCode();
-            } else {
-                return Integer.compare(ra2.getNetworkActionSet().size(), ra1.getNetworkActionSet().size());
-            }
-        } else if (ra1.isDetectedDuringRao()) {
-            return -1;
-        } else {
-            return 1;
+    int deterministicNetworkActionCombinationComparison(NetworkActionCombination ra1, NetworkActionCombination ra2) {
+        // 1. First priority given to combinations detected during RAO
+        int comp1 = compareIsDetectedDuringRao(ra1, ra2);
+        if (comp1 != 0) {
+            return comp1;
         }
+        // 2. Second priority given to pre-defined combinations
+        int comp2 = compareIsPreDefined(ra1, ra2);
+        if (comp2 != 0) {
+            return comp2;
+        }
+        // 3. Third priority given to large combinations
+        int comp3 = compareSize(ra1, ra2);
+        if (comp3 != 0) {
+            return comp3;
+        }
+        // 4. Last priority is random but deterministic
+        return Hashing.crc32().hashString(ra1.getConcatenatedId(), StandardCharsets.UTF_8).hashCode() - Hashing.crc32().hashString(ra2.getConcatenatedId(), StandardCharsets.UTF_8).hashCode();
+    }
+
+    private int compareIsDetectedDuringRao(NetworkActionCombination ra1, NetworkActionCombination ra2) {
+        return -Boolean.compare(ra1.isDetectedDuringRao(), ra2.isDetectedDuringRao());
+    }
+
+    private int compareIsPreDefined(NetworkActionCombination ra1, NetworkActionCombination ra2) {
+        return -Boolean.compare(this.bloomer.hasPreDefinedNetworkActionCombination(ra1), this.bloomer.hasPreDefinedNetworkActionCombination(ra2));
+    }
+
+    private int compareSize(NetworkActionCombination ra1, NetworkActionCombination ra2) {
+        return -Integer.compare(ra1.getNetworkActionSet().size(), ra2.getNetworkActionSet().size());
     }
 
     private String printNetworkActions(Set<NetworkAction> networkActions) {
@@ -354,7 +372,7 @@ public class SearchTree {
         TECHNICAL_LOGS.debug("Evaluated {}", leaf);
         if (!leaf.getStatus().equals(Leaf.Status.ERROR)) {
             if (!stopCriterionReached(leaf)) {
-                if (combinationFulfillingStopCriterion.isPresent() && arbitraryNetworkActionCombinationComparison(naCombination, combinationFulfillingStopCriterion.get()) > 0) {
+                if (combinationFulfillingStopCriterion.isPresent() && deterministicNetworkActionCombinationComparison(naCombination, combinationFulfillingStopCriterion.get()) > 0) {
                     topLevelLogger.info("Skipping {} optimization because earlier combination fulfills stop criterion.", naCombination.getConcatenatedId());
                 } else {
                     optimizeLeaf(leaf);
@@ -432,7 +450,7 @@ public class SearchTree {
             // special case: stop criterion has been reached
             if (combinationFulfillingStopCriterion.isPresent()
                 && stopCriterionReached(leaf)
-                && arbitraryNetworkActionCombinationComparison(networkActionCombination, combinationFulfillingStopCriterion.get()) < 0) {
+                && deterministicNetworkActionCombinationComparison(networkActionCombination, combinationFulfillingStopCriterion.get()) < 0) {
                 optimalLeaf = leaf;
                 combinationFulfillingStopCriterion = Optional.of(networkActionCombination);
             }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -331,7 +331,8 @@ public class SearchTree {
             return comp3;
         }
         // 4. Last priority is random but deterministic
-        return Hashing.crc32().hashString(ra1.getConcatenatedId(), StandardCharsets.UTF_8).hashCode() - Hashing.crc32().hashString(ra2.getConcatenatedId(), StandardCharsets.UTF_8).hashCode();
+        return Integer.compare(Hashing.crc32().hashString(ra1.getConcatenatedId(), StandardCharsets.UTF_8).hashCode(),
+                Hashing.crc32().hashString(ra2.getConcatenatedId(), StandardCharsets.UTF_8).hashCode());
     }
 
     /**

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -334,14 +334,23 @@ public class SearchTree {
         return Hashing.crc32().hashString(ra1.getConcatenatedId(), StandardCharsets.UTF_8).hashCode() - Hashing.crc32().hashString(ra2.getConcatenatedId(), StandardCharsets.UTF_8).hashCode();
     }
 
+    /**
+     * Prioritizes the better network action combination that was detected by the RAO
+     */
     private int compareIsDetectedDuringRao(NetworkActionCombination ra1, NetworkActionCombination ra2) {
         return -Boolean.compare(ra1.isDetectedDuringRao(), ra2.isDetectedDuringRao());
     }
 
+    /**
+     * Prioritizes the network action combination that pre-defined by the user
+     */
     private int compareIsPreDefined(NetworkActionCombination ra1, NetworkActionCombination ra2) {
         return -Boolean.compare(this.bloomer.hasPreDefinedNetworkActionCombination(ra1), this.bloomer.hasPreDefinedNetworkActionCombination(ra2));
     }
 
+    /**
+     * Prioritizes the bigger network action combination
+     */
     private int compareSize(NetworkActionCombination ra1, NetworkActionCombination ra2) {
         return -Integer.compare(ra1.getNetworkActionSet().size(), ra2.getNetworkActionSet().size());
     }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
@@ -77,6 +77,7 @@ public final class SearchTreeBloomer {
 
         // preDefined combinations
         List<NetworkActionCombination> networkActionCombinations = preDefinedNaCombinations.stream()
+            .distinct()
             .filter(naCombination -> networkActions.containsAll(naCombination.getNetworkActionSet()))
             .collect(Collectors.toList());
 
@@ -302,5 +303,9 @@ public final class SearchTreeBloomer {
             leaf.getCostlyElements(virtualCost, Integer.MAX_VALUE).forEach(element -> locations.addAll(element.getLocation(network)));
         }
         return locations;
+    }
+
+    boolean hasPreDefinedNetworkActionCombination(NetworkActionCombination naCombination) {
+        return this.preDefinedNaCombinations.contains(naCombination);
     }
 }

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/commons/parameters/NetworkActionParametersTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/commons/parameters/NetworkActionParametersTest.java
@@ -21,8 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com>}
@@ -59,9 +58,18 @@ public class NetworkActionParametersTest {
         assertTrue(nap.skipNetworkActionFarFromMostLimitingElements());
         assertEquals(4, nap.getMaxNumberOfBoundariesForSkippingNetworkActions());
 
-        NetworkActionCombination naCombination = new NetworkActionCombination(Set.of(Mockito.mock(NetworkAction.class), Mockito.mock(NetworkAction.class)));
+        Set<NetworkAction> naSet = Set.of(Mockito.mock(NetworkAction.class), Mockito.mock(NetworkAction.class));
+        NetworkActionCombination naCombination = new NetworkActionCombination(naSet);
         nap.addNetworkActionCombination(naCombination);
+        assertEquals(2, nap.getNetworkActionCombinations().size());
         assertTrue(nap.getNetworkActionCombinations().contains(naCombination));
+
+        // Test unicity
+        NetworkActionCombination naCombinationDetectedInRao = new NetworkActionCombination(naSet, true);
+        nap.addNetworkActionCombination(naCombinationDetectedInRao);
+        assertEquals(2, nap.getNetworkActionCombinations().size());
+        assertTrue(nap.getNetworkActionCombinations().contains(naCombinationDetectedInRao));
+        assertFalse(nap.getNetworkActionCombinations().contains(naCombination));
     }
 
     @Test (expected = FaraoException.class)

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomerTest.java
@@ -453,4 +453,21 @@ public class SearchTreeBloomerTest {
             .withTapToAngleConversionMap(conversionMap)
             .add();
     }
+
+    @Test
+    public void testFilterIdenticalCombinations() {
+        NetworkAction na1 = Mockito.mock(NetworkAction.class);
+        NetworkAction na2 = Mockito.mock(NetworkAction.class);
+
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class),
+                Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), new HashMap<>(), false, 0,
+                List.of(new NetworkActionCombination(Set.of(na1, na2), false),
+                        new NetworkActionCombination(Set.of(na1, na2), false),
+                        new NetworkActionCombination(Set.of(na1, na2), true)),
+                pState);
+        Leaf leaf = Mockito.mock(Leaf.class);
+        Mockito.when(leaf.getActivatedNetworkActions()).thenReturn(Collections.emptySet());
+        List<NetworkActionCombination> result = bloomer.bloom(leaf, Set.of(na1, na2));
+        assertEquals(4, result.size());
+    }
 }

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
@@ -568,4 +568,10 @@ public class SearchTreeTest {
         assertEquals("[INFO] Optimized leaf-id, stop criterion could have been reached without \"loop-flow-cost\" virtual cost", business.list.get(0).toString());
         assertEquals("[INFO] Optimized leaf-id, limiting \"loop-flow-cost\" constraint #01: flow = 1135.00 MW, threshold = 1000.00 MW, margin = -135.00 MW, element ne-id at state state-id, CNEC ID = \"cnec-id\", CNEC name = \"cnec-name\"", business.list.get(1).toString());
     }
+
+    @Test
+    public void testSortNaCombinations() {
+        // TODO
+        assertTrue(true);
+    }
 }

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
@@ -83,7 +83,6 @@ public class SearchTreeTest {
 
     private NetworkActionCombination predefinedNaCombination;
 
-
     @Before
     public void setUp() throws Exception {
         setSearchTreeInput();

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
@@ -87,7 +87,7 @@ public class SearchTreeTest {
     public void setUp() throws Exception {
         setSearchTreeInput();
         searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
-       setSearchTreeParameters();
+        setSearchTreeParameters();
         searchTree = Mockito.spy(new SearchTree(searchTreeInput, searchTreeParameters, true));
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(RaoParameters.ObjectiveFunction.MAX_MIN_MARGIN_IN_MEGAWATT);
         mockNetworkPool(network);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
- If the 1st preventive RAO hints a combination that already exists in the parameters, the combination is tested twice during 2nd PRAO
- If the user hints a NA-combination with one element only, it is not played at the beginning of the RAO because priority is given to large combinations


**What is the new behavior (if this is a feature change)?**
Both bugs are now fixed
