### PR TITLE
Fix fallback logs

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/CastorFullOptimization.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/CastorFullOptimization.java
@@ -230,6 +230,9 @@ public class CastorFullOptimization {
             // log results
             RaoLogger.logMostLimitingElementsResults(BUSINESS_LOGS, initialResult, objectiveFunctionParameters.getType(), NUMBER_LOGGED_ELEMENTS_END_RAO);
             finalRaoResult = new UnoptimizedRaoResultImpl(initialResult);
+            finalCost = initialCost;
+            finalFunctionalCost = initialFunctionalCost;
+            finalVirtualCost = initialVirtualCost;
             if (raoResult.getOptimizationStepsExecuted().equals(OptimizationStepsExecuted.FIRST_PREVENTIVE_ONLY)) {
                 finalRaoResult.setOptimizationStepsExecuted(OptimizationStepsExecuted.FIRST_PREVENTIVE_FELLBACK_TO_INITIAL_SITUATION);
             } else {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?**

No

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

bug fix

**What is the current behavior?** *(You can also link to an open issue here)*

When Rao fallbacks on inital solution, even though the final result in the RaoResult is good, it logs the wrong after Rao cost :

Cost before RAO = 371.88 (functional: 371.88, virtual: 0.00), cost after RAO = 536.82 (functional: 536.82, virtual: 0.00)



**What is the new behavior (if this is a feature change)?**

Now, after a fallback, the final log is the following :

Cost before RAO = 371.88 (functional: 371.88, virtual: 0.00), cost after RAO = 371.88 (functional: 371.88, virtual: 0.00)

**Does this PR introduce a breaking change?**

No
