### PR TITLE
Auto fixes

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/CastorOneStateOnly.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/CastorOneStateOnly.java
@@ -6,9 +6,6 @@
  */
 package com.farao_community.farao.search_tree_rao.castor.algorithm;
 
-import com.farao_community.farao.data.crac_api.Instant;
-import com.farao_community.farao.data.crac_api.State;
-import com.farao_community.farao.data.crac_api.cnec.FlowCnec;
 import com.farao_community.farao.data.crac_api.usage_rule.UsageMethod;
 import com.farao_community.farao.data.rao_result_api.RaoResult;
 import com.farao_community.farao.rao_api.RaoInput;
@@ -66,10 +63,10 @@ public class CastorOneStateOnly {
 
         // compute initial sensitivity on CNECs of the only optimized state
         PrePerimeterSensitivityAnalysis prePerimeterSensitivityAnalysis = new PrePerimeterSensitivityAnalysis(
-            raoInput.getCrac().getFlowCnecs(raoInput.getOptimizedState()),
-            raoInput.getCrac().getRangeActions(raoInput.getOptimizedState(), UsageMethod.AVAILABLE, UsageMethod.TO_BE_EVALUATED),
-            raoParameters,
-            toolProvider);
+                raoInput.getCrac().getFlowCnecs(raoInput.getOptimizedState()),
+                raoInput.getCrac().getRangeActions(raoInput.getOptimizedState(), UsageMethod.AVAILABLE, UsageMethod.TO_BE_EVALUATED),
+                raoParameters,
+                toolProvider);
 
         PrePerimeterResult initialResults;
         try {
@@ -83,46 +80,37 @@ public class CastorOneStateOnly {
         OptimizationPerimeter optPerimeter;
         TreeParameters treeParameters;
         Set<String> operatorsNotToOptimize = new HashSet<>();
-
-        OptimizationResult optimizationResult;
-        Set<FlowCnec> perimeterFlowCnecs;
-
-        if (raoInput.getOptimizedState().getInstant().equals(Instant.AUTO)) {
-            perimeterFlowCnecs = raoInput.getCrac().getFlowCnecs(raoInput.getOptimizedState());
-            State curativeState = raoInput.getCrac().getState(raoInput.getOptimizedState().getContingency().orElseThrow().getId(), Instant.CURATIVE);
-            AutomatonSimulator automatonSimulator = new AutomatonSimulator(raoInput.getCrac(), raoParameters, toolProvider, initialResults, initialResults, initialResults, stateTree.getOperatorsNotSharingCras(), 2);
-            optimizationResult = automatonSimulator.simulateAutomatonState(raoInput.getOptimizedState(), curativeState, raoInput.getNetwork());
+        if (raoInput.getOptimizedState().equals(raoInput.getCrac().getPreventiveState())) {
+            optPerimeter = PreventiveOptimizationPerimeter.buildWithPreventiveCnecsOnly(raoInput.getCrac(), raoInput.getNetwork(), raoParameters, initialResults);
+            treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters.getExtension(SearchTreeRaoParameters.class));
         } else {
-            if (raoInput.getOptimizedState().equals(raoInput.getCrac().getPreventiveState())) {
-                optPerimeter = PreventiveOptimizationPerimeter.buildWithPreventiveCnecsOnly(raoInput.getCrac(), raoInput.getNetwork(), raoParameters, initialResults);
-                treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters.getExtension(SearchTreeRaoParameters.class));
-            } else {
-                optPerimeter = CurativeOptimizationPerimeter.build(raoInput.getOptimizedState(), raoInput.getCrac(), raoInput.getNetwork(), raoParameters, initialResults);
-                treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters.getExtension(SearchTreeRaoParameters.class), -Double.MAX_VALUE);
-                operatorsNotToOptimize.addAll(stateTree.getOperatorsNotSharingCras());
-            }
-            perimeterFlowCnecs = optPerimeter.getFlowCnecs();
-            SearchTreeParameters searchTreeParameters = SearchTreeParameters.create()
-                    .withConstantParametersOverAllRao(raoParameters, raoInput.getCrac())
-                    .withTreeParameters(treeParameters)
-                    .withUnoptimizedCnecParameters(UnoptimizedCnecParameters.build(raoParameters, stateTree.getOperatorsNotSharingCras(), raoInput.getCrac()))
-                    .build();
-            SearchTreeInput searchTreeInput = SearchTreeInput.create()
-                    .withNetwork(raoInput.getNetwork())
-                    .withOptimizationPerimeter(optPerimeter)
-                    .withInitialFlowResult(initialResults)
-                    .withPrePerimeterResult(initialResults)
-                    .withPreOptimizationAppliedNetworkActions(new AppliedRemedialActions()) //no remedial Action applied
-                    .withObjectiveFunction(ObjectiveFunction.create().build(optPerimeter.getFlowCnecs(), optPerimeter.getLoopFlowCnecs(), initialResults, initialResults, initialResults, raoInput.getCrac(), operatorsNotToOptimize, raoParameters))
-                    .withToolProvider(toolProvider)
-                    .build();
-            optimizationResult = new SearchTree(searchTreeInput, searchTreeParameters, true).run().join();
-
-            // apply RAs and return results
-            optimizationResult.getRangeActions().forEach(rangeAction -> rangeAction.apply(raoInput.getNetwork(), optimizationResult.getOptimizedSetpoint(rangeAction, raoInput.getOptimizedState())));
-            optimizationResult.getActivatedNetworkActions().forEach(networkAction -> networkAction.apply(raoInput.getNetwork()));
+            optPerimeter = CurativeOptimizationPerimeter.build(raoInput.getOptimizedState(), raoInput.getCrac(), raoInput.getNetwork(), raoParameters, initialResults);
+            treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters.getExtension(SearchTreeRaoParameters.class), -Double.MAX_VALUE);
+            operatorsNotToOptimize.addAll(stateTree.getOperatorsNotSharingCras());
         }
 
