### PR TITLE
auto remedial actions were not being applied for curative perimeters

### DIFF
--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/PstRangeActionImpl.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/PstRangeActionImpl.java
@@ -44,9 +44,9 @@ public final class PstRangeActionImpl extends AbstractRangeAction<PstRangeAction
         this.ranges = ranges;
         this.initialTapPosition = initialTap;
         this.tapToAngleConversionMap = tapToAngleConversionMap;
-        this.smallestAngleStep = computeSmallestAngleStep();
         this.lowTapPosition = Collections.min(tapToAngleConversionMap.keySet());
         this.highTapPosition = Collections.max(tapToAngleConversionMap.keySet());
+        this.smallestAngleStep = computeSmallestAngleStep();
     }
 
     @Override

--- a/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/PstRangeActionImplTest.java
+++ b/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/PstRangeActionImplTest.java
@@ -92,6 +92,7 @@ public class PstRangeActionImplTest {
 
         double minAngleInNetwork = phaseTapChanger.getStep(phaseTapChanger.getLowTapPosition()).getAlpha();
         double maxAngleInNetwork = phaseTapChanger.getStep(phaseTapChanger.getHighTapPosition()).getAlpha();
+        assertEquals(0.3885, pstRa.getSmallestAngleStep(), 1e-3);
         assertEquals(minAngleInNetwork, pstRa.getMinAdmissibleSetpoint(0), 1e-3);
         assertEquals(maxAngleInNetwork, pstRa.getMaxAdmissibleSetpoint(0), 1e-3);
     }

--- a/data/rao-result/rao-result-json/src/main/java/com/farao_community/farao/data/rao_result_json/serializers/RangeActionResultArraySerializer.java
+++ b/data/rao-result/rao-result-json/src/main/java/com/farao_community/farao/data/rao_result_json/serializers/RangeActionResultArraySerializer.java
@@ -55,13 +55,6 @@ final class RangeActionResultArraySerializer {
             jsonGenerator.writeNumberField(INITIAL_SETPOINT, initialSetpoint);
         }
 
-        if (rangeAction instanceof PstRangeAction) {
-            Integer initialTap = safeGetPreOptimizedTap(raoResult, crac.getPreventiveState(), (PstRangeAction) rangeAction);
-            if (initialTap != null) {
-                jsonGenerator.writeNumberField(INITIAL_TAP, initialTap);
-            }
-        }
-
         List<State> statesWhenRangeActionIsActivated = crac.getStates().stream()
                 .filter(state -> safeIsActivatedDuringState(raoResult, state, rangeAction))
                 .sorted(STATE_COMPARATOR)
@@ -140,11 +133,7 @@ final class RangeActionResultArraySerializer {
                 jsonGenerator.writeStringField(CONTINGENCY_ID, optContingency.get().getId());
             }
 
-            Integer tap = entry.getValue().getFirst();
             Double setpoint = entry.getValue().getSecond();
-            if (Objects.nonNull(tap)) {
-                jsonGenerator.writeNumberField(TAP, tap);
-            }
             if (!Double.isNaN(setpoint)) {
                 jsonGenerator.writeNumberField(SETPOINT, setpoint);
             }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/CastorFullOptimization.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/CastorFullOptimization.java
@@ -281,10 +281,11 @@ public class CastorFullOptimization {
                         BUSINESS_LOGS.error("Scenario post-contingency {} could not be optimized.", optimizedScenario.getContingency().getId(), e);
                     }
                     TECHNICAL_LOGS.info("Remaining post-contingency scenarios to optimize: {}", remainingScenarios.decrementAndGet());
-                    contingencyCountDownLatch.countDown();
                     try {
                         networkPool.releaseUsedNetwork(networkClone);
+                        contingencyCountDownLatch.countDown();
                     } catch (InterruptedException ex) {
+                        contingencyCountDownLatch.countDown();
                         Thread.currentThread().interrupt();
                         throw new FaraoException(ex);
                     }
