### PR TITLE
More optimal approach to max CRA

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/parameters/SearchTreeRaoParameters.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/parameters/SearchTreeRaoParameters.java
@@ -220,6 +220,7 @@ public class SearchTreeRaoParameters extends AbstractExtension<RaoParameters> {
         if (Objects.isNull(maxCurativeTopoPerTso)) {
             this.maxCurativeTopoPerTso = new HashMap<>();
         } else {
+            crossCheckMaxCraPerTsoParameters(this.maxCurativeRaPerTso, maxCurativeTopoPerTso, this.maxCurativePstPerTso);
             this.maxCurativeTopoPerTso = maxCurativeTopoPerTso;
         }
     }
@@ -232,6 +233,7 @@ public class SearchTreeRaoParameters extends AbstractExtension<RaoParameters> {
         if (Objects.isNull(maxCurativePstPerTso)) {
             this.maxCurativePstPerTso = new HashMap<>();
         } else {
+            crossCheckMaxCraPerTsoParameters(this.maxCurativeRaPerTso, this.maxCurativeTopoPerTso, maxCurativePstPerTso);
             this.maxCurativePstPerTso = maxCurativePstPerTso;
         }
     }
@@ -244,6 +246,7 @@ public class SearchTreeRaoParameters extends AbstractExtension<RaoParameters> {
         if (Objects.isNull(maxCurativeRaPerTso)) {
             this.maxCurativeRaPerTso = new HashMap<>();
         } else {
+            crossCheckMaxCraPerTsoParameters(maxCurativeRaPerTso, this.maxCurativeTopoPerTso, this.maxCurativePstPerTso);
             this.maxCurativeRaPerTso = maxCurativeRaPerTso;
         }
     }
@@ -331,6 +334,23 @@ public class SearchTreeRaoParameters extends AbstractExtension<RaoParameters> {
         }
 
         return Optional.of(new NetworkActionCombination(networkActions));
+    }
+
+    private static void crossCheckMaxCraPerTsoParameters(Map<String, Integer> maxCurativeRaPerTso, Map<String, Integer> maxCurativeTopoPerTso, Map<String, Integer> maxCurativePstPerTso) {
+        Set<String> tsos = new HashSet<>();
+        tsos.addAll(maxCurativeRaPerTso.keySet());
+        tsos.addAll(maxCurativeTopoPerTso.keySet());
+        tsos.addAll(maxCurativePstPerTso.keySet());
+        tsos.forEach(tso -> {
+            if (maxCurativeTopoPerTso.containsKey(tso)
+                && maxCurativeRaPerTso.getOrDefault(tso, 1000) < maxCurativeTopoPerTso.get(tso)) {
+                throw new FaraoException(String.format("TSO %s has a maximum number of allowed CRAs smaller than the number of allowed topological CRAs. This is not supported.", tso));
+            }
+            if (maxCurativePstPerTso.containsKey(tso)
+                && maxCurativeRaPerTso.getOrDefault(tso, 1000) < maxCurativePstPerTso.get(tso)) {
+                throw new FaraoException(String.format("TSO %s has a maximum number of allowed CRAs smaller than the number of allowed PST CRAs. This is not supported.", tso));
+            }
+        });
     }
 
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -18,12 +18,10 @@ import com.farao_community.farao.search_tree_rao.commons.NetworkActionCombinatio
 import com.farao_community.farao.search_tree_rao.commons.RaoLogger;
 import com.farao_community.farao.search_tree_rao.commons.SensitivityComputer;
 import com.farao_community.farao.search_tree_rao.commons.optimization_perimeters.CurativeOptimizationPerimeter;
-import com.farao_community.farao.search_tree_rao.commons.optimization_perimeters.GlobalOptimizationPerimeter;
 import com.farao_community.farao.search_tree_rao.commons.optimization_perimeters.OptimizationPerimeter;
 import com.farao_community.farao.search_tree_rao.commons.parameters.TreeParameters;
 import com.farao_community.farao.search_tree_rao.result.api.OptimizationResult;
 import com.farao_community.farao.search_tree_rao.result.api.PrePerimeterResult;
-import com.farao_community.farao.search_tree_rao.result.api.RangeActionActivationResult;
 import com.farao_community.farao.search_tree_rao.result.impl.RangeActionActivationResultImpl;
 import com.farao_community.farao.search_tree_rao.search_tree.inputs.SearchTreeInput;
 import com.farao_community.farao.search_tree_rao.search_tree.parameters.SearchTreeParameters;
