### PR TITLE
[FAR-784] rerun sensi if 2ARA != 1ARA

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/CastorFullOptimization.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/CastorFullOptimization.java
@@ -430,9 +430,10 @@ public class CastorFullOptimization {
         BUSINESS_LOGS.info("----- Second automaton simulation [end]");
 
         BUSINESS_LOGS.info("Merging first, second preventive and post-contingency RAO results:");
-        if (newPostContingencyResults.entrySet().stream().anyMatch(entry -> !entry.getValue().getActivatedNetworkActions().isEmpty() || !entry.getValue().getActivatedRangeActions(entry.getKey()).isEmpty())) {
-            // If any activated ARA, re-run curative sensitivity analysis
-            AppliedRemedialActions appliedArasAndCras = secondPreventiveRaoResult.appliedCras.copy();
+        if (newPostContingencyResults.entrySet().stream().anyMatch(entry -> !entry.getValue().getActivatedNetworkActions().equals(postContingencyResults.get(entry.getKey()).getActivatedNetworkActions())
+                || !entry.getValue().getActivatedRangeActions(entry.getKey()).equals(postContingencyResults.get(entry.getKey()).getActivatedRangeActions(entry.getKey())))) {
+            // If activated ARAs in ARAO2 are different from activated ARAs in ARAO1, re-run curative sensitivity analysis
+            AppliedRemedialActions appliedArasAndCras = secondPreventiveRaoResult.getAppliedCurativeRas();
             addAppliedNetworkActionsPostContingency(appliedArasAndCras, newPostContingencyResults);
             addAppliedRangeActionsPostContingency(appliedArasAndCras, newPostContingencyResults);
             PrePerimeterResult postCraSensitivityAnalysisOutput = prePerimeterSensitivityAnalysis.runBasedOnInitialResults(raoInput.getNetwork(), raoInput.getCrac(), initialOutput, initialOutput, Collections.emptySet(), appliedArasAndCras);
@@ -476,14 +477,19 @@ public class CastorFullOptimization {
         private final PerimeterResult perimeterResult;
         private final PrePerimeterResult postPraSensitivityAnalysisOutput;
         private final Set<RemedialAction<?>> remedialActionsExcluded;
-        private final AppliedRemedialActions appliedCras;
+        private final AppliedRemedialActions appliedRas;
 
-        public SecondPreventiveRaoResult(PerimeterResult perimeterResult, PrePerimeterResult postPraSensitivityAnalysisOutput, Set<RemedialAction<?>> remedialActionsExcluded, AppliedRemedialActions appliedCras) {
+        public SecondPreventiveRaoResult(PerimeterResult perimeterResult, PrePerimeterResult postPraSensitivityAnalysisOutput, Set<RemedialAction<?>> remedialActionsExcluded, AppliedRemedialActions appliedRas) {
             this.perimeterResult = perimeterResult;
             this.postPraSensitivityAnalysisOutput = postPraSensitivityAnalysisOutput;
             this.remedialActionsExcluded = remedialActionsExcluded;
-            this.appliedCras = appliedCras;
+            this.appliedRas = appliedRas;
         }
+
+        public AppliedRemedialActions getAppliedCurativeRas() {
+            return appliedRas.getAppliedCurativeRas();
+        }
+
     }
 
     /**

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/AppliedRemedialActions.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/AppliedRemedialActions.java
@@ -113,6 +113,16 @@ public class AppliedRemedialActions {
         return ara;
     }
 
+    public AppliedRemedialActions getAppliedCurativeRas() {
+        AppliedRemedialActions ara = new AppliedRemedialActions();
+        appliedRa.entrySet().stream().filter(entry -> entry.getKey().getInstant().equals(Instant.CURATIVE))
+                .forEach(entry -> {
+                    ara.addAppliedNetworkActions(entry.getKey(), entry.getValue().networkActions);
+                    ara.addAppliedRangeActions(entry.getKey(), entry.getValue().rangeActions);
+                });
+        return ara;
+    }
+
     private void checkState(State state) {
         if (!state.getInstant().equals(Instant.CURATIVE) && !state.getInstant().equals(Instant.AUTO)) {
             throw new FaraoException("Sensitivity analysis with applied remedial actions only work with CURATIVE and AUTO remedial actions.");

--- a/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/AppliedRemedialActions.java
+++ b/sensitivity-analysis/src/main/java/com/farao_community/farao/sensitivity_analysis/AppliedRemedialActions.java
@@ -113,9 +113,12 @@ public class AppliedRemedialActions {
         return ara;
     }
 
-    public AppliedRemedialActions getAppliedCurativeRas() {
+    public AppliedRemedialActions getAppliedRemedialActionsAtAGivenInstant(Instant instant) {
+        if (!(instant.equals(Instant.AUTO) || instant.equals(Instant.CURATIVE))) {
+            throw new FaraoException("Only works with CURATIVE and AUTO remedial actions");
+        }
         AppliedRemedialActions ara = new AppliedRemedialActions();
-        appliedRa.entrySet().stream().filter(entry -> entry.getKey().getInstant().equals(Instant.CURATIVE))
+        appliedRa.entrySet().stream().filter(entry -> entry.getKey().getInstant().equals(instant))
                 .forEach(entry -> {
                     ara.addAppliedNetworkActions(entry.getKey(), entry.getValue().networkActions);
                     ara.addAppliedRangeActions(entry.getKey(), entry.getValue().rangeActions);

--- a/sensitivity-analysis/src/test/java/com/farao_community/farao/sensitivity_analysis/AppliedRemedialActionsTest.java
+++ b/sensitivity-analysis/src/test/java/com/farao_community/farao/sensitivity_analysis/AppliedRemedialActionsTest.java
@@ -53,9 +53,7 @@ public class AppliedRemedialActionsTest {
 
         // check object
         assertFalse(appliedRemedialActions.isEmpty(network));
-        assertFalse(appliedRemedialActions.getAppliedCurativeRas().isEmpty(network));
         assertEquals(1, appliedRemedialActions.getStatesWithRa(network).size());
-        assertEquals(1, appliedRemedialActions.getAppliedCurativeRas().getStatesWithRa(network).size());
         assertEquals("Contingency FR1 FR3", appliedRemedialActions.getStatesWithRa(network).iterator().next().getContingency().orElseThrow().getId());
         // apply remedial actions on network
         assertTrue(network.getBranch("BBE2AA1  FFR3AA1  1").getTerminal1().isConnected());
@@ -76,9 +74,7 @@ public class AppliedRemedialActionsTest {
         appliedRemedialActions.addAppliedRangeAction(crac.getState("Contingency FR1 FR2", Instant.CURATIVE), pstRangeAction, 3.2);
 
         assertFalse(appliedRemedialActions.isEmpty(network));
-        assertFalse(appliedRemedialActions.getAppliedCurativeRas().isEmpty(network));
         assertEquals(2, appliedRemedialActions.getStatesWithRa(network).size());
-        assertEquals(2, appliedRemedialActions.getAppliedCurativeRas().getStatesWithRa(network).size());
 
         // apply remedial actions on network
         assertTrue(network.getBranch("BBE2AA1  FFR3AA1  1").getTerminal1().isConnected());
@@ -95,9 +91,7 @@ public class AppliedRemedialActionsTest {
         AppliedRemedialActions appliedRemedialActions = new AppliedRemedialActions();
 
         assertTrue(appliedRemedialActions.isEmpty(network));
-        assertTrue(appliedRemedialActions.getAppliedCurativeRas().isEmpty(network));
         assertEquals(0, appliedRemedialActions.getStatesWithRa(network).size());
-        assertEquals(0, appliedRemedialActions.getAppliedCurativeRas().getStatesWithRa(network).size());
 
     }
 
@@ -108,9 +102,7 @@ public class AppliedRemedialActionsTest {
         // should not be taken into account, as PST setpoint is the same as in the initial network
 
         assertTrue(appliedRemedialActions.isEmpty(network));
-        assertTrue(appliedRemedialActions.getAppliedCurativeRas().isEmpty(network));
         assertEquals(0, appliedRemedialActions.getStatesWithRa(network).size());
-        assertEquals(0, appliedRemedialActions.getAppliedCurativeRas().getStatesWithRa(network).size());
 
     }
 
@@ -159,8 +151,8 @@ public class AppliedRemedialActionsTest {
     }
 
     @Test
-    public void testGetCurativeRAs() {
-        // Setup specific to this test to verify that method only takes Curative RAs and no other
+    public void testGetAppliedRemedialActionsAtAGivenInstant() {
+        // Setup specific to this test to verify that method only takes RAs from a given instant and no other
         // Creates a fake_pst with an AUTO instant because addAppliedRemedialAction method only allows instant Curative or Auto
         IidmPstHelper pstHelper = new IidmPstHelper("BBE2AA1  BBE3AA1  1", network);
         crac.newPstRangeAction()
@@ -184,6 +176,9 @@ public class AppliedRemedialActionsTest {
         appliedRemedialActions.addAppliedRangeAction(crac.getState("Contingency FR1 FR3", Instant.AUTO), pstRangeAction, 3.2);
 
         assertEquals(2, appliedRemedialActions.getStatesWithRa(network).size());
-        assertEquals(1, appliedRemedialActions.getAppliedCurativeRas().getStatesWithRa(network).size());
+        assertEquals(1, appliedRemedialActions.getAppliedRemedialActionsAtAGivenInstant(Instant.AUTO).getStatesWithRa(network).size());
+        assertEquals(1, appliedRemedialActions.getAppliedRemedialActionsAtAGivenInstant(Instant.CURATIVE).getStatesWithRa(network).size());
+        assertThrows(FaraoException.class, () -> appliedRemedialActions.getAppliedRemedialActionsAtAGivenInstant(Instant.PREVENTIVE));
+        assertThrows(FaraoException.class, () -> appliedRemedialActions.getAppliedRemedialActionsAtAGivenInstant(Instant.OUTAGE));
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No but it refers to the FAR-784 ticket on JIRA

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*

If any activated ARA, re-run sensi with applied Aras and Cras

**What is the new behavior (if this is a feature change)?**

If 2ARA != 1ARA, re-run sensi with applied Cras

**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*

No

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