@@ -294,6 +295,7 @@ public class CastorFullOptimization {
             if (!success) {
                 throw new FaraoException("At least one post-contingency state could not be optimized within the given time (24 hours). This should not happen.");
             }
+            networkPool.shutdownAndAwaitTermination(24, TimeUnit.HOURS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/result/impl/PreventiveAndCurativesRaoResultImpl.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/result/impl/PreventiveAndCurativesRaoResultImpl.java
@@ -181,7 +181,7 @@ public class PreventiveAndCurativesRaoResultImpl implements SearchTreeRaoResult 
         highestFunctionalCost = Math.max(
             highestFunctionalCost,
             postContingencyResults.entrySet().stream()
-                .filter(entry -> entry.getKey().getInstant().equals(instant))
+                .filter(entry -> entry.getKey().getInstant().equals(instant) || entry.getKey().getInstant().comesBefore(instant))
                 .map(Map.Entry::getValue)
                 .filter(PreventiveAndCurativesRaoResultImpl::hasActualFunctionalCost)
                 .map(PerimeterResult::getFunctionalCost)

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/result/impl/PreventiveAndCurativesRaoResultImplTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/result/impl/PreventiveAndCurativesRaoResultImplTest.java
@@ -250,7 +250,7 @@ public class PreventiveAndCurativesRaoResultImplTest {
 
         when(postPrevResult.getFunctionalCost()).thenReturn(-2020.);
         assertEquals(-1025., output.getFunctionalCost(AFTER_ARA), DOUBLE_TOLERANCE);
-        assertEquals(-1030., output.getFunctionalCost(AFTER_CRA), DOUBLE_TOLERANCE);
+        assertEquals(-1025., output.getFunctionalCost(AFTER_CRA), DOUBLE_TOLERANCE);
     }
 
     @Test

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/AppliedRemedialActions.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/AppliedRemedialActions.java
@@ -13,10 +13,7 @@ import com.farao_community.farao.data.crac_api.network_action.NetworkAction;
 import com.farao_community.farao.data.crac_api.range_action.RangeAction;
 import com.powsybl.iidm.network.Network;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -94,9 +91,10 @@ public class AppliedRemedialActions {
         appliedRa.keySet().stream().filter(stateBefore ->
             (stateBefore.getInstant().comesBefore(state.getInstant()) || stateBefore.getInstant().equals(state.getInstant()))
                 && (stateBefore.getContingency().isEmpty() || stateBefore.getContingency().equals(state.getContingency())))
+            .sorted(Comparator.comparingInt(stateBefore -> stateBefore.getInstant().getOrder()))
             .forEach(stateBefore -> {
-                appliedRa.get(state).rangeActions.forEach((rangeAction, setPoint) -> rangeAction.apply(network, setPoint));
-                appliedRa.get(state).networkActions.forEach(networkAction -> networkAction.apply(network));
+                appliedRa.get(stateBefore).rangeActions.forEach((rangeAction, setPoint) -> rangeAction.apply(network, setPoint));
+                appliedRa.get(stateBefore).networkActions.forEach(networkAction -> networkAction.apply(network));
             });
     }
 

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityAdapter.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/SystematicSensitivityAdapter.java
@@ -61,7 +61,10 @@ final class SystematicSensitivityAdapter {
         }
 
         TECHNICAL_LOGS.debug("Systematic sensitivity analysis with applied RA [start]");
-
+        // Information : for contingencies with auto RA but no curative RA, SystematicSensitivityResult::getCnecStateResult will
+        // retrieve sensi information for curative state from auto state to take into account auto RAs.
+        // (When auto AND curative RAs are applied, they will both be included in statesWithRa and both sensis
+        // are computed.)
         Set<State> statesWithRa = appliedRemedialActions.getStatesWithRa(network);
         Set<State> statesWithoutRa = cnecSensitivityProvider.getFlowCnecs().stream().map(Cnec::getState).collect(Collectors.toSet());
         statesWithoutRa.removeAll(statesWithRa);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Auto remedial actions are not being applied when evaluating flows on curative perimeters at the very end of a RAO with second preventive and second auto.


**What is the new behavior (if this is a feature change)?**
Autos and curatives are correctly being applied for curative perimeters.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