-        return CompletableFuture.completedFuture(new OneStateOnlyRaoResultImpl(raoInput.getOptimizedState(), initialResults, optimizationResult, perimeterFlowCnecs));
+        SearchTreeParameters searchTreeParameters = SearchTreeParameters.create()
+                .withConstantParametersOverAllRao(raoParameters, raoInput.getCrac())
+                .withTreeParameters(treeParameters)
+                .withUnoptimizedCnecParameters(UnoptimizedCnecParameters.build(raoParameters, stateTree.getOperatorsNotSharingCras(), raoInput.getCrac()))
+                .build();
+
+        SearchTreeInput searchTreeInput = SearchTreeInput.create()
+                .withNetwork(raoInput.getNetwork())
+                .withOptimizationPerimeter(optPerimeter)
+                .withInitialFlowResult(initialResults)
+                .withPrePerimeterResult(initialResults)
+                .withPreOptimizationAppliedNetworkActions(new AppliedRemedialActions()) //no remedial Action applied
+                .withObjectiveFunction(ObjectiveFunction.create().build(optPerimeter.getFlowCnecs(), optPerimeter.getLoopFlowCnecs(), initialResults, initialResults, initialResults, raoInput.getCrac(), operatorsNotToOptimize, raoParameters))
+                .withToolProvider(toolProvider)
+                .build();
+
+        OptimizationResult optimizationResult = new SearchTree(searchTreeInput, searchTreeParameters, true).run().join();
+
+        // apply RAs and return results
+        optimizationResult.getRangeActions().forEach(rangeAction -> rangeAction.apply(raoInput.getNetwork(), optimizationResult.getOptimizedSetpoint(rangeAction, raoInput.getOptimizedState())));
+        optimizationResult.getActivatedNetworkActions().forEach(networkAction -> networkAction.apply(raoInput.getNetwork()));
+
+        return CompletableFuture.completedFuture(new OneStateOnlyRaoResultImpl(raoInput.getOptimizedState(), initialResults, optimizationResult, optPerimeter.getFlowCnecs()));
     }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/CastorOneStateOnly.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/CastorOneStateOnly.java