@@ -100,27 +98,25 @@ public class SearchTree {
         if (input.getOptimizationPerimeter() instanceof CurativeOptimizationPerimeter) {
             this.bloomer = new SearchTreeBloomer(
                 input.getNetwork(),
-                input.getPrePerimeterResult(),
                 parameters.getRaLimitationParameters().getMaxCurativeRa(),
                 parameters.getRaLimitationParameters().getMaxCurativeTso(),
                 parameters.getRaLimitationParameters().getMaxCurativeTopoPerTso(),
                 parameters.getRaLimitationParameters().getMaxCurativeRaPerTso(),
                 parameters.getNetworkActionParameters().skipNetworkActionFarFromMostLimitingElements(),
                 parameters.getNetworkActionParameters().getMaxNumberOfBoundariesForSkippingNetworkActions(),
-                parameters.getNetworkActionParameters().getNetworkActionCombinations(),
-                input.getOptimizationPerimeter().getMainOptimizationState());
+                parameters.getNetworkActionParameters().getNetworkActionCombinations()
+            );
         } else {
             this.bloomer = new SearchTreeBloomer(
                 input.getNetwork(),
-                input.getPrePerimeterResult(),
                 Integer.MAX_VALUE, //no limitation of RA in preventive
                 Integer.MAX_VALUE, //no limitation of RA in preventive
                 new HashMap<>(),   //no limitation of RA in preventive
                 new HashMap<>(),   //no limitation of RA in preventive
                 parameters.getNetworkActionParameters().skipNetworkActionFarFromMostLimitingElements(),
                 parameters.getNetworkActionParameters().getMaxNumberOfBoundariesForSkippingNetworkActions(),
-                parameters.getNetworkActionParameters().getNetworkActionCombinations(),
-                input.getOptimizationPerimeter().getMainOptimizationState());
+                parameters.getNetworkActionParameters().getNetworkActionCombinations()
+            );
         }
     }
 
