### PR TITLE
Monitor network copies in search tree

### DIFF
--- a/monitoring/angle-monitoring/src/main/java/com/farao_community/farao/monitoring/angle_monitoring/AngleMonitoring.java
+++ b/monitoring/angle-monitoring/src/main/java/com/farao_community/farao/monitoring/angle_monitoring/AngleMonitoring.java
@@ -89,9 +89,16 @@ public class AngleMonitoring {
         }
 
         try {
+            int numberOfClones = Math.min(numberOfLoadFlowsInParallel, contingencyStates.size());
+
             try (AbstractNetworkPool networkPool =
-                         AbstractNetworkPool.create(inputNetwork, inputNetwork.getVariantManager().getWorkingVariantId(), Math.min(numberOfLoadFlowsInParallel, contingencyStates.size()))
+                         AbstractNetworkPool.create(inputNetwork, inputNetwork.getVariantManager().getWorkingVariantId(), numberOfClones)
             ) {
+
+                if (numberOfClones != 1) {
+                    networkPool.addNetworkClones(numberOfClones);
+                }
+
                 CountDownLatch stateCountDownLatch = new CountDownLatch(contingencyStates.size());
                 contingencyStates.forEach(state ->
                         networkPool.submit(() -> {

--- a/monitoring/angle-monitoring/src/main/java/com/farao_community/farao/monitoring/angle_monitoring/AngleMonitoring.java
+++ b/monitoring/angle-monitoring/src/main/java/com/farao_community/farao/monitoring/angle_monitoring/AngleMonitoring.java
@@ -89,12 +89,9 @@ public class AngleMonitoring {
         }
 
         try {
-            int numberOfClones = Math.min(numberOfLoadFlowsInParallel, contingencyStates.size());
-
             try (AbstractNetworkPool networkPool =
-                         AbstractNetworkPool.create(inputNetwork, inputNetwork.getVariantManager().getWorkingVariantId(), numberOfClones, true)
+                         AbstractNetworkPool.create(inputNetwork, inputNetwork.getVariantManager().getWorkingVariantId(), Math.min(numberOfLoadFlowsInParallel, contingencyStates.size()), true)
             ) {
-
                 CountDownLatch stateCountDownLatch = new CountDownLatch(contingencyStates.size());
                 contingencyStates.forEach(state ->
                         networkPool.submit(() -> {

--- a/monitoring/angle-monitoring/src/main/java/com/farao_community/farao/monitoring/angle_monitoring/AngleMonitoring.java
+++ b/monitoring/angle-monitoring/src/main/java/com/farao_community/farao/monitoring/angle_monitoring/AngleMonitoring.java
@@ -92,12 +92,8 @@ public class AngleMonitoring {
             int numberOfClones = Math.min(numberOfLoadFlowsInParallel, contingencyStates.size());
 
             try (AbstractNetworkPool networkPool =
-                         AbstractNetworkPool.create(inputNetwork, inputNetwork.getVariantManager().getWorkingVariantId(), numberOfClones)
+                         AbstractNetworkPool.create(inputNetwork, inputNetwork.getVariantManager().getWorkingVariantId(), numberOfClones, true)
             ) {
-
-                if (numberOfClones != 1) {
-                    networkPool.addNetworkClones(numberOfClones);
-                }
 
                 CountDownLatch stateCountDownLatch = new CountDownLatch(contingencyStates.size());
                 contingencyStates.forEach(state ->

--- a/monitoring/voltage-monitoring/src/main/java/com/farao_community/farao/monitoring/voltage_monitoring/VoltageMonitoring.java
+++ b/monitoring/voltage-monitoring/src/main/java/com/farao_community/farao/monitoring/voltage_monitoring/VoltageMonitoring.java
@@ -61,9 +61,16 @@ public class VoltageMonitoring {
 
         try {
 
+            int numberOfClones = Math.min(numberOfLoadFlowsInParallel, contingencyStates.size());
+
             try (AbstractNetworkPool networkPool =
-                     AbstractNetworkPool.create(network, network.getVariantManager().getWorkingVariantId(), Math.min(numberOfLoadFlowsInParallel, contingencyStates.size()))
+                     AbstractNetworkPool.create(network, network.getVariantManager().getWorkingVariantId(), numberOfClones)
             ) {
+
+                if (numberOfClones != 1) {
+                    networkPool.addNetworkClones(numberOfClones);
+                }
+
                 CountDownLatch stateCountDownLatch = new CountDownLatch(contingencyStates.size());
                 contingencyStates.forEach(state ->
                     networkPool.submit(() -> {

--- a/monitoring/voltage-monitoring/src/main/java/com/farao_community/farao/monitoring/voltage_monitoring/VoltageMonitoring.java
+++ b/monitoring/voltage-monitoring/src/main/java/com/farao_community/farao/monitoring/voltage_monitoring/VoltageMonitoring.java
@@ -64,12 +64,8 @@ public class VoltageMonitoring {
             int numberOfClones = Math.min(numberOfLoadFlowsInParallel, contingencyStates.size());
 
             try (AbstractNetworkPool networkPool =
-                     AbstractNetworkPool.create(network, network.getVariantManager().getWorkingVariantId(), numberOfClones)
+                     AbstractNetworkPool.create(network, network.getVariantManager().getWorkingVariantId(), numberOfClones, true)
             ) {
-
-                if (numberOfClones != 1) {
-                    networkPool.addNetworkClones(numberOfClones);
-                }
 
                 CountDownLatch stateCountDownLatch = new CountDownLatch(contingencyStates.size());
                 contingencyStates.forEach(state ->

--- a/monitoring/voltage-monitoring/src/main/java/com/farao_community/farao/monitoring/voltage_monitoring/VoltageMonitoring.java
+++ b/monitoring/voltage-monitoring/src/main/java/com/farao_community/farao/monitoring/voltage_monitoring/VoltageMonitoring.java
@@ -60,13 +60,9 @@ public class VoltageMonitoring {
         }
 
         try {
-
-            int numberOfClones = Math.min(numberOfLoadFlowsInParallel, contingencyStates.size());
-
             try (AbstractNetworkPool networkPool =
-                     AbstractNetworkPool.create(network, network.getVariantManager().getWorkingVariantId(), numberOfClones, true)
+                     AbstractNetworkPool.create(network, network.getVariantManager().getWorkingVariantId(), Math.min(numberOfLoadFlowsInParallel, contingencyStates.size()), true)
             ) {
-
                 CountDownLatch stateCountDownLatch = new CountDownLatch(contingencyStates.size());
                 contingencyStates.forEach(state ->
                     networkPool.submit(() -> {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/CastorFullOptimization.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/CastorFullOptimization.java
@@ -295,11 +295,7 @@ public class CastorFullOptimization {
 
         int numberOfClones = raoParameters.getMultithreadingParameters().getContingencyScenariosInParallel();
 
-        try (AbstractNetworkPool networkPool = AbstractNetworkPool.create(network, newVariant, numberOfClones)) {
-
-            if (numberOfClones != 1) {
-                networkPool.addNetworkClones(numberOfClones);
-            }
+        try (AbstractNetworkPool networkPool = AbstractNetworkPool.create(network, newVariant, numberOfClones, true)) {
 
             AtomicInteger remainingScenarios = new AtomicInteger(stateTree.getContingencyScenarios().size());
             CountDownLatch contingencyCountDownLatch = new CountDownLatch(stateTree.getContingencyScenarios().size());

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/CastorFullOptimization.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/CastorFullOptimization.java
@@ -292,11 +292,7 @@ public class CastorFullOptimization {
         // Create an automaton simulator
         AutomatonSimulator automatonSimulator = new AutomatonSimulator(crac, raoParameters, toolProvider, initialSensitivityOutput, prePerimeterSensitivityOutput, prePerimeterSensitivityOutput, stateTree.getOperatorsNotSharingCras(), NUMBER_LOGGED_ELEMENTS_DURING_RAO);
         // Go through all contingency scenarios
-
-        int numberOfClones = raoParameters.getMultithreadingParameters().getContingencyScenariosInParallel();
-
-        try (AbstractNetworkPool networkPool = AbstractNetworkPool.create(network, newVariant, numberOfClones, true)) {
-
+        try (AbstractNetworkPool networkPool = AbstractNetworkPool.create(network, newVariant, raoParameters.getMultithreadingParameters().getContingencyScenariosInParallel(), true)) {
             AtomicInteger remainingScenarios = new AtomicInteger(stateTree.getContingencyScenarios().size());
             CountDownLatch contingencyCountDownLatch = new CountDownLatch(stateTree.getContingencyScenarios().size());
             stateTree.getContingencyScenarios().forEach(optimizedScenario ->

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/CastorFullOptimization.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/CastorFullOptimization.java
@@ -292,7 +292,15 @@ public class CastorFullOptimization {
         // Create an automaton simulator
         AutomatonSimulator automatonSimulator = new AutomatonSimulator(crac, raoParameters, toolProvider, initialSensitivityOutput, prePerimeterSensitivityOutput, prePerimeterSensitivityOutput, stateTree.getOperatorsNotSharingCras(), NUMBER_LOGGED_ELEMENTS_DURING_RAO);
         // Go through all contingency scenarios
-        try (AbstractNetworkPool networkPool = AbstractNetworkPool.create(network, newVariant, raoParameters.getMultithreadingParameters().getContingencyScenariosInParallel())) {
+
+        int numberOfClones = raoParameters.getMultithreadingParameters().getContingencyScenariosInParallel();
+
+        try (AbstractNetworkPool networkPool = AbstractNetworkPool.create(network, newVariant, numberOfClones)) {
+
+            if (numberOfClones != 1) {
+                networkPool.addNetworkClones(numberOfClones);
+            }
+
             AtomicInteger remainingScenarios = new AtomicInteger(stateTree.getContingencyScenarios().size());
             CountDownLatch contingencyCountDownLatch = new CountDownLatch(stateTree.getContingencyScenarios().size());
             stateTree.getContingencyScenarios().forEach(optimizedScenario ->

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -26,7 +26,6 @@ import com.farao_community.farao.search_tree_rao.search_tree.inputs.SearchTreeIn
 import com.farao_community.farao.search_tree_rao.search_tree.parameters.SearchTreeParameters;
 import com.farao_community.farao.sensitivity_analysis.AppliedRemedialActions;
 import com.farao_community.farao.util.AbstractNetworkPool;
-import com.farao_community.farao.util.MultipleNetworkPool;
 import com.google.common.hash.Hashing;
 import com.powsybl.iidm.network.Network;
 import org.apache.commons.lang3.NotImplementedException;
@@ -248,15 +247,7 @@ public class SearchTree {
     private void updateOptimalLeafWithNextDepthBestLeaf(AbstractNetworkPool networkPool) throws InterruptedException {
 
         final List<NetworkActionCombination> naCombinations = bloomer.bloom(optimalLeaf, input.getOptimizationPerimeter().getNetworkActions());
-        int requiredLeaves;
-
-        if (networkPool instanceof MultipleNetworkPool) {
-            requiredLeaves = Math.min(networkPool.getParallelism(), naCombinations.size());
-            if (requiredLeaves > networkPool.getNetworkNumberOfClones()) {
-                // Increase the number of copies and the current parallelism
-                networkPool.addNetworkClones(requiredLeaves - networkPool.getNetworkNumberOfClones());
-            }
-        }
+        networkPool.initClones(naCombinations.size());
 
         naCombinations.sort(this::deterministicNetworkActionCombinationComparison);
         if (naCombinations.isEmpty()) {
@@ -359,7 +350,7 @@ public class SearchTree {
     }
 
     AbstractNetworkPool makeFaraoNetworkPool(Network network, int leavesInParallel) {
-        return AbstractNetworkPool.create(network, network.getVariantManager().getWorkingVariantId(), leavesInParallel);
+        return AbstractNetworkPool.create(network, network.getVariantManager().getWorkingVariantId(), leavesInParallel, false);
     }
 
     void optimizeNextLeafAndUpdate(NetworkActionCombination naCombination, Network network) {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -26,6 +26,7 @@ import com.farao_community.farao.search_tree_rao.search_tree.inputs.SearchTreeIn
 import com.farao_community.farao.search_tree_rao.search_tree.parameters.SearchTreeParameters;
 import com.farao_community.farao.sensitivity_analysis.AppliedRemedialActions;
 import com.farao_community.farao.util.AbstractNetworkPool;
+import com.farao_community.farao.util.MultipleNetworkPool;
 import com.google.common.hash.Hashing;
 import com.powsybl.iidm.network.Network;
 import org.apache.commons.lang3.NotImplementedException;
@@ -247,11 +248,14 @@ public class SearchTree {
     private void updateOptimalLeafWithNextDepthBestLeaf(AbstractNetworkPool networkPool, Network network) throws InterruptedException {
 
         final List<NetworkActionCombination> naCombinations = bloomer.bloom(optimalLeaf, input.getOptimizationPerimeter().getNetworkActions());
+        int requiredLeaves;
 
-        int requiredLeaves = Math.min(networkPool.getParallelism(), naCombinations.size());
-        if (requiredLeaves > networkPool.getNetworkNumberOfClones()) {
-            // Increase the number of copy and the current parallelism
-            networkPool.addNetworkClones(requiredLeaves - networkPool.getNetworkNumberOfClones());
+        if (networkPool instanceof MultipleNetworkPool) {
+            requiredLeaves = Math.min(networkPool.getParallelism(), naCombinations.size());
+            if (requiredLeaves > networkPool.getNetworkNumberOfClones()) {
+                // Increase the number of copies and the current parallelism
+                networkPool.addNetworkClones(requiredLeaves - networkPool.getNetworkNumberOfClones());
+            }
         }
 
         naCombinations.sort(this::deterministicNetworkActionCombinationComparison);

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -248,7 +248,6 @@ public class SearchTree {
 
         final List<NetworkActionCombination> naCombinations = bloomer.bloom(optimalLeaf, input.getOptimizationPerimeter().getNetworkActions());
         networkPool.initClones(naCombinations.size());
-
         naCombinations.sort(this::deterministicNetworkActionCombinationComparison);
         if (naCombinations.isEmpty()) {
             TECHNICAL_LOGS.info("No more network action available");

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -219,7 +219,7 @@ public class SearchTree {
             while (depth < parameters.getTreeParameters().getMaximumSearchDepth() && hasImproved && !stopCriterionReached(optimalLeaf)) {
                 TECHNICAL_LOGS.info("Search depth {} [start]", depth + 1);
                 previousDepthOptimalLeaf = optimalLeaf;
-                updateOptimalLeafWithNextDepthBestLeaf(networkPool, input.getNetwork());
+                updateOptimalLeafWithNextDepthBestLeaf(networkPool);
                 hasImproved = previousDepthOptimalLeaf != optimalLeaf; // It means this depth evaluation has improved the global cost
                 if (hasImproved) {
                     TECHNICAL_LOGS.info("Search depth {} [end]", depth + 1);
@@ -245,7 +245,7 @@ public class SearchTree {
     /**
      * Evaluate all the leaves. We use FaraoNetworkPool to parallelize the computation
      */
-    private void updateOptimalLeafWithNextDepthBestLeaf(AbstractNetworkPool networkPool, Network network) throws InterruptedException {
+    private void updateOptimalLeafWithNextDepthBestLeaf(AbstractNetworkPool networkPool) throws InterruptedException {
 
         final List<NetworkActionCombination> naCombinations = bloomer.bloom(optimalLeaf, input.getOptimizationPerimeter().getNetworkActions());
         int requiredLeaves;

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
@@ -374,7 +374,7 @@ class SearchTreeTest {
         String workingVariantId = "ID";
         when(variantManager.getWorkingVariantId()).thenReturn(workingVariantId);
         when(network.getVariantManager()).thenReturn(variantManager);
-        AbstractNetworkPool faraoNetworkPool = AbstractNetworkPool.create(network, workingVariantId, leavesInParallel);
+        AbstractNetworkPool faraoNetworkPool = AbstractNetworkPool.create(network, workingVariantId, leavesInParallel, true);
         Mockito.doReturn(faraoNetworkPool).when(searchTree).makeFaraoNetworkPool(network, leavesInParallel);
     }
 

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
@@ -37,7 +37,7 @@ import com.farao_community.farao.search_tree_rao.result.api.PrePerimeterResult;
 import com.farao_community.farao.search_tree_rao.search_tree.inputs.SearchTreeInput;
 import com.farao_community.farao.search_tree_rao.search_tree.parameters.SearchTreeParameters;
 import com.farao_community.farao.sensitivity_analysis.AppliedRemedialActions;
-import com.farao_community.farao.util.MultipleNetworkPool;
+import com.farao_community.farao.util.AbstractNetworkPool;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VariantManager;
 import org.junit.jupiter.api.BeforeEach;
@@ -195,23 +195,6 @@ class SearchTreeTest {
         OptimizationResult result = searchTree.run().get();
         assertEquals(rootLeaf, result);
         assertEquals(2., result.getCost(), DOUBLE_TOLERANCE);
-    }
-
-    public class MockedNetworkPool extends MultipleNetworkPool {
-
-        public MockedNetworkPool(Network network, String targetVariant, int parallelism) {
-            super(network, targetVariant, parallelism);
-        }
-
-        @Override
-        protected void initAvailableNetworks(Network network) {
-            this.networksQueue.offer(network);
-        }
-
-        @Override
-        protected void cleanVariants(Network network) {
-            // do nothing
-        }
     }
 
     @Test
@@ -391,7 +374,7 @@ class SearchTreeTest {
         String workingVariantId = "ID";
         when(variantManager.getWorkingVariantId()).thenReturn(workingVariantId);
         when(network.getVariantManager()).thenReturn(variantManager);
-        MockedNetworkPool faraoNetworkPool = new MockedNetworkPool(network, workingVariantId, leavesInParallel);
+        AbstractNetworkPool faraoNetworkPool = AbstractNetworkPool.create(network, workingVariantId, leavesInParallel);
         Mockito.doReturn(faraoNetworkPool).when(searchTree).makeFaraoNetworkPool(network, leavesInParallel);
     }
 

--- a/util/src/main/java/com/farao_community/farao/util/AbstractNetworkPool.java
+++ b/util/src/main/java/com/farao_community/farao/util/AbstractNetworkPool.java
@@ -29,11 +29,11 @@ public abstract class AbstractNetworkPool extends ForkJoinPool implements AutoCl
     protected String networkInitialVariantId;
     protected Set<String> baseNetworkVariantIds;
 
-    public static AbstractNetworkPool create(Network network, String targetVariant, int parallelism) {
+    public static AbstractNetworkPool create(Network network, String targetVariant, int parallelism, boolean initClones) {
         if (parallelism == 1) {
             return new SingleNetworkPool(network, targetVariant);
         } else {
-            return new MultipleNetworkPool(network, targetVariant, parallelism);
+            return new MultipleNetworkPool(network, targetVariant, parallelism, initClones);
         }
     }
 
@@ -96,6 +96,6 @@ public abstract class AbstractNetworkPool extends ForkJoinPool implements AutoCl
         return 1;
     }
 
-    public void addNetworkClones(int numberOfClones) { }
+    public abstract void initClones(int desiredNumberOfClones);
 
 }

--- a/util/src/main/java/com/farao_community/farao/util/AbstractNetworkPool.java
+++ b/util/src/main/java/com/farao_community/farao/util/AbstractNetworkPool.java
@@ -7,16 +7,12 @@
 package com.farao_community.farao.util;
 
 import com.farao_community.farao.commons.RandomizedString;
-import com.farao_community.farao.commons.logs.FaraoLoggerProvider;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.VariantManagerConstants;
-import com.powsybl.iidm.xml.NetworkXml;
 
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
 
-import static com.farao_community.farao.commons.logs.FaraoLoggerProvider.TECHNICAL_LOGS;
 import static com.farao_community.farao.util.MCDContextWrapper.wrapWithMdcContext;
 
 /**
@@ -29,7 +25,6 @@ public abstract class AbstractNetworkPool extends ForkJoinPool implements AutoCl
     // State used to save initial content of target variant.
     // Useful when targetVariant equals VariantManagerConstants.INITIAL_VARIANT_ID
     protected final String stateSaveVariant;
-    protected int networkNumberOfClones;
     protected Network network;
     protected String networkInitialVariantId;
     protected Set<String> baseNetworkVariantIds;
@@ -45,12 +40,13 @@ public abstract class AbstractNetworkPool extends ForkJoinPool implements AutoCl
     protected AbstractNetworkPool(Network network, String targetVariant, int parallelism) {
         super(parallelism);
         Objects.requireNonNull(network);
-        this.networkNumberOfClones = 1;
         this.targetVariant = Objects.requireNonNull(targetVariant);
         this.stateSaveVariant = RandomizedString.getRandomizedString("FaraoNetworkPool state save ", network.getVariantManager().getVariantIds(), 5);
         this.workingVariant = RandomizedString.getRandomizedString("FaraoNetworkPool working variant ", network.getVariantManager().getVariantIds(), 5);
         this.networksQueue = new ArrayBlockingQueue<>(getParallelism());
-        initAvailableNetworks(network);
+        this.networkInitialVariantId = network.getVariantManager().getWorkingVariantId();
+        this.network = network;
+        this.baseNetworkVariantIds = new HashSet<>(network.getVariantManager().getVariantIds());
     }
 
     public Network getAvailableNetwork() throws InterruptedException {
@@ -60,20 +56,16 @@ public abstract class AbstractNetworkPool extends ForkJoinPool implements AutoCl
         return networkClone;
     }
 
-    protected void initAvailableNetworks(Network network) {
-        this.networkInitialVariantId = network.getVariantManager().getWorkingVariantId();
-        this.network = network;
-        this.baseNetworkVariantIds = new HashSet<>(network.getVariantManager().getVariantIds());
-        FaraoLoggerProvider.TECHNICAL_LOGS.info("Using base network '{}' on variant '{}'", network.getId(), targetVariant);
-        network.getVariantManager().setWorkingVariant(targetVariant);
-        network.getVariantManager().cloneVariant(networkInitialVariantId, Arrays.asList(stateSaveVariant, workingVariant), true);
-        boolean isSuccess = networksQueue.offer(network);
-        if (!isSuccess) {
-            throw new AssertionError("Cannot offer base network in pool. Should not happen");
-        }
+    public void shutdownAndAwaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        super.shutdown();
+        super.awaitTermination(timeout, unit);
     }
 
-    public abstract void shutdownAndAwaitTermination(long timeout, TimeUnit unit) throws InterruptedException;
+    protected void cleanBaseNetwork() {
+        cleanVariants(network);
+        network.getVariantManager().removeVariant(stateSaveVariant);
+        network.getVariantManager().setWorkingVariant(networkInitialVariantId);
+    }
 
     public void releaseUsedNetwork(Network networkToRelease) throws InterruptedException {
         cleanVariants(networkToRelease);
@@ -101,40 +93,9 @@ public abstract class AbstractNetworkPool extends ForkJoinPool implements AutoCl
     }
 
     public int getNetworkNumberOfClones() {
-        // The number of clones includes the original network itself
-        return networkNumberOfClones;
+        return 1;
     }
 
-    public void addNetworkClones(int numberOfClones) {
-
-        int addedClones;
-        int previousClones = this.networkNumberOfClones;
-
-        if (this.networkNumberOfClones + numberOfClones > getParallelism()) {
-            addedClones = getParallelism() - this.networkNumberOfClones;
-            this.networkNumberOfClones = getParallelism();
-        } else {
-            addedClones = numberOfClones;
-            this.networkNumberOfClones += numberOfClones;
-        }
-
-        TECHNICAL_LOGS.debug("Filling network pool with '{}' cop'{}' of network '{}' on variant '{}'", addedClones, addedClones == 1 ? "y" : "ies", network.getId(), targetVariant);
-
-        network.getVariantManager().setWorkingVariant(targetVariant);
-
-        for (int i = previousClones; i < previousClones + addedClones; i++) {
-            TECHNICAL_LOGS.debug("Copy n°{}", i + 1);
-            Network copy = NetworkXml.copy(network);
-            // The initial network working variant is VariantManagerConstants.INITIAL_VARIANT_ID
-            // in cloned network, so we need to copy it again.
-            copy.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, Arrays.asList(stateSaveVariant, workingVariant), true);
-            boolean isSuccess = networksQueue.offer(copy);
-            if (!isSuccess) {
-                throw new AssertionError(String.format("Cannot offer copy n°'%d' in pool. Should not happen", i + 1));
-            }
-        }
-        network.getVariantManager().setWorkingVariant(networkInitialVariantId);
-
-    }
+    public void addNetworkClones(int numberOfClones) { }
 
 }

--- a/util/src/main/java/com/farao_community/farao/util/AbstractNetworkPool.java
+++ b/util/src/main/java/com/farao_community/farao/util/AbstractNetworkPool.java
@@ -7,11 +7,16 @@
 package com.farao_community.farao.util;
 
 import com.farao_community.farao.commons.RandomizedString;
+import com.farao_community.farao.commons.logs.FaraoLoggerProvider;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.VariantManagerConstants;
+import com.powsybl.iidm.xml.NetworkXml;
 
-import java.util.Objects;
+import java.util.*;
 import java.util.concurrent.*;
+import java.util.stream.Collectors;
 
+import static com.farao_community.farao.commons.logs.FaraoLoggerProvider.TECHNICAL_LOGS;
 import static com.farao_community.farao.util.MCDContextWrapper.wrapWithMdcContext;
 
 /**
@@ -24,6 +29,10 @@ public abstract class AbstractNetworkPool extends ForkJoinPool implements AutoCl
     // State used to save initial content of target variant.
     // Useful when targetVariant equals VariantManagerConstants.INITIAL_VARIANT_ID
     protected final String stateSaveVariant;
+    protected int networkNumberOfClones;
+    protected Network network;
+    protected String networkInitialVariantId;
+    protected Set<String> baseNetworkVariantIds;
 
     public static AbstractNetworkPool create(Network network, String targetVariant, int parallelism) {
         if (parallelism == 1) {
@@ -36,6 +45,7 @@ public abstract class AbstractNetworkPool extends ForkJoinPool implements AutoCl
     protected AbstractNetworkPool(Network network, String targetVariant, int parallelism) {
         super(parallelism);
         Objects.requireNonNull(network);
+        this.networkNumberOfClones = 1;
         this.targetVariant = Objects.requireNonNull(targetVariant);
         this.stateSaveVariant = RandomizedString.getRandomizedString("FaraoNetworkPool state save ", network.getVariantManager().getVariantIds(), 5);
         this.workingVariant = RandomizedString.getRandomizedString("FaraoNetworkPool working variant ", network.getVariantManager().getVariantIds(), 5);
@@ -50,7 +60,18 @@ public abstract class AbstractNetworkPool extends ForkJoinPool implements AutoCl
         return networkClone;
     }
 
-    protected abstract void initAvailableNetworks(Network network);
+    protected void initAvailableNetworks(Network network) {
+        this.networkInitialVariantId = network.getVariantManager().getWorkingVariantId();
+        this.network = network;
+        this.baseNetworkVariantIds = new HashSet<>(network.getVariantManager().getVariantIds());
+        FaraoLoggerProvider.TECHNICAL_LOGS.info("Using base network '{}' on variant '{}'", network.getId(), targetVariant);
+        network.getVariantManager().setWorkingVariant(targetVariant);
+        network.getVariantManager().cloneVariant(networkInitialVariantId, Arrays.asList(stateSaveVariant, workingVariant), true);
+        boolean isSuccess = networksQueue.offer(network);
+        if (!isSuccess) {
+            throw new AssertionError("Cannot offer base network in pool. Should not happen");
+        }
+    }
 
     public abstract void shutdownAndAwaitTermination(long timeout, TimeUnit unit) throws InterruptedException;
 
@@ -59,7 +80,13 @@ public abstract class AbstractNetworkPool extends ForkJoinPool implements AutoCl
         networksQueue.put(networkToRelease);
     }
 
-    protected abstract void cleanVariants(Network networkToRelease);
+    protected void cleanVariants(Network networkClone) {
+        List<String> variantsToBeRemoved = networkClone.getVariantManager().getVariantIds().stream()
+                .filter(variantId -> !baseNetworkVariantIds.contains(variantId))
+                .filter(variantId -> !variantId.equals(stateSaveVariant))
+                .collect(Collectors.toList());
+        variantsToBeRemoved.forEach(variantId -> networkClone.getVariantManager().removeVariant(variantId));
+    }
 
     @Override
     public void close() {
@@ -71,6 +98,43 @@ public abstract class AbstractNetworkPool extends ForkJoinPool implements AutoCl
     @Override
     public ForkJoinTask<?> submit(Runnable task) {
         return super.submit(wrapWithMdcContext(task));
+    }
+
+    public int getNetworkNumberOfClones() {
+        // The number of clones includes the original network itself
+        return networkNumberOfClones;
+    }
+
+    public void addNetworkClones(int numberOfClones) {
+
+        int addedClones;
+        int previousClones = this.networkNumberOfClones;
+
+        if (this.networkNumberOfClones + numberOfClones > getParallelism()) {
+            addedClones = getParallelism() - this.networkNumberOfClones;
+            this.networkNumberOfClones = getParallelism();
+        } else {
+            addedClones = numberOfClones;
+            this.networkNumberOfClones += numberOfClones;
+        }
+
+        TECHNICAL_LOGS.debug("Filling network pool with '{}' cop'{}' of network '{}' on variant '{}'", addedClones, addedClones == 1 ? "y" : "ies", network.getId(), targetVariant);
+
+        network.getVariantManager().setWorkingVariant(targetVariant);
+
+        for (int i = previousClones; i < previousClones + addedClones; i++) {
+            TECHNICAL_LOGS.debug("Copy n°{}", i + 1);
+            Network copy = NetworkXml.copy(network);
+            // The initial network working variant is VariantManagerConstants.INITIAL_VARIANT_ID
+            // in cloned network, so we need to copy it again.
+            copy.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, Arrays.asList(stateSaveVariant, workingVariant), true);
+            boolean isSuccess = networksQueue.offer(copy);
+            if (!isSuccess) {
+                throw new AssertionError(String.format("Cannot offer copy n°'%d' in pool. Should not happen", i + 1));
+            }
+        }
+        network.getVariantManager().setWorkingVariant(networkInitialVariantId);
+
     }
 
 }

--- a/util/src/main/java/com/farao_community/farao/util/MultipleNetworkPool.java
+++ b/util/src/main/java/com/farao_community/farao/util/MultipleNetworkPool.java
@@ -25,33 +25,33 @@ public class MultipleNetworkPool extends AbstractNetworkPool {
         super(network, targetVariant, parallelism);
     }
 
-    @Override
-    protected void initAvailableNetworks(Network network) {
-        TECHNICAL_LOGS.debug("Filling network pool with copies of network '{}' on variant '{}'", network.getId(), targetVariant);
-        String initialVariant = network.getVariantManager().getWorkingVariantId();
-        network.getVariantManager().setWorkingVariant(targetVariant);
-        for (int i = 0; i < getParallelism(); i++) {
-            TECHNICAL_LOGS.debug("Copy n°{}", i + 1);
-            Network copy = NetworkXml.copy(network);
-            // The initial network working variant is VariantManagerConstants.INITIAL_VARIANT_ID
-            // in cloned network, so we need to copy it again.
-            copy.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, Arrays.asList(stateSaveVariant, workingVariant), true);
-            boolean isSuccess = networksQueue.offer(copy);
-            if (!isSuccess) {
-                throw new AssertionError(String.format("Cannot offer copy n°'%d' in pool. Should not happen", i + 1));
-            }
-        }
-        network.getVariantManager().setWorkingVariant(initialVariant);
-    }
+//    @Override
+//    protected void initAvailableNetworks(Network network) {
+//        TECHNICAL_LOGS.debug("Filling network pool with copies of network '{}' on variant '{}'", network.getId(), targetVariant);
+//        String initialVariant = network.getVariantManager().getWorkingVariantId();
+//        network.getVariantManager().setWorkingVariant(targetVariant);
+//        for (int i = 0; i < getParallelism(); i++) {
+//            TECHNICAL_LOGS.debug("Copy n°{}", i + 1);
+//            Network copy = NetworkXml.copy(network);
+//            // The initial network working variant is VariantManagerConstants.INITIAL_VARIANT_ID
+//            // in cloned network, so we need to copy it again.
+//            copy.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, Arrays.asList(stateSaveVariant, workingVariant), true);
+//            boolean isSuccess = networksQueue.offer(copy);
+//            if (!isSuccess) {
+//                throw new AssertionError(String.format("Cannot offer copy n°'%d' in pool. Should not happen", i + 1));
+//            }
+//        }
+//        network.getVariantManager().setWorkingVariant(initialVariant);
+//    }
 
-    @Override
-    protected void cleanVariants(Network networkClone) {
-        List<String> variantsToBeRemoved = networkClone.getVariantManager().getVariantIds().stream()
-                .filter(variantId -> !variantId.equals(VariantManagerConstants.INITIAL_VARIANT_ID))
-                .filter(variantId -> !variantId.equals(stateSaveVariant))
-                .collect(Collectors.toList());
-        variantsToBeRemoved.forEach(variantId -> networkClone.getVariantManager().removeVariant(variantId));
-    }
+//    @Override
+//    protected void cleanVariants(Network networkClone) {
+//        List<String> variantsToBeRemoved = networkClone.getVariantManager().getVariantIds().stream()
+//                .filter(variantId -> !variantId.equals(VariantManagerConstants.INITIAL_VARIANT_ID))
+//                .filter(variantId -> !variantId.equals(stateSaveVariant))
+//                .collect(Collectors.toList());
+//        variantsToBeRemoved.forEach(variantId -> networkClone.getVariantManager().removeVariant(variantId));
+//    }
 
     @Override
     public void shutdownAndAwaitTermination(long timeout, TimeUnit unit) throws InterruptedException {

--- a/util/src/main/java/com/farao_community/farao/util/MultipleNetworkPool.java
+++ b/util/src/main/java/com/farao_community/farao/util/MultipleNetworkPool.java
@@ -47,7 +47,6 @@ public class MultipleNetworkPool extends AbstractNetworkPool {
 
     @Override
     public void initClones(int desiredNumberOfClones) {
-
         int requiredClones = Math.min(getParallelism(), desiredNumberOfClones);
         int clonesToAdd = requiredClones - networkNumberOfClones;
 

--- a/util/src/main/java/com/farao_community/farao/util/MultipleNetworkPool.java
+++ b/util/src/main/java/com/farao_community/farao/util/MultipleNetworkPool.java
@@ -12,7 +12,6 @@ import com.powsybl.iidm.xml.NetworkXml;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static com.farao_community.farao.commons.logs.FaraoLoggerProvider.TECHNICAL_LOGS;
@@ -21,41 +20,65 @@ import static com.farao_community.farao.commons.logs.FaraoLoggerProvider.TECHNIC
  * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
  */
 public class MultipleNetworkPool extends AbstractNetworkPool {
+
+    private int networkNumberOfClones;
+
     protected MultipleNetworkPool(Network network, String targetVariant, int parallelism) {
         super(network, targetVariant, parallelism);
+        this.networkNumberOfClones = 0;
+    }
+
+    @Override
+    protected void cleanVariants(Network networkClone) {
+        List<String> variantsToBeRemoved = networkClone.getVariantManager().getVariantIds().stream()
+                .filter(variantId -> !variantId.equals(VariantManagerConstants.INITIAL_VARIANT_ID))
+                .filter(variantId -> !variantId.equals(stateSaveVariant))
+                .collect(Collectors.toList());
+        variantsToBeRemoved.forEach(variantId -> networkClone.getVariantManager().removeVariant(variantId));
     }
 
 //    @Override
-//    protected void initAvailableNetworks(Network network) {
-//        TECHNICAL_LOGS.debug("Filling network pool with copies of network '{}' on variant '{}'", network.getId(), targetVariant);
-//        String initialVariant = network.getVariantManager().getWorkingVariantId();
-//        network.getVariantManager().setWorkingVariant(targetVariant);
-//        for (int i = 0; i < getParallelism(); i++) {
-//            TECHNICAL_LOGS.debug("Copy n°{}", i + 1);
-//            Network copy = NetworkXml.copy(network);
-//            // The initial network working variant is VariantManagerConstants.INITIAL_VARIANT_ID
-//            // in cloned network, so we need to copy it again.
-//            copy.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, Arrays.asList(stateSaveVariant, workingVariant), true);
-//            boolean isSuccess = networksQueue.offer(copy);
-//            if (!isSuccess) {
-//                throw new AssertionError(String.format("Cannot offer copy n°'%d' in pool. Should not happen", i + 1));
-//            }
-//        }
-//        network.getVariantManager().setWorkingVariant(initialVariant);
-//    }
-
-//    @Override
-//    protected void cleanVariants(Network networkClone) {
-//        List<String> variantsToBeRemoved = networkClone.getVariantManager().getVariantIds().stream()
-//                .filter(variantId -> !variantId.equals(VariantManagerConstants.INITIAL_VARIANT_ID))
-//                .filter(variantId -> !variantId.equals(stateSaveVariant))
-//                .collect(Collectors.toList());
-//        variantsToBeRemoved.forEach(variantId -> networkClone.getVariantManager().removeVariant(variantId));
+//    public void shutdownAndAwaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+//        super.shutdown();
+//        super.awaitTermination(timeout, unit);
 //    }
 
     @Override
-    public void shutdownAndAwaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        super.shutdown();
-        super.awaitTermination(timeout, unit);
+    public int getNetworkNumberOfClones() {
+        // The number of clones includes the original network itself
+        return networkNumberOfClones;
+    }
+
+    @Override
+    public void addNetworkClones(int numberOfClones) {
+
+        int addedClones;
+        int previousClones = this.networkNumberOfClones;
+
+        if (this.networkNumberOfClones + numberOfClones > getParallelism()) {
+            addedClones = getParallelism() - this.networkNumberOfClones;
+            this.networkNumberOfClones = getParallelism();
+        } else {
+            addedClones = numberOfClones;
+            this.networkNumberOfClones += numberOfClones;
+        }
+
+        TECHNICAL_LOGS.debug("Filling network pool with '{}' cop'{}' of network '{}' on variant '{}'", addedClones, addedClones == 1 ? "y" : "ies", network.getId(), targetVariant);
+
+        String initialVariant = network.getVariantManager().getWorkingVariantId();
+        network.getVariantManager().setWorkingVariant(targetVariant);
+
+        for (int i = previousClones; i < previousClones + addedClones; i++) {
+            TECHNICAL_LOGS.debug("Copy n°{}", i + 1);
+            Network copy = NetworkXml.copy(network);
+            // The initial network working variant is VariantManagerConstants.INITIAL_VARIANT_ID
+            // in cloned network, so we need to copy it again.
+            copy.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, Arrays.asList(stateSaveVariant, workingVariant), true);
+            boolean isSuccess = networksQueue.offer(copy);
+            if (!isSuccess) {
+                throw new AssertionError(String.format("Cannot offer copy n°'%d' in pool. Should not happen", i + 1));
+            }
+        }
+        network.getVariantManager().setWorkingVariant(initialVariant);
     }
 }

--- a/util/src/main/java/com/farao_community/farao/util/MultipleNetworkPool.java
+++ b/util/src/main/java/com/farao_community/farao/util/MultipleNetworkPool.java
@@ -37,12 +37,6 @@ public class MultipleNetworkPool extends AbstractNetworkPool {
         variantsToBeRemoved.forEach(variantId -> networkClone.getVariantManager().removeVariant(variantId));
     }
 
-//    @Override
-//    public void shutdownAndAwaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-//        super.shutdown();
-//        super.awaitTermination(timeout, unit);
-//    }
-
     @Override
     public int getNetworkNumberOfClones() {
         // The number of clones includes the original network itself

--- a/util/src/main/java/com/farao_community/farao/util/SingleNetworkPool.java
+++ b/util/src/main/java/com/farao_community/farao/util/SingleNetworkPool.java
@@ -35,29 +35,6 @@ public class SingleNetworkPool extends AbstractNetworkPool {
         }
     }
 
-//    @Override
-//    protected void initAvailableNetworks(Network network) {
-//        this.networkInitialVariantId = network.getVariantManager().getWorkingVariantId();
-//        this.network = network;
-//        this.baseNetworkVariantIds = new HashSet<>(network.getVariantManager().getVariantIds());
-//        FaraoLoggerProvider.TECHNICAL_LOGS.info("Using base network '{}' on variant '{}'", network.getId(), targetVariant);
-//        network.getVariantManager().setWorkingVariant(targetVariant);
-//        network.getVariantManager().cloneVariant(networkInitialVariantId, Arrays.asList(stateSaveVariant, workingVariant), true);
-//        boolean isSuccess = networksQueue.offer(network);
-//        if (!isSuccess) {
-//            throw new AssertionError("Cannot offer base network in pool. Should not happen");
-//        }
-//    }
-
-//    @Override
-//    protected void cleanVariants(Network networkClone) {
-//        List<String> variantsToBeRemoved = networkClone.getVariantManager().getVariantIds().stream()
-//                .filter(variantId -> !baseNetworkVariantIds.contains(variantId))
-//                .filter(variantId -> !variantId.equals(stateSaveVariant))
-//                .collect(Collectors.toList());
-//        variantsToBeRemoved.forEach(variantId -> networkClone.getVariantManager().removeVariant(variantId));
-//    }
-
     @Override
     public void shutdownAndAwaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         super.shutdown();

--- a/util/src/main/java/com/farao_community/farao/util/SingleNetworkPool.java
+++ b/util/src/main/java/com/farao_community/farao/util/SingleNetworkPool.java
@@ -23,36 +23,36 @@ import java.util.stream.Collectors;
  * @author Peter Mitri {@literal <peter.mitri at rte-france.com>}
  */
 class SingleNetworkPool extends AbstractNetworkPool {
-    private String networkInitialVariantId;
-    private Network network;
-    private Collection<String> baseNetworkVariantIds;
+//    private String networkInitialVariantId;
+//    private Network network;
+//    private Collection<String> baseNetworkVariantIds;
 
     SingleNetworkPool(Network network, String targetVariant) {
         super(network, targetVariant, 1);
     }
 
-    @Override
-    protected void initAvailableNetworks(Network network) {
-        this.networkInitialVariantId = network.getVariantManager().getWorkingVariantId();
-        this.network = network;
-        this.baseNetworkVariantIds = new HashSet<>(network.getVariantManager().getVariantIds());
-        FaraoLoggerProvider.TECHNICAL_LOGS.info("Using base network '{}' on variant '{}'", network.getId(), targetVariant);
-        network.getVariantManager().setWorkingVariant(targetVariant);
-        network.getVariantManager().cloneVariant(networkInitialVariantId, Arrays.asList(stateSaveVariant, workingVariant), true);
-        boolean isSuccess = networksQueue.offer(network);
-        if (!isSuccess) {
-            throw new AssertionError("Cannot offer base network in pool. Should not happen");
-        }
-    }
+//    @Override
+//    protected void initAvailableNetworks(Network network) {
+//        this.networkInitialVariantId = network.getVariantManager().getWorkingVariantId();
+//        this.network = network;
+//        this.baseNetworkVariantIds = new HashSet<>(network.getVariantManager().getVariantIds());
+//        FaraoLoggerProvider.TECHNICAL_LOGS.info("Using base network '{}' on variant '{}'", network.getId(), targetVariant);
+//        network.getVariantManager().setWorkingVariant(targetVariant);
+//        network.getVariantManager().cloneVariant(networkInitialVariantId, Arrays.asList(stateSaveVariant, workingVariant), true);
+//        boolean isSuccess = networksQueue.offer(network);
+//        if (!isSuccess) {
+//            throw new AssertionError("Cannot offer base network in pool. Should not happen");
+//        }
+//    }
 
-    @Override
-    protected void cleanVariants(Network networkClone) {
-        List<String> variantsToBeRemoved = networkClone.getVariantManager().getVariantIds().stream()
-            .filter(variantId -> !baseNetworkVariantIds.contains(variantId))
-            .filter(variantId -> !variantId.equals(stateSaveVariant))
-            .collect(Collectors.toList());
-        variantsToBeRemoved.forEach(variantId -> networkClone.getVariantManager().removeVariant(variantId));
-    }
+//    @Override
+//    protected void cleanVariants(Network networkClone) {
+//        List<String> variantsToBeRemoved = networkClone.getVariantManager().getVariantIds().stream()
+//            .filter(variantId -> !baseNetworkVariantIds.contains(variantId))
+//            .filter(variantId -> !variantId.equals(stateSaveVariant))
+//            .collect(Collectors.toList());
+//        variantsToBeRemoved.forEach(variantId -> networkClone.getVariantManager().removeVariant(variantId));
+//    }
 
     @Override
     public void shutdownAndAwaitTermination(long timeout, TimeUnit unit) throws InterruptedException {

--- a/util/src/main/java/com/farao_community/farao/util/SingleNetworkPool.java
+++ b/util/src/main/java/com/farao_community/farao/util/SingleNetworkPool.java
@@ -20,12 +20,18 @@ import java.util.concurrent.TimeUnit;
  */
 public class SingleNetworkPool extends AbstractNetworkPool {
 
+    boolean cloneInitialised = false;
+
     SingleNetworkPool(Network network, String targetVariant) {
         super(network, targetVariant, 1);
-        initAvailableNetworks(network);
+        initClones(1);
     }
 
-    private void initAvailableNetworks(Network network) {
+    @Override
+    public void initClones(int desiredNumberOfClones) {
+        if (cloneInitialised) {
+            return;
+        }
         FaraoLoggerProvider.TECHNICAL_LOGS.info("Using base network '{}' on variant '{}'", network.getId(), targetVariant);
         network.getVariantManager().setWorkingVariant(targetVariant);
         network.getVariantManager().cloneVariant(networkInitialVariantId, Arrays.asList(stateSaveVariant, workingVariant), true);
@@ -33,6 +39,7 @@ public class SingleNetworkPool extends AbstractNetworkPool {
         if (!isSuccess) {
             throw new AssertionError("Cannot offer base network in pool. Should not happen");
         }
+        cloneInitialised = true;
     }
 
     @Override

--- a/util/src/test/java/com/farao_community/farao/util/NetworkPoolTest.java
+++ b/util/src/test/java/com/farao_community/farao/util/NetworkPoolTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -41,10 +40,12 @@ class NetworkPoolTest {
     @Test
     void networkPoolUsageTest() {
         try (AbstractNetworkPool pool = AbstractNetworkPool.create(network, otherVariant, 10)) {
+
+            pool.addNetworkClones(4);
             Network networkCopy = pool.getAvailableNetwork();
 
             assertNotNull(networkCopy);
-            assertEquals(network, networkCopy);
+            assertNotEquals(network, networkCopy);
             assertTrue(networkCopy.getVariantManager().getWorkingVariantId().startsWith("FaraoNetworkPool working variant"));
 
             pool.addNetworkClones(1);
@@ -97,14 +98,14 @@ class NetworkPoolTest {
     }
 
     @Test
-    void addClonesUnderMaxLimitTest() throws InterruptedException {
+    void addClonesUnderMaxLimit() throws InterruptedException {
         AbstractNetworkPool pool = AbstractNetworkPool.create(network, otherVariant, 8);
-        pool.addNetworkClones(5);
+        pool.addNetworkClones(6);
         assertEquals(6, pool.getNetworkNumberOfClones());
     }
 
     @Test
-    void addClonesOverMaxLimitTest() throws InterruptedException {
+    void addClonesOverMaxLimit() throws InterruptedException {
         AbstractNetworkPool pool = AbstractNetworkPool.create(network, otherVariant, 8);
         pool.addNetworkClones(14);
         assertEquals(8, pool.getNetworkNumberOfClones());
@@ -112,11 +113,16 @@ class NetworkPoolTest {
 
     // Does not pass so far
     @Test
-    void checkSameInitialVariantTest() throws InterruptedException {
+    void checkSameInitialVariant() throws InterruptedException {
         Set<String> variantsIds = new HashSet<>(network.getVariantManager().getVariantIds());
         AbstractNetworkPool pool = AbstractNetworkPool.create(network, otherVariant, 12);
+
+        pool.addNetworkClones(1);
         Network newNetwork = pool.getAvailableNetwork();
+
         pool.releaseUsedNetwork(newNetwork);
+
+        pool.shutdownAndAwaitTermination(24, TimeUnit.HOURS);
         assertEquals(variantsIds, new HashSet<>(network.getVariantManager().getVariantIds()));
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
The PR provides a better management of the number of copies of the network (`MultipleNetworkPool` class) by limiting the number of copies by the number of network actions actually available.

**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**
The parallelised RAO is now supposed to be faster since no useless copies of the network are created.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
The class now has a `addNetworkClones(int numberOfClones)` method that creates copies of the network. At present, there is no copy of the network initially in the Blocking Queue so a test is performed before calling a `NetworkPool` to ensure that the queue is not empty (which would result in an infinite loop).

The method `SearchTree.updateOptimalLeafWithNextDepthBestLeaf` was refactored since the `network` argument is no longer used because the `AbstractNetworkPool` know has a `network` attribute.


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