@@ -6,6 +6,9 @@
  */
 package com.farao_community.farao.search_tree_rao.castor.algorithm;
 
+import com.farao_community.farao.data.crac_api.Instant;
+import com.farao_community.farao.data.crac_api.State;
+import com.farao_community.farao.data.crac_api.cnec.FlowCnec;
 import com.farao_community.farao.data.crac_api.usage_rule.UsageMethod;
 import com.farao_community.farao.data.rao_result_api.RaoResult;
 import com.farao_community.farao.rao_api.RaoInput;
@@ -80,37 +83,46 @@ public class CastorOneStateOnly {
         OptimizationPerimeter optPerimeter;
         TreeParameters treeParameters;
         Set<String> operatorsNotToOptimize = new HashSet<>();
-        if (raoInput.getOptimizedState().equals(raoInput.getCrac().getPreventiveState())) {
-            optPerimeter = PreventiveOptimizationPerimeter.buildWithPreventiveCnecsOnly(raoInput.getCrac(), raoInput.getNetwork(), raoParameters, initialResults);
-            treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters.getExtension(SearchTreeRaoParameters.class));
+
+        OptimizationResult optimizationResult;
+        Set<FlowCnec> perimeterFlowCnecs;
+
+        if (raoInput.getOptimizedState().getInstant().equals(Instant.AUTO)) {
+            perimeterFlowCnecs = raoInput.getCrac().getFlowCnecs(raoInput.getOptimizedState());
+            State curativeState = raoInput.getCrac().getState(raoInput.getOptimizedState().getContingency().orElseThrow().getId(), Instant.CURATIVE);
+            AutomatonSimulator automatonSimulator = new AutomatonSimulator(raoInput.getCrac(), raoParameters, toolProvider, initialResults, initialResults, initialResults, stateTree.getOperatorsNotSharingCras(), 2);
+            optimizationResult = automatonSimulator.simulateAutomatonState(raoInput.getOptimizedState(), curativeState, raoInput.getNetwork());
         } else {
-            optPerimeter = CurativeOptimizationPerimeter.build(raoInput.getOptimizedState(), raoInput.getCrac(), raoInput.getNetwork(), raoParameters, initialResults);
-            treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters.getExtension(SearchTreeRaoParameters.class), -Double.MAX_VALUE);
-            operatorsNotToOptimize.addAll(stateTree.getOperatorsNotSharingCras());
+            if (raoInput.getOptimizedState().equals(raoInput.getCrac().getPreventiveState())) {
+                optPerimeter = PreventiveOptimizationPerimeter.buildWithPreventiveCnecsOnly(raoInput.getCrac(), raoInput.getNetwork(), raoParameters, initialResults);
+                treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters.getExtension(SearchTreeRaoParameters.class));
+            } else {
+                optPerimeter = CurativeOptimizationPerimeter.build(raoInput.getOptimizedState(), raoInput.getCrac(), raoInput.getNetwork(), raoParameters, initialResults);
+                treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters.getExtension(SearchTreeRaoParameters.class), -Double.MAX_VALUE);
+                operatorsNotToOptimize.addAll(stateTree.getOperatorsNotSharingCras());
+            }
+            perimeterFlowCnecs = optPerimeter.getFlowCnecs();
+            SearchTreeParameters searchTreeParameters = SearchTreeParameters.create()
+                    .withConstantParametersOverAllRao(raoParameters, raoInput.getCrac())
+                    .withTreeParameters(treeParameters)
+                    .withUnoptimizedCnecParameters(UnoptimizedCnecParameters.build(raoParameters, stateTree.getOperatorsNotSharingCras(), raoInput.getCrac()))
+                    .build();
+            SearchTreeInput searchTreeInput = SearchTreeInput.create()
+                    .withNetwork(raoInput.getNetwork())
+                    .withOptimizationPerimeter(optPerimeter)
+                    .withInitialFlowResult(initialResults)
+                    .withPrePerimeterResult(initialResults)
+                    .withPreOptimizationAppliedNetworkActions(new AppliedRemedialActions()) //no remedial Action applied
+                    .withObjectiveFunction(ObjectiveFunction.create().build(optPerimeter.getFlowCnecs(), optPerimeter.getLoopFlowCnecs(), initialResults, initialResults, initialResults, raoInput.getCrac(), operatorsNotToOptimize, raoParameters))
+                    .withToolProvider(toolProvider)
+                    .build();
+            optimizationResult = new SearchTree(searchTreeInput, searchTreeParameters, true).run().join();
+
+            // apply RAs and return results
+            optimizationResult.getRangeActions().forEach(rangeAction -> rangeAction.apply(raoInput.getNetwork(), optimizationResult.getOptimizedSetpoint(rangeAction, raoInput.getOptimizedState())));
+            optimizationResult.getActivatedNetworkActions().forEach(networkAction -> networkAction.apply(raoInput.getNetwork()));
         }
 
