### PR TITLE
Fix bug in parallelization

### DIFF
--- a/monitoring/angle-monitoring/src/main/java/com/farao_community/farao/monitoring/angle_monitoring/AngleMonitoring.java
+++ b/monitoring/angle-monitoring/src/main/java/com/farao_community/farao/monitoring/angle_monitoring/AngleMonitoring.java
@@ -111,10 +111,11 @@ public class AngleMonitoring {
                                 BUSINESS_WARNS.warn(e.getMessage());
                                 stateSpecificResults.add(catchAngleMonitoringResult(state, AngleMonitoringResult.Status.UNKNOWN));
                             }
-                            stateCountDownLatch.countDown();
                             try {
                                 networkPool.releaseUsedNetwork(networkClone);
+                                stateCountDownLatch.countDown();
                             } catch (InterruptedException ex) {
+                                stateCountDownLatch.countDown();
                                 Thread.currentThread().interrupt();
                                 throw new FaraoException(ex);
                             }

--- a/monitoring/voltage-monitoring/src/main/java/com/farao_community/farao/monitoring/voltage_monitoring/VoltageMonitoring.java
+++ b/monitoring/voltage-monitoring/src/main/java/com/farao_community/farao/monitoring/voltage_monitoring/VoltageMonitoring.java
@@ -84,10 +84,11 @@ public class VoltageMonitoring {
                             Thread.currentThread().interrupt();
                             throw new FaraoException(CONTINGENCY_ERROR, e);
                         }
-                        stateCountDownLatch.countDown();
                         try {
                             networkPool.releaseUsedNetwork(networkClone);
+                            stateCountDownLatch.countDown();
                         } catch (InterruptedException ex) {
+                            stateCountDownLatch.countDown();
                             Thread.currentThread().interrupt();
                             throw new FaraoException(ex);
                         }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -298,10 +298,11 @@ public class SearchTree {
                     BUSINESS_WARNS.warn("Cannot optimize remedial action combination {}: {}", naCombination.getConcatenatedId(), e.getMessage());
                 }
                 TECHNICAL_LOGS.info("Remaining leaves to evaluate: {}", remainingLeaves.decrementAndGet());
-                latch.countDown();
                 try {
                     networkPool.releaseUsedNetwork(networkClone);
+                    latch.countDown();
                 } catch (InterruptedException ex) {
+                    latch.countDown();
                     Thread.currentThread().interrupt();
                     throw new FaraoException(ex);
                 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
It can happen, when parallelizing computations on multiple networks, that the CountDownLatch counts down before a network instance is released. This can cause the following code to be executed while no network is available for computations.
Errors and/or unpredictable behavior can result fron this.

**What is the new behavior (if this is a feature change)?**
Now the latch only counts down after the network is released.