@@ -131,7 +127,7 @@ public class SearchTree {
         applyForcedNetworkActionsOnRootLeaf();
 
         TECHNICAL_LOGS.info("Evaluating root leaf");
-        rootLeaf.evaluate(input.getObjectiveFunction(), getSensitivityComputerForEvaluation(true));
+        rootLeaf.evaluate(input.getObjectiveFunction(), getSensitivityComputerForEvaluation());
         this.preOptimFunctionalCost = rootLeaf.getFunctionalCost();
         this.preOptimVirtualCost = rootLeaf.getVirtualCost();
 
@@ -270,7 +266,7 @@ public class SearchTree {
         CountDownLatch latch = new CountDownLatch(naCombinations.size());
         naCombinations.forEach(naCombination ->
             networkPool.submit(() -> {
-                Network networkClone = null;
+                Network networkClone;
                 try {
                     networkClone = networkPool.getAvailableNetwork(); //This is where the threads actually wait for available networks
                 } catch (InterruptedException e) {
@@ -279,16 +275,11 @@ public class SearchTree {
                     throw new FaraoException(e);
                 }
                 try {
-                    Network networkFinal = networkClone;
                     if (combinationFulfillingStopCriterion.isEmpty() || deterministicNetworkActionCombinationComparison(naCombination, combinationFulfillingStopCriterion.get()) < 0) {
-                        // Apply range actions that has been changed by the previous leaf on the network to start next depth leaves
-                        // from previous optimal leaf starting point
-                        // TODO: we can wonder if it's better to do this here or at creation of each leaves or at each evaluation/optimization
-                        previousDepthOptimalLeaf.getRangeActions()
-                            .forEach(ra -> ra.apply(networkFinal, previousDepthOptimalLeaf.getOptimizedSetpoint(ra, input.getOptimizationPerimeter().getMainOptimizationState())));
-
-                        // todo
-                        // set alreadyAppliedRa
+                        // Reset range action to their pre-perimeter set-points
+                        previousDepthOptimalLeaf.getRangeActions().forEach(ra ->
+                            ra.apply(networkClone, input.getPrePerimeterResult().getRangeActionSetpointResult().getSetpoint(ra))
+                        );
 
                         optimizeNextLeafAndUpdate(naCombination, networkClone);
                     } else {
@@ -379,7 +370,7 @@ public class SearchTree {
             throw e;
         }
         // We evaluate the leaf with taking the results of the previous optimal leaf if we do not want to update some results
-        leaf.evaluate(input.getObjectiveFunction(), getSensitivityComputerForEvaluation(false));
+        leaf.evaluate(input.getObjectiveFunction(), getSensitivityComputerForEvaluation());
         TECHNICAL_LOGS.debug("Evaluated {}", leaf);
         if (!leaf.getStatus().equals(Leaf.Status.ERROR)) {
             if (!stopCriterionReached(leaf)) {
@@ -405,9 +396,9 @@ public class SearchTree {
             network,
             previousDepthOptimalLeaf.getActivatedNetworkActions(),
             naCombination,
-            previousDepthOptimalLeaf.getRangeActionActivationResult(),
+            new RangeActionActivationResultImpl(input.getPrePerimeterResult()),
             input.getPrePerimeterResult(),
-            getAppliedRemedialActions(previousDepthOptimalLeaf));
+            input.getPreOptimizationAppliedNetworkActions());
     }
 
     private void optimizeLeaf(Leaf leaf) {
@@ -422,18 +413,14 @@ public class SearchTree {
         leaf.finalizeOptimization();
     }
 
-    private SensitivityComputer getSensitivityComputerForEvaluation(boolean isRootLeaf) {
+    private SensitivityComputer getSensitivityComputerForEvaluation() {
 
         SensitivityComputer.SensitivityComputerBuilder sensitivityComputerBuilder = SensitivityComputer.create()
             .withToolProvider(input.getToolProvider())
             .withCnecs(input.getOptimizationPerimeter().getFlowCnecs())
             .withRangeActions(input.getOptimizationPerimeter().getRangeActions());
 
-        if (isRootLeaf) {
-            sensitivityComputerBuilder.withAppliedRemedialActions(input.getPreOptimizationAppliedNetworkActions());
-        } else {
-            sensitivityComputerBuilder.withAppliedRemedialActions(getAppliedRemedialActions(previousDepthOptimalLeaf));
-        }
+        sensitivityComputerBuilder.withAppliedRemedialActions(input.getPreOptimizationAppliedNetworkActions());
 
         if (parameters.getObjectiveFunction().relativePositiveMargins()) {
             sensitivityComputerBuilder.withPtdfsResults(input.getInitialFlowResult());
@@ -518,16 +505,6 @@ public class SearchTree {
 
         return previousDepthBestCost - absoluteImpact > newCost // enough absolute impact
             && (1 - Math.signum(previousDepthBestCost) * relativeImpact) * previousDepthBestCost > newCost; // enough relative impact
-    }
-
-    private AppliedRemedialActions getAppliedRemedialActions(RangeActionActivationResult previousDepthRangeActionActivations) {
-        AppliedRemedialActions alreadyAppliedRa = input.getPreOptimizationAppliedNetworkActions().copy();
-        if (input.getOptimizationPerimeter() instanceof GlobalOptimizationPerimeter) {
-            input.getOptimizationPerimeter().getRangeActionsPerState().entrySet().stream()
-                .filter(e -> !e.getKey().equals(input.getOptimizationPerimeter().getMainOptimizationState())) // remove preventive state
-                .forEach(e -> e.getValue().forEach(ra -> alreadyAppliedRa.addAppliedRangeAction(e.getKey(), ra, previousDepthRangeActionActivations.getOptimizedSetpoint(ra, e.getKey()))));
-        }
-        return alreadyAppliedRa;
     }
 
     /**

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -169,7 +169,7 @@ public class SearchTree {
     }
 
     void initLeaves(SearchTreeInput input) {
-        rootLeaf = makeLeaf(input.getOptimizationPerimeter(), input.getNetwork(), input.getPrePerimeterResult(), input.getPreOptimizationAppliedNetworkActions());
+        rootLeaf = makeLeaf(input.getOptimizationPerimeter(), input.getNetwork(), input.getPrePerimeterResult(), input.getPreOptimizationAppliedRemedialActions());
         optimalLeaf = rootLeaf;
         previousDepthOptimalLeaf = rootLeaf;
     }
@@ -196,7 +196,7 @@ public class SearchTree {
                 forcedNetworkActions,
                 null,
                 input.getPrePerimeterResult(),
-                input.getPreOptimizationAppliedNetworkActions());
+                input.getPreOptimizationAppliedRemedialActions());
             optimalLeaf = rootLeaf;
             previousDepthOptimalLeaf = rootLeaf;
         }
@@ -395,7 +395,7 @@ public class SearchTree {
             previousDepthOptimalLeaf.getActivatedNetworkActions(),
             naCombination,
             input.getPrePerimeterResult(),
-            input.getPreOptimizationAppliedNetworkActions());
+            input.getPreOptimizationAppliedRemedialActions());
     }
 
     private void optimizeLeaf(Leaf leaf) {
@@ -417,7 +417,7 @@ public class SearchTree {
             .withCnecs(input.getOptimizationPerimeter().getFlowCnecs())
             .withRangeActions(input.getOptimizationPerimeter().getRangeActions());
 
-        sensitivityComputerBuilder.withAppliedRemedialActions(input.getPreOptimizationAppliedNetworkActions());
+        sensitivityComputerBuilder.withAppliedRemedialActions(input.getPreOptimizationAppliedRemedialActions());
 
         if (parameters.getObjectiveFunction().relativePositiveMargins()) {
             sensitivityComputerBuilder.withPtdfsResults(input.getInitialFlowResult());

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -22,7 +22,6 @@ import com.farao_community.farao.search_tree_rao.commons.optimization_perimeters
 import com.farao_community.farao.search_tree_rao.commons.parameters.TreeParameters;
 import com.farao_community.farao.search_tree_rao.result.api.OptimizationResult;
 import com.farao_community.farao.search_tree_rao.result.api.PrePerimeterResult;
-import com.farao_community.farao.search_tree_rao.result.impl.RangeActionActivationResultImpl;
 import com.farao_community.farao.search_tree_rao.search_tree.inputs.SearchTreeInput;
 import com.farao_community.farao.search_tree_rao.search_tree.parameters.SearchTreeParameters;
 import com.farao_community.farao.sensitivity_analysis.AppliedRemedialActions;
@@ -196,7 +195,6 @@ public class SearchTree {
                 input.getNetwork(),
                 forcedNetworkActions,
                 null,
-                new RangeActionActivationResultImpl(input.getPrePerimeterResult()),
                 input.getPrePerimeterResult(),
                 input.getPreOptimizationAppliedNetworkActions());
             optimalLeaf = rootLeaf;
@@ -396,7 +394,6 @@ public class SearchTree {
             network,
             previousDepthOptimalLeaf.getActivatedNetworkActions(),
             naCombination,
-            new RangeActionActivationResultImpl(input.getPrePerimeterResult()),
             input.getPrePerimeterResult(),
             input.getPreOptimizationAppliedNetworkActions());
     }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/inputs/SearchTreeInput.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/inputs/SearchTreeInput.java
@@ -26,7 +26,7 @@ public final class SearchTreeInput {
 
     private final FlowResult initialFlowResult;
     private final PrePerimeterResult prePerimeterResult;
-    private final AppliedRemedialActions preOptimizationAppliedNetworkActions;
+    private final AppliedRemedialActions preOptimizationAppliedRemedialActions;
 
     private final ObjectiveFunction objectiveFunction;
     private final ToolProvider toolProvider;
@@ -35,14 +35,14 @@ public final class SearchTreeInput {
                             OptimizationPerimeter optimizationPerimeter,
                             FlowResult initialFlowResult,
                             PrePerimeterResult prePerimeterResult,
-                            AppliedRemedialActions preOptimizationAppliedNetworkActions,
+                            AppliedRemedialActions preOptimizationAppliedRemedialActions,
                             ObjectiveFunction objectiveFunction,
                             ToolProvider toolProvider) {
         this.network = network;
         this.optimizationPerimeter = optimizationPerimeter;
         this.initialFlowResult = initialFlowResult;
         this.prePerimeterResult = prePerimeterResult;
-        this.preOptimizationAppliedNetworkActions = preOptimizationAppliedNetworkActions;
+        this.preOptimizationAppliedRemedialActions = preOptimizationAppliedRemedialActions;
         this.objectiveFunction = objectiveFunction;
         this.toolProvider = toolProvider;
     }
@@ -63,8 +63,8 @@ public final class SearchTreeInput {
         return prePerimeterResult;
     }
 
-    public AppliedRemedialActions getPreOptimizationAppliedNetworkActions() {
-        return preOptimizationAppliedNetworkActions;
+    public AppliedRemedialActions getPreOptimizationAppliedRemedialActions() {
+        return preOptimizationAppliedRemedialActions;
     }
 
     public ObjectiveFunction getObjectiveFunction() {

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/castor/parameters/SearchTreeRaoParametersTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/castor/parameters/SearchTreeRaoParametersTest.java
@@ -204,4 +204,18 @@ public class SearchTreeRaoParametersTest {
         parameters.setCurativeRaoOptimizeOperatorsNotSharingCras(true);
         assertTrue(parameters.getCurativeRaoOptimizeOperatorsNotSharingCras());
     }
+
+    @Test
+    public void testIncompatibleMaxCraParameters() {
+        SearchTreeRaoParameters parameters = new SearchTreeRaoParameters();
+        parameters.setMaxCurativeRaPerTso(Map.of("RTE", 5, "REE", 1));
+
+        Exception exception = assertThrows(FaraoException.class, () -> parameters.setMaxCurativeTopoPerTso(Map.of("RTE", 6)));
+        assertEquals("TSO RTE has a maximum number of allowed CRAs smaller than the number of allowed topological CRAs. This is not supported.", exception.getMessage());
+        assertTrue(parameters.getMaxCurativeTopoPerTso().isEmpty());
+
+        exception = assertThrows(FaraoException.class, () -> parameters.setMaxCurativePstPerTso(Map.of("REE", 2)));
+        assertEquals("TSO REE has a maximum number of allowed CRAs smaller than the number of allowed PST CRAs. This is not supported.", exception.getMessage());
+        assertTrue(parameters.getMaxCurativePstPerTso().isEmpty());
+    }
 }

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
@@ -110,7 +110,7 @@ public class LeafTest {
 
     private Leaf buildNotEvaluatedRootLeaf() {
         RangeActionActivationResult rangeActionActivationResult = Mockito.mock(RangeActionActivationResult.class);
-        return new Leaf(optimizationPerimeter, network, new HashSet<>(), new NetworkActionCombination(na1),  rangeActionActivationResult, prePerimeterResult, appliedRemedialActions);
+        return new Leaf(optimizationPerimeter, network, new HashSet<>(), new NetworkActionCombination(na1), prePerimeterResult, appliedRemedialActions);
     }
 
     private void prepareLinearProblemBuilder(IteratingLinearOptimizationResultImpl linearOptimizationResult) {
@@ -144,8 +144,8 @@ public class LeafTest {
     public void testMultipleLeafsDefinition() {
         Leaf rootLeaf = new Leaf(optimizationPerimeter, network, prePerimeterResult, appliedRemedialActions);
         RangeActionActivationResult rangeActionActivationResult = Mockito.mock(RangeActionActivationResult.class);
-        Leaf leaf1 = new Leaf(optimizationPerimeter, network, rootLeaf.getActivatedNetworkActions(), new NetworkActionCombination(na1), rangeActionActivationResult, prePerimeterResult, appliedRemedialActions);
-        Leaf leaf2 = new Leaf(optimizationPerimeter, network, leaf1.getActivatedNetworkActions(), new NetworkActionCombination(na2), rangeActionActivationResult, prePerimeterResult, appliedRemedialActions);
+        Leaf leaf1 = new Leaf(optimizationPerimeter, network, rootLeaf.getActivatedNetworkActions(), new NetworkActionCombination(na1), prePerimeterResult, appliedRemedialActions);
+        Leaf leaf2 = new Leaf(optimizationPerimeter, network, leaf1.getActivatedNetworkActions(), new NetworkActionCombination(na2), prePerimeterResult, appliedRemedialActions);
         assertEquals(1, leaf1.getActivatedNetworkActions().size());
         assertEquals(2, leaf2.getActivatedNetworkActions().size());
         assertTrue(leaf1.getActivatedNetworkActions().contains(na1));
@@ -163,8 +163,8 @@ public class LeafTest {
     public void testMultipleLeafDefinitionWithSameNetworkAction() {
         Leaf rootLeaf = new Leaf(optimizationPerimeter, network, prePerimeterResult, appliedRemedialActions);
         RangeActionActivationResult rangeActionActivationResult = Mockito.mock(RangeActionActivationResult.class);
-        Leaf leaf1 = new Leaf(optimizationPerimeter, network, rootLeaf.getActivatedNetworkActions(), new NetworkActionCombination(na1), rangeActionActivationResult, prePerimeterResult, appliedRemedialActions);
-        Leaf leaf2 = new Leaf(optimizationPerimeter, network, leaf1.getActivatedNetworkActions(), new NetworkActionCombination(na1), rangeActionActivationResult, prePerimeterResult, appliedRemedialActions);
+        Leaf leaf1 = new Leaf(optimizationPerimeter, network, rootLeaf.getActivatedNetworkActions(), new NetworkActionCombination(na1), prePerimeterResult, appliedRemedialActions);
+        Leaf leaf2 = new Leaf(optimizationPerimeter, network, leaf1.getActivatedNetworkActions(), new NetworkActionCombination(na1), prePerimeterResult, appliedRemedialActions);
         assertEquals(1, leaf2.getActivatedNetworkActions().size());
         assertTrue(leaf2.getActivatedNetworkActions().contains(na1));
         assertFalse(leaf2.isRoot());
@@ -185,7 +185,7 @@ public class LeafTest {
         when(networkAction.apply(any())).thenReturn(true);
         Leaf rootLeaf = new Leaf(optimizationPerimeter, network, prePerimeterResult, appliedRemedialActions);
         RangeActionActivationResult rangeActionActivationResult = Mockito.mock(RangeActionActivationResult.class);
-        Leaf leaf = new Leaf(optimizationPerimeter, network, rootLeaf.getActivatedNetworkActions(), new NetworkActionCombination(networkAction), rangeActionActivationResult, prePerimeterResult, appliedRemedialActions);
+        Leaf leaf = new Leaf(optimizationPerimeter, network, rootLeaf.getActivatedNetworkActions(), new NetworkActionCombination(networkAction), prePerimeterResult, appliedRemedialActions);
         SensitivityResult expectedSensitivityResult = Mockito.mock(SensitivityResult.class);
         when(sensitivityComputer.getSensitivityResult()).thenReturn(expectedSensitivityResult);
         when(expectedSensitivityResult.getSensitivityStatus()).thenReturn(expectedSensitivityStatus);
@@ -777,7 +777,7 @@ public class LeafTest {
         Network network = Mockito.mock(Network.class);
         RangeActionActivationResult rangeActionActivationResult = Mockito.mock(RangeActionActivationResult.class);
         Set<NetworkAction> alreadyAppliedNetworkActions = Set.of();
-        assertThrows(FaraoException.class, () -> new Leaf(optimizationPerimeter, network, alreadyAppliedNetworkActions, naCombinationToApply, rangeActionActivationResult, prePerimeterResult, appliedRemedialActions));
+        assertThrows(FaraoException.class, () -> new Leaf(optimizationPerimeter, network, alreadyAppliedNetworkActions, naCombinationToApply, prePerimeterResult, appliedRemedialActions));
     }
 
     @Test

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomerTest.java
@@ -22,7 +22,6 @@ import com.farao_community.farao.data.crac_api.usage_rule.UsageMethod;
 import com.farao_community.farao.data.crac_impl.utils.CommonCracCreation;
 import com.farao_community.farao.data.crac_impl.utils.NetworkImportsUtil;
 import com.farao_community.farao.search_tree_rao.commons.NetworkActionCombination;
-import com.farao_community.farao.search_tree_rao.result.api.RangeActionSetpointResult;
 import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import org.junit.Before;
@@ -135,7 +134,7 @@ public class SearchTreeBloomerTest {
         Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Collections.singleton(naFr1));
 
         // filter already activated NetworkAction
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>());
         List<NetworkActionCombination> filteredNaCombinations = bloomer.removeAlreadyActivatedNetworkActions(naCombinations, previousLeaf);
 
         assertEquals(5, filteredNaCombinations.size());
@@ -155,7 +154,7 @@ public class SearchTreeBloomerTest {
         Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Set.of(naFr1, naBe1));
 
         // filter already tested combinations
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, false, 0, preDefinedNaCombinations, pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, false, 0, preDefinedNaCombinations);
         List<NetworkActionCombination> filteredNaCombinations = bloomer.removeAlreadyTestedCombinations(naCombinations, previousLeaf);
 
         assertEquals(5, filteredNaCombinations.size());
@@ -174,20 +173,20 @@ public class SearchTreeBloomerTest {
         Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Collections.singleton(naFr1));
 
         // filter - max 4 RAs
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 4, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, 4, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>());
         List<NetworkActionCombination> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(8, filteredNaCombination.size()); // no combination filtered
 
         // filter - max 3 RAs
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 3, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, 3, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>());
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(7, filteredNaCombination.size()); // one combination filtered
         assertFalse(filteredNaCombination.contains(comb3Be));
 
         // max 2 RAs
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 2, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, 2, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>());
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(4, filteredNaCombination.size());
@@ -197,7 +196,7 @@ public class SearchTreeBloomerTest {
         assertTrue(filteredNaCombination.contains(indNl1));
 
         // max 1 RAs
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 1, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, 1, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>());
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(0, filteredNaCombination.size()); // all combination filtered
@@ -209,7 +208,8 @@ public class SearchTreeBloomerTest {
         // arrange naCombination list
         List<NetworkActionCombination> naCombinations = List.of(indFr2, indBe1, indNl1, indFrDe, comb2Fr, comb3Be, comb2BeNl, comb2FrNl);
 
-        // arrange Leaf -> naFr1 and raBe1 have already been activated
+        // arrange Leaf -> naFr1 and raBe1 have already been activated in previous leaf
+        // but only naFr1 should count
         Leaf previousLeaf = Mockito.mock(Leaf.class);
         Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Collections.singleton(naFr1));
         Mockito.when(previousLeaf.getRangeActions()).thenReturn(Collections.singleton(raBe1));
@@ -217,7 +217,7 @@ public class SearchTreeBloomerTest {
 
         // filter - max 2 topo in FR and DE
         Map<String, Integer> maxTopoPerTso = Map.of("fr", 2, "be", 2);
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>());
         List<NetworkActionCombination> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(6, filteredNaCombination.size()); // 2 combinations filtered
@@ -226,7 +226,7 @@ public class SearchTreeBloomerTest {
 
         // filter - max 1 topo in FR
         maxTopoPerTso = Map.of("fr", 1);
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>());
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(4, filteredNaCombination.size()); // 4 combinations filtered
@@ -237,7 +237,7 @@ public class SearchTreeBloomerTest {
 
         // filter - max 1 RA in FR and max 2 RA in BE
         Map<String, Integer> maxRaPerTso = Map.of("fr", 1, "be", 2);
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), maxRaPerTso, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), maxRaPerTso, false, 0, new ArrayList<>());
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(3, filteredNaCombination.size());
@@ -248,17 +248,18 @@ public class SearchTreeBloomerTest {
         // filter - max 2 topo in FR, max 0 topo in Nl and max 1 RA in BE
         maxTopoPerTso = Map.of("fr", 2, "nl", 0);
         maxRaPerTso = Map.of("be", 1);
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>());
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
-        assertEquals(2, filteredNaCombination.size());
+        assertEquals(3, filteredNaCombination.size());
         assertTrue(filteredNaCombination.contains(indFr2));
         assertTrue(filteredNaCombination.contains(indFrDe));
+        assertTrue(filteredNaCombination.contains(indBe1));
 
         // filter - no RA in NL
         maxTopoPerTso = Map.of("fr", 10, "nl", 10, "be", 10);
         maxRaPerTso = Map.of("nl", 0);
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>());
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(5, filteredNaCombination.size());
@@ -278,20 +279,20 @@ public class SearchTreeBloomerTest {
         Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Collections.singleton(naFr1));
 
         // max 3 TSOs
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, 3, null, null, false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, 3, null, null, false, 0, new ArrayList<>());
         List<NetworkActionCombination> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
 
         assertEquals(8, filteredNaCombination.size()); // no combination filtered
 
         // max 2 TSOs
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, 2, null, null, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, 2, null, null, false, 0, new ArrayList<>());
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
 
         assertEquals(7, filteredNaCombination.size());
         assertFalse(filteredNaCombination.contains(comb2BeNl)); // one combination filtered
 
         // max 1 TSO
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, 1, null, null, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, 1, null, null, false, 0, new ArrayList<>());
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
 
         assertEquals(3, filteredNaCombination.size());
@@ -312,7 +313,7 @@ public class SearchTreeBloomerTest {
 
         // test - no border cross, most limiting element is in BE/FR
         Mockito.when(previousLeaf.getMostLimitingElements(1)).thenReturn(List.of(crac.getFlowCnec("cnec1basecase"))); // be fr
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, true, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, true, 0, new ArrayList<>());
         List<NetworkActionCombination> filteredNaCombination = bloomer.removeCombinationsFarFromMostLimitingElement(naCombinations, previousLeaf);
 
         assertEquals(7, filteredNaCombination.size());
@@ -327,7 +328,7 @@ public class SearchTreeBloomerTest {
 
         // test - max 1 border cross, most limiting element is in BE
         Mockito.when(previousLeaf.getMostLimitingElements(1)).thenReturn(List.of(crac.getFlowCnec("cnecBe"))); // be
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>());
         filteredNaCombination = bloomer.removeCombinationsFarFromMostLimitingElement(naCombinations, previousLeaf);
 
         assertEquals(9, filteredNaCombination.size());
@@ -337,7 +338,7 @@ public class SearchTreeBloomerTest {
     @Test
     public void testGetOptimizedMostLimitingElementsLocation() {
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>());
 
         Leaf leaf = mock(Leaf.class);
         Mockito.when(leaf.getVirtualCostNames()).thenReturn(Set.of("mnec", "lf"));
@@ -383,7 +384,7 @@ public class SearchTreeBloomerTest {
         boundaries.add(new CountryBoundary(Country.DE, Country.AT));
         CountryGraph countryGraph = new CountryGraph(boundaries);
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>());
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.empty()), countryGraph));
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.FR)), countryGraph));
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.BE)), countryGraph));
@@ -391,11 +392,11 @@ public class SearchTreeBloomerTest {
         assertFalse(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.AT)), countryGraph));
         assertTrue(bloomer.isNetworkActionCloseToLocations(na2, Set.of(Optional.of(Country.AT)), countryGraph));
 
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>());
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.DE)), countryGraph));
         assertFalse(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.AT)), countryGraph));
 
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, true, 2, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, true, 2, new ArrayList<>());
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.AT)), countryGraph));
     }
 
@@ -412,12 +413,11 @@ public class SearchTreeBloomerTest {
         Mockito.when(leaf.getOptimizedSetpoint(raBe1, pState)).thenReturn(5.);
         Mockito.when(leaf.getOptimizedSetpoint(nonActivatedRa, pState)).thenReturn(0.);
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
-        Set<String> activatedTsos = bloomer.getActivatedTsos(leaf);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>());
+        Set<String> activatedTsos = bloomer.getTsosWithActivatedNetworkActions(leaf);
 
-        assertEquals(2, activatedTsos.size());
-        assertTrue(activatedTsos.contains("fr"));
-        assertTrue(activatedTsos.contains("be"));
+        // only network actions count when counting activated RAs in previous leaf
+        assertEquals(Set.of("fr"), activatedTsos);
     }
 
     @Test
@@ -425,9 +425,9 @@ public class SearchTreeBloomerTest {
         NetworkAction na1 = Mockito.mock(NetworkAction.class);
         NetworkAction na2 = Mockito.mock(NetworkAction.class);
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class),
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,
             Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), new HashMap<>(), false, 0,
-            List.of(new NetworkActionCombination(Set.of(na2), true)), pState);
+            List.of(new NetworkActionCombination(Set.of(na2), true)));
         Leaf leaf = Mockito.mock(Leaf.class);
         Mockito.when(leaf.getActivatedNetworkActions()).thenReturn(Collections.emptySet());
         List<NetworkActionCombination> result = bloomer.bloom(leaf, Set.of(na1, na2));
@@ -459,12 +459,12 @@ public class SearchTreeBloomerTest {
         NetworkAction na1 = Mockito.mock(NetworkAction.class);
         NetworkAction na2 = Mockito.mock(NetworkAction.class);
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class),
-                Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), new HashMap<>(), false, 0,
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,
+            Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), new HashMap<>(), false, 0,
                 List.of(new NetworkActionCombination(Set.of(na1, na2), false),
                         new NetworkActionCombination(Set.of(na1, na2), false),
-                        new NetworkActionCombination(Set.of(na1, na2), true)),
-                pState);
+                        new NetworkActionCombination(Set.of(na1, na2), true))
+        );
         Leaf leaf = Mockito.mock(Leaf.class);
         Mockito.when(leaf.getActivatedNetworkActions()).thenReturn(Collections.emptySet());
         List<NetworkActionCombination> result = bloomer.bloom(leaf, Set.of(na1, na2));

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
@@ -114,7 +114,7 @@ public class SearchTreeTest {
     private void setSearchTreeInput() {
         searchTreeInput = Mockito.mock(SearchTreeInput.class);
         appliedRemedialActions = Mockito.mock(AppliedRemedialActions.class);
-        when(searchTreeInput.getPreOptimizationAppliedNetworkActions()).thenReturn(appliedRemedialActions);
+        when(searchTreeInput.getPreOptimizationAppliedRemedialActions()).thenReturn(appliedRemedialActions);
         network = Mockito.mock(Network.class);
         when(searchTreeInput.getNetwork()).thenReturn(network);
         optimizationPerimeter = Mockito.mock(OptimizationPerimeter.class);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature + bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
In search-tree, when range actions are applied at a given leaf, they are ket at their optimal set-points in children leves. This improves search-tree computation performance.
However, when max CRA parameters are defined, network actions cannot be implemented.
Moreover, when a max-cra-per-tso parameters is defined, activated range actions are counted among all TSOs (bug).


**What is the new behavior (if this is a feature change)?**
Now, at the beginning of every leaf, range actions are reset to their pre-perimeter set-points. This way the search-tree can decide wether to implement a range action or a network action in order to optimize the minimum margin.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
Minimum margin results shall improve when "max CRA" parameters are used