-        SearchTreeParameters searchTreeParameters = SearchTreeParameters.create()
-                .withConstantParametersOverAllRao(raoParameters, raoInput.getCrac())
-                .withTreeParameters(treeParameters)
-                .withUnoptimizedCnecParameters(UnoptimizedCnecParameters.build(raoParameters, stateTree.getOperatorsNotSharingCras(), raoInput.getCrac()))
-                .build();
-
-        SearchTreeInput searchTreeInput = SearchTreeInput.create()
-                .withNetwork(raoInput.getNetwork())
-                .withOptimizationPerimeter(optPerimeter)
-                .withInitialFlowResult(initialResults)
-                .withPrePerimeterResult(initialResults)
-                .withPreOptimizationAppliedNetworkActions(new AppliedRemedialActions()) //no remedial Action applied
-                .withObjectiveFunction(ObjectiveFunction.create().build(optPerimeter.getFlowCnecs(), optPerimeter.getLoopFlowCnecs(), initialResults, initialResults, initialResults, raoInput.getCrac(), operatorsNotToOptimize, raoParameters))
-                .withToolProvider(toolProvider)
-                .build();
-
-        OptimizationResult optimizationResult = new SearchTree(searchTreeInput, searchTreeParameters, true).run().join();
-
-        // apply RAs and return results
-        optimizationResult.getRangeActions().forEach(rangeAction -> rangeAction.apply(raoInput.getNetwork(), optimizationResult.getOptimizedSetpoint(rangeAction, raoInput.getOptimizedState())));
-        optimizationResult.getActivatedNetworkActions().forEach(networkAction -> networkAction.apply(raoInput.getNetwork()));
-
-        return CompletableFuture.completedFuture(new OneStateOnlyRaoResultImpl(raoInput.getOptimizedState(), initialResults, optimizationResult, optPerimeter.getFlowCnecs()));
+        return CompletableFuture.completedFuture(new OneStateOnlyRaoResultImpl(raoInput.getOptimizedState(), initialResults, optimizationResult, perimeterFlowCnecs));
     }
 }

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/castor/algorithm/AutomatonSimulatorTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/castor/algorithm/AutomatonSimulatorTest.java
@@ -519,7 +519,6 @@ public class AutomatonSimulatorTest {
         assertEquals(Map.of(ara1, 0.1, ara2, 0.1), result.getOptimizedSetpointsOnState(autoState));
     }
 
-
     @Test
     public void testDisableAcEmulationBeforeShifting() {
         PrePerimeterResult prePerimeterResult = mock(PrePerimeterResult.class);

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/castor/algorithm/AutomatonSimulatorTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/castor/algorithm/AutomatonSimulatorTest.java
@@ -250,7 +250,7 @@ public class AutomatonSimulatorTest {
         PrePerimeterResult prePerimeterResult = mock(PrePerimeterResult.class);
         when(mockedPreAutoPerimeterSensitivityAnalysis.runBasedOnInitialResults(any(), any(), any(), any(), any(), any())).thenReturn(mockedPrePerimeterResult);
 
-        PrePerimeterResult result = automatonSimulator.disableACEmulation(List.of(hvdcRa), network, mockedPreAutoPerimeterSensitivityAnalysis, prePerimeterResult);
+        PrePerimeterResult result = automatonSimulator.disableACEmulation(List.of(hvdcRa), network, mockedPreAutoPerimeterSensitivityAnalysis, prePerimeterResult, autoState);
         // check that AC emulation was disabled on HVDC
         assertFalse(network.getHvdcLine("BBE2AA11 FFR3AA11 1").getExtension(HvdcAngleDroopActivePowerControl.class).isEnabled());
         // check that other HVDC was not touched
@@ -259,24 +259,24 @@ public class AutomatonSimulatorTest {
         assertEquals(mockedPrePerimeterResult, result);
 
         // run a second time => no influence + sensi not run
-        result = automatonSimulator.disableACEmulation(List.of(hvdcRa), network, mockedPreAutoPerimeterSensitivityAnalysis, prePerimeterResult);
+        result = automatonSimulator.disableACEmulation(List.of(hvdcRa), network, mockedPreAutoPerimeterSensitivityAnalysis, prePerimeterResult, autoState);
         assertFalse(network.getHvdcLine("BBE2AA11 FFR3AA11 1").getExtension(HvdcAngleDroopActivePowerControl.class).isEnabled());
         assertTrue(network.getHvdcLine("BBE2AA12 FFR3AA12 1").getExtension(HvdcAngleDroopActivePowerControl.class).isEnabled());
         assertEquals(prePerimeterResult, result);
 
         // Test on 2 aligned HVDC RAs
-        result = automatonSimulator.disableACEmulation(List.of(hvdcRa, hvdcRa2), network, mockedPreAutoPerimeterSensitivityAnalysis, prePerimeterResult);
+        result = automatonSimulator.disableACEmulation(List.of(hvdcRa, hvdcRa2), network, mockedPreAutoPerimeterSensitivityAnalysis, prePerimeterResult, autoState);
         assertFalse(network.getHvdcLine("BBE2AA11 FFR3AA11 1").getExtension(HvdcAngleDroopActivePowerControl.class).isEnabled());
         assertFalse(network.getHvdcLine("BBE2AA12 FFR3AA12 1").getExtension(HvdcAngleDroopActivePowerControl.class).isEnabled());
         assertEquals(mockedPrePerimeterResult, result);
 
         // Test on an HVDC with no HvdcAngleDroopActivePowerControl
         network.getHvdcLine("BBE2AA11 FFR3AA11 1").removeExtension(HvdcAngleDroopActivePowerControl.class);
-        result = automatonSimulator.disableACEmulation(List.of(hvdcRa), network, mockedPreAutoPerimeterSensitivityAnalysis, prePerimeterResult);
+        result = automatonSimulator.disableACEmulation(List.of(hvdcRa), network, mockedPreAutoPerimeterSensitivityAnalysis, prePerimeterResult, autoState);
         assertEquals(prePerimeterResult, result);
 
         // Test on non-HVDC : nothing should happen
-        result = automatonSimulator.disableACEmulation(List.of(ra2), network, mockedPreAutoPerimeterSensitivityAnalysis, prePerimeterResult);
+        result = automatonSimulator.disableACEmulation(List.of(ra2), network, mockedPreAutoPerimeterSensitivityAnalysis, prePerimeterResult, autoState);
         assertEquals(prePerimeterResult, result);
     }
 
@@ -338,7 +338,7 @@ public class AutomatonSimulatorTest {
         // so PSTs should be shifted to setpoint +1.1 on first iteration, then +2.1 on second
 
         Pair<PrePerimeterResult, Map<RangeAction<?>, Double>> shiftResult =
-            automatonSimulator.shiftRangeActionsUntilFlowCnecsSecure(List.of(ara1, ara2), Set.of(cnec), network, mockedPreAutoPerimeterSensitivityAnalysis, mockedPrePerimeterResult);
+            automatonSimulator.shiftRangeActionsUntilFlowCnecsSecure(List.of(ara1, ara2), Set.of(cnec), network, mockedPreAutoPerimeterSensitivityAnalysis, mockedPrePerimeterResult, autoState);
         assertEquals(2.1, shiftResult.getRight().get(ara1), DOUBLE_TOLERANCE);
         assertEquals(2.1, shiftResult.getRight().get(ara2), DOUBLE_TOLERANCE);
     }
@@ -365,7 +365,7 @@ public class AutomatonSimulatorTest {
         when(mockedPrePerimeterResult.getSensitivityValue(cnec, Side.RIGHT, ara2, Unit.MEGAWATT)).thenReturn(-50., -5.);
 
         Pair<PrePerimeterResult, Map<RangeAction<?>, Double>> shiftResult =
-            automatonSimulator.shiftRangeActionsUntilFlowCnecsSecure(List.of(ara1, ara2), Set.of(cnec), network, mockedPreAutoPerimeterSensitivityAnalysis, mockedPrePerimeterResult);
+            automatonSimulator.shiftRangeActionsUntilFlowCnecsSecure(List.of(ara1, ara2), Set.of(cnec), network, mockedPreAutoPerimeterSensitivityAnalysis, mockedPrePerimeterResult, autoState);
         assertEquals(2.1, shiftResult.getRight().get(ara1), DOUBLE_TOLERANCE);
         assertEquals(2.1, shiftResult.getRight().get(ara2), DOUBLE_TOLERANCE);
     }
@@ -388,7 +388,7 @@ public class AutomatonSimulatorTest {
         when(mockedPrePerimeterResult.getSensitivityValue(cnec, Side.LEFT, ara2, Unit.MEGAWATT)).thenReturn(50., 5.);
 
         Pair<PrePerimeterResult, Map<RangeAction<?>, Double>> shiftResult =
-            automatonSimulator.shiftRangeActionsUntilFlowCnecsSecure(List.of(ara1, ara2), Set.of(cnec), network, mockedPreAutoPerimeterSensitivityAnalysis, mockedPrePerimeterResult);
+            automatonSimulator.shiftRangeActionsUntilFlowCnecsSecure(List.of(ara1, ara2), Set.of(cnec), network, mockedPreAutoPerimeterSensitivityAnalysis, mockedPrePerimeterResult, autoState);
         assertEquals(-2.1, shiftResult.getRight().get(ara1), DOUBLE_TOLERANCE);
         assertEquals(-2.1, shiftResult.getRight().get(ara2), DOUBLE_TOLERANCE);
     }
@@ -421,7 +421,7 @@ public class AutomatonSimulatorTest {
         when(mockedPrePerimeterResult.getSensitivityValue(cnec2, Side.RIGHT, ara2, Unit.MEGAWATT)).thenReturn(0.);
 
         Pair<PrePerimeterResult, Map<RangeAction<?>, Double>> shiftResult =
-            automatonSimulator.shiftRangeActionsUntilFlowCnecsSecure(List.of(ara1, ara2), Set.of(cnec, cnec2), network, mockedPreAutoPerimeterSensitivityAnalysis, mockedPrePerimeterResult);
+            automatonSimulator.shiftRangeActionsUntilFlowCnecsSecure(List.of(ara1, ara2), Set.of(cnec, cnec2), network, mockedPreAutoPerimeterSensitivityAnalysis, mockedPrePerimeterResult, autoState);
         assertEquals(-2.1, shiftResult.getRight().get(ara1), DOUBLE_TOLERANCE);
         assertEquals(-2.1, shiftResult.getRight().get(ara2), DOUBLE_TOLERANCE);
     }


### PR DESCRIPTION
- Filter out curative CNECs from the automaton simulation logs
- Do not disable AC emulation on auto HVDC RAs unless at least one CNEC is overloaded