### PR TITLE
add limit to pst range for sensi changes

### DIFF
--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/AbstractRemedialAction.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/AbstractRemedialAction.java
@@ -72,20 +72,20 @@ public abstract class AbstractRemedialAction<I extends RemedialAction<I>> extend
         }
     }
 
-    @Override
     /**
      * Evaluates if the remedial action is available depending on its UsageMethod.
      * If TO_BE_EVALUATED condition has not been evaluated, default behavior is false
      */
+    @Override
     public boolean isRemedialActionAvailable(State state) {
         return isRemedialActionAvailable(state, false);
     }
 
-    @Override
     /**
      * Evaluates if the remedial action is available depending on its UsageMethod.
      * When UsageMethod is TO_BE_EVALUATED, condition has to have been evaluated previously
      */
+    @Override
     public boolean isRemedialActionAvailable(State state, boolean evaluatedCondition) {
         switch (getUsageMethod(state)) {
             case AVAILABLE:

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/RaoParametersConstants.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/RaoParametersConstants.java
@@ -43,7 +43,7 @@ public final class RaoParametersConstants {
     public static final String SOLVER = "solver";
     public static final String RELATIVE_MIP_GAP = "relative-mip-gap";
     public static final String SOLVER_SPECIFIC_PARAMETERS = "solver-specific-parameters";
-    public static final String MIP_MODEL = "mip-model";
+    public static final String PST_VARIATION_GRADUAL_DECREASE = "pst-variation-gradual-decrease";
 
     // topological actions optimization parameters
     public static final String TOPOLOGICAL_ACTIONS_OPTIMIZATION = "topological-actions-optimization";

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/RaoParametersConstants.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/RaoParametersConstants.java
@@ -43,6 +43,7 @@ public final class RaoParametersConstants {
     public static final String SOLVER = "solver";
     public static final String RELATIVE_MIP_GAP = "relative-mip-gap";
     public static final String SOLVER_SPECIFIC_PARAMETERS = "solver-specific-parameters";
+    public static final String MIP_MODEL = "mip-model";
 
     // topological actions optimization parameters
     public static final String TOPOLOGICAL_ACTIONS_OPTIMIZATION = "topological-actions-optimization";

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/RaoParametersConstants.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/RaoParametersConstants.java
@@ -43,7 +43,7 @@ public final class RaoParametersConstants {
     public static final String SOLVER = "solver";
     public static final String RELATIVE_MIP_GAP = "relative-mip-gap";
     public static final String SOLVER_SPECIFIC_PARAMETERS = "solver-specific-parameters";
-    public static final String PST_VARIATION_GRADUAL_DECREASE = "pst-range-decrease";
+    public static final String PST_RANGE_DECREASE = "pst-range-shrinking";
 
     // topological actions optimization parameters
     public static final String TOPOLOGICAL_ACTIONS_OPTIMIZATION = "topological-actions-optimization";

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/RaoParametersConstants.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/RaoParametersConstants.java
@@ -43,7 +43,7 @@ public final class RaoParametersConstants {
     public static final String SOLVER = "solver";
     public static final String RELATIVE_MIP_GAP = "relative-mip-gap";
     public static final String SOLVER_SPECIFIC_PARAMETERS = "solver-specific-parameters";
-    public static final String PST_RANGE_DECREASE = "pst-range-shrinking";
+    public static final String PST_RANGE_SHRINKING = "pst-range-shrinking";
 
     // topological actions optimization parameters
     public static final String TOPOLOGICAL_ACTIONS_OPTIMIZATION = "topological-actions-optimization";

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/RaoParametersConstants.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/RaoParametersConstants.java
@@ -43,7 +43,7 @@ public final class RaoParametersConstants {
     public static final String SOLVER = "solver";
     public static final String RELATIVE_MIP_GAP = "relative-mip-gap";
     public static final String SOLVER_SPECIFIC_PARAMETERS = "solver-specific-parameters";
-    public static final String PST_RANGE_SHRINKING = "pst-range-shrinking";
+    public static final String RA_RANGE_SHRINKING = "ra-range-shrinking";
 
     // topological actions optimization parameters
     public static final String TOPOLOGICAL_ACTIONS_OPTIMIZATION = "topological-actions-optimization";

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/RaoParametersConstants.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/RaoParametersConstants.java
@@ -43,7 +43,7 @@ public final class RaoParametersConstants {
     public static final String SOLVER = "solver";
     public static final String RELATIVE_MIP_GAP = "relative-mip-gap";
     public static final String SOLVER_SPECIFIC_PARAMETERS = "solver-specific-parameters";
-    public static final String PST_VARIATION_GRADUAL_DECREASE = "pst-variation-gradual-decrease";
+    public static final String PST_VARIATION_GRADUAL_DECREASE = "pst-range-decrease";
 
     // topological actions optimization parameters
     public static final String TOPOLOGICAL_ACTIONS_OPTIMIZATION = "topological-actions-optimization";

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/JsonRangeActionsOptimizationParameters.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/JsonRangeActionsOptimizationParameters.java
@@ -30,7 +30,7 @@ final class JsonRangeActionsOptimizationParameters {
         jsonGenerator.writeNumberField(PST_PENALTY_COST, parameters.getRangeActionsOptimizationParameters().getPstPenaltyCost());
         jsonGenerator.writeNumberField(PST_SENSITIVITY_THRESHOLD, parameters.getRangeActionsOptimizationParameters().getPstSensitivityThreshold());
         jsonGenerator.writeObjectField(PST_MODEL, parameters.getRangeActionsOptimizationParameters().getPstModel());
-        jsonGenerator.writeObjectField(PST_RANGE_SHRINKING, parameters.getRangeActionsOptimizationParameters().getPstRangeShrinking());
+        jsonGenerator.writeObjectField(RA_RANGE_SHRINKING, parameters.getRangeActionsOptimizationParameters().getRaRangeShrinking());
         jsonGenerator.writeNumberField(HVDC_PENALTY_COST, parameters.getRangeActionsOptimizationParameters().getHvdcPenaltyCost());
         jsonGenerator.writeNumberField(HVDC_SENSITIVITY_THRESHOLD, parameters.getRangeActionsOptimizationParameters().getHvdcSensitivityThreshold());
         jsonGenerator.writeNumberField(INJECTION_RA_PENALTY_COST, parameters.getRangeActionsOptimizationParameters().getInjectionRaPenaltyCost());
@@ -81,8 +81,8 @@ final class JsonRangeActionsOptimizationParameters {
                     jsonParser.nextToken();
                     deserializeLinearOptimizationSolver(jsonParser, raoParameters);
                     break;
-                case PST_RANGE_SHRINKING:
-                    raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(stringToPstRangeShrinking(jsonParser.nextTextValue()));
+                case RA_RANGE_SHRINKING:
+                    raoParameters.getRangeActionsOptimizationParameters().setRaRangeShrinking(stringToRaRangeShrinking(jsonParser.nextTextValue()));
                     break;
                 default:
                     throw new FaraoException(String.format("Cannot deserialize range action optimization parameters: unexpected field in %s (%s)", RANGE_ACTIONS_OPTIMIZATION, jsonParser.getCurrentName()));
@@ -118,9 +118,9 @@ final class JsonRangeActionsOptimizationParameters {
         }
     }
 
-    private static RangeActionsOptimizationParameters.PstRangeShrinking stringToPstRangeShrinking(String string) {
+    private static RangeActionsOptimizationParameters.RaRangeShrinking stringToRaRangeShrinking(String string) {
         try {
-            return RangeActionsOptimizationParameters.PstRangeShrinking.valueOf(string);
+            return RangeActionsOptimizationParameters.RaRangeShrinking.valueOf(string);
         } catch (IllegalArgumentException e) {
             throw new FaraoException(String.format("Unknown Pst variation range shrinking: %s", string));
         }

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/JsonRangeActionsOptimizationParameters.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/JsonRangeActionsOptimizationParameters.java
@@ -30,7 +30,7 @@ final class JsonRangeActionsOptimizationParameters {
         jsonGenerator.writeNumberField(PST_PENALTY_COST, parameters.getRangeActionsOptimizationParameters().getPstPenaltyCost());
         jsonGenerator.writeNumberField(PST_SENSITIVITY_THRESHOLD, parameters.getRangeActionsOptimizationParameters().getPstSensitivityThreshold());
         jsonGenerator.writeObjectField(PST_MODEL, parameters.getRangeActionsOptimizationParameters().getPstModel());
-        jsonGenerator.writeObjectField(PST_VARIATION_GRADUAL_DECREASE, parameters.getRangeActionsOptimizationParameters().getPstVariationGradualDecrease());
+        jsonGenerator.writeObjectField(PST_RANGE_DECREASE, parameters.getRangeActionsOptimizationParameters().getPstRangeDecrease());
         jsonGenerator.writeNumberField(HVDC_PENALTY_COST, parameters.getRangeActionsOptimizationParameters().getHvdcPenaltyCost());
         jsonGenerator.writeNumberField(HVDC_SENSITIVITY_THRESHOLD, parameters.getRangeActionsOptimizationParameters().getHvdcSensitivityThreshold());
         jsonGenerator.writeNumberField(INJECTION_RA_PENALTY_COST, parameters.getRangeActionsOptimizationParameters().getInjectionRaPenaltyCost());
@@ -81,8 +81,8 @@ final class JsonRangeActionsOptimizationParameters {
                     jsonParser.nextToken();
                     deserializeLinearOptimizationSolver(jsonParser, raoParameters);
                     break;
-                case PST_VARIATION_GRADUAL_DECREASE:
-                    raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(stringToPstVariationGradualDecrease(jsonParser.nextTextValue()));
+                case PST_RANGE_DECREASE:
+                    raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(stringToPstVariationGradualDecrease(jsonParser.nextTextValue()));
                     break;
                 default:
                     throw new FaraoException(String.format("Cannot deserialize range action optimization parameters: unexpected field in %s (%s)", RANGE_ACTIONS_OPTIMIZATION, jsonParser.getCurrentName()));

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/JsonRangeActionsOptimizationParameters.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/JsonRangeActionsOptimizationParameters.java
@@ -30,7 +30,7 @@ final class JsonRangeActionsOptimizationParameters {
         jsonGenerator.writeNumberField(PST_PENALTY_COST, parameters.getRangeActionsOptimizationParameters().getPstPenaltyCost());
         jsonGenerator.writeNumberField(PST_SENSITIVITY_THRESHOLD, parameters.getRangeActionsOptimizationParameters().getPstSensitivityThreshold());
         jsonGenerator.writeObjectField(PST_MODEL, parameters.getRangeActionsOptimizationParameters().getPstModel());
-        jsonGenerator.writeObjectField(MIP_MODEL, parameters.getRangeActionsOptimizationParameters().getMipModel());
+        jsonGenerator.writeObjectField(PST_VARIATION_GRADUAL_DECREASE, parameters.getRangeActionsOptimizationParameters().getPstVariationGradualDecrease());
         jsonGenerator.writeNumberField(HVDC_PENALTY_COST, parameters.getRangeActionsOptimizationParameters().getHvdcPenaltyCost());
         jsonGenerator.writeNumberField(HVDC_SENSITIVITY_THRESHOLD, parameters.getRangeActionsOptimizationParameters().getHvdcSensitivityThreshold());
         jsonGenerator.writeNumberField(INJECTION_RA_PENALTY_COST, parameters.getRangeActionsOptimizationParameters().getInjectionRaPenaltyCost());
@@ -81,8 +81,8 @@ final class JsonRangeActionsOptimizationParameters {
                     jsonParser.nextToken();
                     deserializeLinearOptimizationSolver(jsonParser, raoParameters);
                     break;
-                case MIP_MODEL:
-                    raoParameters.getRangeActionsOptimizationParameters().setMipModel(stringToMipModel(jsonParser.nextTextValue()));
+                case PST_VARIATION_GRADUAL_DECREASE:
+                    raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(stringToPstVariationGradualDecrease(jsonParser.nextTextValue()));
                     break;
                 default:
                     throw new FaraoException(String.format("Cannot deserialize range action optimization parameters: unexpected field in %s (%s)", RANGE_ACTIONS_OPTIMIZATION, jsonParser.getCurrentName()));
@@ -118,11 +118,11 @@ final class JsonRangeActionsOptimizationParameters {
         }
     }
 
-    private static RangeActionsOptimizationParameters.MipModel stringToMipModel(String string) {
+    private static RangeActionsOptimizationParameters.PstVariationGradualDecrease stringToPstVariationGradualDecrease(String string) {
         try {
-            return RangeActionsOptimizationParameters.MipModel.valueOf(string);
+            return RangeActionsOptimizationParameters.PstVariationGradualDecrease.valueOf(string);
         } catch (IllegalArgumentException e) {
-            throw new FaraoException(String.format("Unknown Mip model: %s", string));
+            throw new FaraoException(String.format("Unknown Pst variation gradual decrease: %s", string));
         }
     }
 

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/JsonRangeActionsOptimizationParameters.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/JsonRangeActionsOptimizationParameters.java
@@ -30,11 +30,11 @@ final class JsonRangeActionsOptimizationParameters {
         jsonGenerator.writeNumberField(PST_PENALTY_COST, parameters.getRangeActionsOptimizationParameters().getPstPenaltyCost());
         jsonGenerator.writeNumberField(PST_SENSITIVITY_THRESHOLD, parameters.getRangeActionsOptimizationParameters().getPstSensitivityThreshold());
         jsonGenerator.writeObjectField(PST_MODEL, parameters.getRangeActionsOptimizationParameters().getPstModel());
-        jsonGenerator.writeObjectField(RA_RANGE_SHRINKING, parameters.getRangeActionsOptimizationParameters().getRaRangeShrinking());
         jsonGenerator.writeNumberField(HVDC_PENALTY_COST, parameters.getRangeActionsOptimizationParameters().getHvdcPenaltyCost());
         jsonGenerator.writeNumberField(HVDC_SENSITIVITY_THRESHOLD, parameters.getRangeActionsOptimizationParameters().getHvdcSensitivityThreshold());
         jsonGenerator.writeNumberField(INJECTION_RA_PENALTY_COST, parameters.getRangeActionsOptimizationParameters().getInjectionRaPenaltyCost());
         jsonGenerator.writeNumberField(INJECTION_RA_SENSITIVITY_THRESHOLD, parameters.getRangeActionsOptimizationParameters().getInjectionRaSensitivityThreshold());
+        jsonGenerator.writeObjectField(RA_RANGE_SHRINKING, parameters.getRangeActionsOptimizationParameters().getRaRangeShrinking());
         jsonGenerator.writeObjectFieldStart(LINEAR_OPTIMIZATION_SOLVER);
         jsonGenerator.writeObjectField(SOLVER, parameters.getRangeActionsOptimizationParameters().getLinearOptimizationSolver().getSolver());
         jsonGenerator.writeNumberField(RELATIVE_MIP_GAP, parameters.getRangeActionsOptimizationParameters().getLinearOptimizationSolver().getRelativeMipGap());

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/JsonRangeActionsOptimizationParameters.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/JsonRangeActionsOptimizationParameters.java
@@ -30,6 +30,7 @@ final class JsonRangeActionsOptimizationParameters {
         jsonGenerator.writeNumberField(PST_PENALTY_COST, parameters.getRangeActionsOptimizationParameters().getPstPenaltyCost());
         jsonGenerator.writeNumberField(PST_SENSITIVITY_THRESHOLD, parameters.getRangeActionsOptimizationParameters().getPstSensitivityThreshold());
         jsonGenerator.writeObjectField(PST_MODEL, parameters.getRangeActionsOptimizationParameters().getPstModel());
+        jsonGenerator.writeObjectField(MIP_MODEL, parameters.getRangeActionsOptimizationParameters().getMipModel());
         jsonGenerator.writeNumberField(HVDC_PENALTY_COST, parameters.getRangeActionsOptimizationParameters().getHvdcPenaltyCost());
         jsonGenerator.writeNumberField(HVDC_SENSITIVITY_THRESHOLD, parameters.getRangeActionsOptimizationParameters().getHvdcSensitivityThreshold());
         jsonGenerator.writeNumberField(INJECTION_RA_PENALTY_COST, parameters.getRangeActionsOptimizationParameters().getInjectionRaPenaltyCost());
@@ -80,6 +81,9 @@ final class JsonRangeActionsOptimizationParameters {
                     jsonParser.nextToken();
                     deserializeLinearOptimizationSolver(jsonParser, raoParameters);
                     break;
+                case MIP_MODEL:
+                    raoParameters.getRangeActionsOptimizationParameters().setMipModel(stringToMipModel(jsonParser.nextTextValue()));
+                    break;
                 default:
                     throw new FaraoException(String.format("Cannot deserialize range action optimization parameters: unexpected field in %s (%s)", RANGE_ACTIONS_OPTIMIZATION, jsonParser.getCurrentName()));
             }
@@ -111,6 +115,14 @@ final class JsonRangeActionsOptimizationParameters {
             return RangeActionsOptimizationParameters.PstModel.valueOf(string);
         } catch (IllegalArgumentException e) {
             throw new FaraoException(String.format("Unknown Pst model: %s", string));
+        }
+    }
+
+    private static RangeActionsOptimizationParameters.MipModel stringToMipModel(String string) {
+        try {
+            return RangeActionsOptimizationParameters.MipModel.valueOf(string);
+        } catch (IllegalArgumentException e) {
+            throw new FaraoException(String.format("Unknown Mip model: %s", string));
         }
     }
 

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/JsonRangeActionsOptimizationParameters.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/JsonRangeActionsOptimizationParameters.java
@@ -30,7 +30,7 @@ final class JsonRangeActionsOptimizationParameters {
         jsonGenerator.writeNumberField(PST_PENALTY_COST, parameters.getRangeActionsOptimizationParameters().getPstPenaltyCost());
         jsonGenerator.writeNumberField(PST_SENSITIVITY_THRESHOLD, parameters.getRangeActionsOptimizationParameters().getPstSensitivityThreshold());
         jsonGenerator.writeObjectField(PST_MODEL, parameters.getRangeActionsOptimizationParameters().getPstModel());
-        jsonGenerator.writeObjectField(PST_RANGE_DECREASE, parameters.getRangeActionsOptimizationParameters().getPstRangeDecrease());
+        jsonGenerator.writeObjectField(PST_RANGE_SHRINKING, parameters.getRangeActionsOptimizationParameters().getPstRangeShrinking());
         jsonGenerator.writeNumberField(HVDC_PENALTY_COST, parameters.getRangeActionsOptimizationParameters().getHvdcPenaltyCost());
         jsonGenerator.writeNumberField(HVDC_SENSITIVITY_THRESHOLD, parameters.getRangeActionsOptimizationParameters().getHvdcSensitivityThreshold());
         jsonGenerator.writeNumberField(INJECTION_RA_PENALTY_COST, parameters.getRangeActionsOptimizationParameters().getInjectionRaPenaltyCost());
@@ -81,8 +81,8 @@ final class JsonRangeActionsOptimizationParameters {
                     jsonParser.nextToken();
                     deserializeLinearOptimizationSolver(jsonParser, raoParameters);
                     break;
-                case PST_RANGE_DECREASE:
-                    raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(stringToPstVariationGradualDecrease(jsonParser.nextTextValue()));
+                case PST_RANGE_SHRINKING:
+                    raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(stringToPstRangeShrinking(jsonParser.nextTextValue()));
                     break;
                 default:
                     throw new FaraoException(String.format("Cannot deserialize range action optimization parameters: unexpected field in %s (%s)", RANGE_ACTIONS_OPTIMIZATION, jsonParser.getCurrentName()));
@@ -118,11 +118,11 @@ final class JsonRangeActionsOptimizationParameters {
         }
     }
 
-    private static RangeActionsOptimizationParameters.PstRangeDecrease stringToPstVariationGradualDecrease(String string) {
+    private static RangeActionsOptimizationParameters.PstRangeShrinking stringToPstRangeShrinking(String string) {
         try {
-            return RangeActionsOptimizationParameters.PstRangeDecrease.valueOf(string);
+            return RangeActionsOptimizationParameters.PstRangeShrinking.valueOf(string);
         } catch (IllegalArgumentException e) {
-            throw new FaraoException(String.format("Unknown Pst variation gradual decrease: %s", string));
+            throw new FaraoException(String.format("Unknown Pst variation range shrinking: %s", string));
         }
     }
 

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/JsonRangeActionsOptimizationParameters.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/json/JsonRangeActionsOptimizationParameters.java
@@ -118,9 +118,9 @@ final class JsonRangeActionsOptimizationParameters {
         }
     }
 
-    private static RangeActionsOptimizationParameters.PstVariationGradualDecrease stringToPstVariationGradualDecrease(String string) {
+    private static RangeActionsOptimizationParameters.PstRangeDecrease stringToPstVariationGradualDecrease(String string) {
         try {
-            return RangeActionsOptimizationParameters.PstVariationGradualDecrease.valueOf(string);
+            return RangeActionsOptimizationParameters.PstRangeDecrease.valueOf(string);
         } catch (IllegalArgumentException e) {
             throw new FaraoException(String.format("Unknown Pst variation gradual decrease: %s", string));
         }

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/parameters/RangeActionsOptimizationParameters.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/parameters/RangeActionsOptimizationParameters.java
@@ -30,7 +30,7 @@ public class RangeActionsOptimizationParameters {
     private static final double DEFAULT_HVDC_SENSITIVITY_THRESHOLD = 0.0;
     private static final double DEFAULT_INJECTION_RA_PENALTY_COST = 0.001;
     private static final double DEFAULT_INJECTION_RA_SENSITIVITY_THRESHOLD = 0.0;
-    private static final MipModel DEFAULT_MIP_MODEL = MipModel.DISABLED;
+    private static final PstVariationGradualDecrease DEFAULT_PST_DECREASE = PstVariationGradualDecrease.DISABLED;
     // Attributes
     private int maxMipIterations = DEFAULT_MAX_MIP_ITERATIONS;
     private double pstPenaltyCost = DEFAULT_PST_PENALTY_COST;
@@ -41,7 +41,7 @@ public class RangeActionsOptimizationParameters {
     private double injectionRaPenaltyCost = DEFAULT_INJECTION_RA_PENALTY_COST;
     private double injectionRaSensitivityThreshold = DEFAULT_INJECTION_RA_SENSITIVITY_THRESHOLD;
     private LinearOptimizationSolver linearOptimizationSolver = new LinearOptimizationSolver();
-    private MipModel mipModel = DEFAULT_MIP_MODEL;
+    private PstVariationGradualDecrease pstVariationGradualDecrease = DEFAULT_PST_DECREASE;
 
     // Enum
     public enum PstModel {
@@ -49,8 +49,8 @@ public class RangeActionsOptimizationParameters {
         APPROXIMATED_INTEGERS
     }
 
-    // Refactore these names
-    public enum MipModel {
+    // Refactor these names
+    public enum PstVariationGradualDecrease {
         DISABLED,
         FIRST_PREV_AND_CURATIVE_ONLY,
         ALL
@@ -180,9 +180,13 @@ public class RangeActionsOptimizationParameters {
         this.linearOptimizationSolver = linearOptimizationSolver;
     }
 
-    public void setMipModel(MipModel mipModel) {this.mipModel = mipModel;}
+    public void setPstVariationGradualDecrease(PstVariationGradualDecrease pstVariationGradualDecrease) {
+        this.pstVariationGradualDecrease = pstVariationGradualDecrease;
+    }
 
-    public MipModel getMipModel() {return mipModel;}
+    public PstVariationGradualDecrease getPstVariationGradualDecrease() {
+        return pstVariationGradualDecrease;
+    }
 
     public static RangeActionsOptimizationParameters load(PlatformConfig platformConfig) {
         Objects.requireNonNull(platformConfig);
@@ -197,7 +201,7 @@ public class RangeActionsOptimizationParameters {
                     parameters.setHvdcSensitivityThreshold(config.getDoubleProperty(HVDC_SENSITIVITY_THRESHOLD, DEFAULT_HVDC_SENSITIVITY_THRESHOLD));
                     parameters.setInjectionRaPenaltyCost(config.getDoubleProperty(INJECTION_RA_PENALTY_COST, DEFAULT_INJECTION_RA_PENALTY_COST));
                     parameters.setInjectionRaSensitivityThreshold(config.getDoubleProperty(INJECTION_RA_SENSITIVITY_THRESHOLD, DEFAULT_INJECTION_RA_SENSITIVITY_THRESHOLD));
-                    parameters.setMipModel(config.getEnumProperty(MIP_MODEL, MipModel.class, DEFAULT_MIP_MODEL));
+                    parameters.setPstVariationGradualDecrease(config.getEnumProperty(PST_VARIATION_GRADUAL_DECREASE, PstVariationGradualDecrease.class, DEFAULT_PST_DECREASE));
                 });
         parameters.setLinearOptimizationSolver(LinearOptimizationSolver.load(platformConfig));
         return parameters;

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/parameters/RangeActionsOptimizationParameters.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/parameters/RangeActionsOptimizationParameters.java
@@ -30,7 +30,7 @@ public class RangeActionsOptimizationParameters {
     private static final double DEFAULT_HVDC_SENSITIVITY_THRESHOLD = 0.0;
     private static final double DEFAULT_INJECTION_RA_PENALTY_COST = 0.001;
     private static final double DEFAULT_INJECTION_RA_SENSITIVITY_THRESHOLD = 0.0;
-    private static final PstRangeShrinking DEFAULT_PST_RANGE_SHRINKING = PstRangeShrinking.DISABLED;
+    private static final RaRangeShrinking DEFAULT_RA_RANGE_SHRINKING = RaRangeShrinking.DISABLED;
     // Attributes
     private int maxMipIterations = DEFAULT_MAX_MIP_ITERATIONS;
     private double pstPenaltyCost = DEFAULT_PST_PENALTY_COST;
@@ -41,16 +41,14 @@ public class RangeActionsOptimizationParameters {
     private double injectionRaPenaltyCost = DEFAULT_INJECTION_RA_PENALTY_COST;
     private double injectionRaSensitivityThreshold = DEFAULT_INJECTION_RA_SENSITIVITY_THRESHOLD;
     private LinearOptimizationSolver linearOptimizationSolver = new LinearOptimizationSolver();
-    private PstRangeShrinking pstRangeShrinking = DEFAULT_PST_RANGE_SHRINKING;
+    private RaRangeShrinking raRangeShrinking = DEFAULT_RA_RANGE_SHRINKING;
 
-    // Enum
     public enum PstModel {
         CONTINUOUS,
         APPROXIMATED_INTEGERS
     }
 
-    // Refactor these names
-    public enum PstRangeShrinking {
+    public enum RaRangeShrinking {
         DISABLED,
         ENABLED,
         ENABLED_IN_FIRST_PRAO_AND_CRAO
@@ -180,12 +178,12 @@ public class RangeActionsOptimizationParameters {
         this.linearOptimizationSolver = linearOptimizationSolver;
     }
 
-    public void setPstRangeShrinking(PstRangeShrinking pstRangeShrinking) {
-        this.pstRangeShrinking = pstRangeShrinking;
+    public void setRaRangeShrinking(RaRangeShrinking raRangeShrinking) {
+        this.raRangeShrinking = raRangeShrinking;
     }
 
-    public PstRangeShrinking getPstRangeShrinking() {
-        return pstRangeShrinking;
+    public RaRangeShrinking getRaRangeShrinking() {
+        return raRangeShrinking;
     }
 
     public static RangeActionsOptimizationParameters load(PlatformConfig platformConfig) {
@@ -201,7 +199,7 @@ public class RangeActionsOptimizationParameters {
                     parameters.setHvdcSensitivityThreshold(config.getDoubleProperty(HVDC_SENSITIVITY_THRESHOLD, DEFAULT_HVDC_SENSITIVITY_THRESHOLD));
                     parameters.setInjectionRaPenaltyCost(config.getDoubleProperty(INJECTION_RA_PENALTY_COST, DEFAULT_INJECTION_RA_PENALTY_COST));
                     parameters.setInjectionRaSensitivityThreshold(config.getDoubleProperty(INJECTION_RA_SENSITIVITY_THRESHOLD, DEFAULT_INJECTION_RA_SENSITIVITY_THRESHOLD));
-                    parameters.setPstRangeShrinking(config.getEnumProperty(PST_RANGE_SHRINKING, PstRangeShrinking.class, DEFAULT_PST_RANGE_SHRINKING));
+                    parameters.setRaRangeShrinking(config.getEnumProperty(RA_RANGE_SHRINKING, RaRangeShrinking.class, DEFAULT_RA_RANGE_SHRINKING));
                 });
         parameters.setLinearOptimizationSolver(LinearOptimizationSolver.load(platformConfig));
         return parameters;

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/parameters/RangeActionsOptimizationParameters.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/parameters/RangeActionsOptimizationParameters.java
@@ -30,6 +30,7 @@ public class RangeActionsOptimizationParameters {
     private static final double DEFAULT_HVDC_SENSITIVITY_THRESHOLD = 0.0;
     private static final double DEFAULT_INJECTION_RA_PENALTY_COST = 0.001;
     private static final double DEFAULT_INJECTION_RA_SENSITIVITY_THRESHOLD = 0.0;
+    private static final MipModel DEFAULT_MIP_MODEL = MipModel.DISABLED;
     // Attributes
     private int maxMipIterations = DEFAULT_MAX_MIP_ITERATIONS;
     private double pstPenaltyCost = DEFAULT_PST_PENALTY_COST;
@@ -40,11 +41,19 @@ public class RangeActionsOptimizationParameters {
     private double injectionRaPenaltyCost = DEFAULT_INJECTION_RA_PENALTY_COST;
     private double injectionRaSensitivityThreshold = DEFAULT_INJECTION_RA_SENSITIVITY_THRESHOLD;
     private LinearOptimizationSolver linearOptimizationSolver = new LinearOptimizationSolver();
+    private MipModel mipModel = DEFAULT_MIP_MODEL;
 
     // Enum
     public enum PstModel {
         CONTINUOUS,
         APPROXIMATED_INTEGERS
+    }
+
+    // Refactore these names
+    public enum MipModel {
+        DISABLED,
+        FIRST_PREV_AND_CURATIVE_ONLY,
+        ALL
     }
 
     public static class LinearOptimizationSolver {
@@ -171,6 +180,10 @@ public class RangeActionsOptimizationParameters {
         this.linearOptimizationSolver = linearOptimizationSolver;
     }
 
+    public void setMipModel(MipModel mipModel) {this.mipModel = mipModel;}
+
+    public MipModel getMipModel() {return mipModel;}
+
     public static RangeActionsOptimizationParameters load(PlatformConfig platformConfig) {
         Objects.requireNonNull(platformConfig);
         RangeActionsOptimizationParameters parameters = new RangeActionsOptimizationParameters();
@@ -184,6 +197,7 @@ public class RangeActionsOptimizationParameters {
                     parameters.setHvdcSensitivityThreshold(config.getDoubleProperty(HVDC_SENSITIVITY_THRESHOLD, DEFAULT_HVDC_SENSITIVITY_THRESHOLD));
                     parameters.setInjectionRaPenaltyCost(config.getDoubleProperty(INJECTION_RA_PENALTY_COST, DEFAULT_INJECTION_RA_PENALTY_COST));
                     parameters.setInjectionRaSensitivityThreshold(config.getDoubleProperty(INJECTION_RA_SENSITIVITY_THRESHOLD, DEFAULT_INJECTION_RA_SENSITIVITY_THRESHOLD));
+                    parameters.setMipModel(config.getEnumProperty(MIP_MODEL, MipModel.class, DEFAULT_MIP_MODEL));
                 });
         parameters.setLinearOptimizationSolver(LinearOptimizationSolver.load(platformConfig));
         return parameters;

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/parameters/RangeActionsOptimizationParameters.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/parameters/RangeActionsOptimizationParameters.java
@@ -53,7 +53,7 @@ public class RangeActionsOptimizationParameters {
     public enum PstRangeDecrease {
         DISABLED,
         ENABLED,
-        ENABLED_FOR_FIRST_PREVENTIVE_AND_CURATIVE_ONLY
+        ENABLED_IN_FIRST_PRAO_AND_CRAO
     }
 
     public static class LinearOptimizationSolver {
@@ -180,11 +180,11 @@ public class RangeActionsOptimizationParameters {
         this.linearOptimizationSolver = linearOptimizationSolver;
     }
 
-    public void setPstVariationGradualDecrease(PstRangeDecrease pstVariationGradualDecrease) {
+    public void setPstRangeDecrease(PstRangeDecrease pstVariationGradualDecrease) {
         this.pstVariationGradualDecrease = pstVariationGradualDecrease;
     }
 
-    public PstRangeDecrease getPstVariationGradualDecrease() {
+    public PstRangeDecrease getPstRangeDecrease() {
         return pstVariationGradualDecrease;
     }
 
@@ -201,7 +201,7 @@ public class RangeActionsOptimizationParameters {
                     parameters.setHvdcSensitivityThreshold(config.getDoubleProperty(HVDC_SENSITIVITY_THRESHOLD, DEFAULT_HVDC_SENSITIVITY_THRESHOLD));
                     parameters.setInjectionRaPenaltyCost(config.getDoubleProperty(INJECTION_RA_PENALTY_COST, DEFAULT_INJECTION_RA_PENALTY_COST));
                     parameters.setInjectionRaSensitivityThreshold(config.getDoubleProperty(INJECTION_RA_SENSITIVITY_THRESHOLD, DEFAULT_INJECTION_RA_SENSITIVITY_THRESHOLD));
-                    parameters.setPstVariationGradualDecrease(config.getEnumProperty(PST_VARIATION_GRADUAL_DECREASE, PstRangeDecrease.class, DEFAULT_PST_DECREASE));
+                    parameters.setPstRangeDecrease(config.getEnumProperty(PST_RANGE_DECREASE, PstRangeDecrease.class, DEFAULT_PST_DECREASE));
                 });
         parameters.setLinearOptimizationSolver(LinearOptimizationSolver.load(platformConfig));
         return parameters;

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/parameters/RangeActionsOptimizationParameters.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/parameters/RangeActionsOptimizationParameters.java
@@ -52,8 +52,8 @@ public class RangeActionsOptimizationParameters {
     // Refactor these names
     public enum PstVariationGradualDecrease {
         DISABLED,
-        FIRST_PREV_AND_CURATIVE_ONLY,
-        ALL
+        ENABLED_FOR_ALL_STATE,
+        ENABLED_FOR_FIRST_PREVENTIVE_AND_CURATIVE
     }
 
     public static class LinearOptimizationSolver {

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/parameters/RangeActionsOptimizationParameters.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/parameters/RangeActionsOptimizationParameters.java
@@ -30,7 +30,7 @@ public class RangeActionsOptimizationParameters {
     private static final double DEFAULT_HVDC_SENSITIVITY_THRESHOLD = 0.0;
     private static final double DEFAULT_INJECTION_RA_PENALTY_COST = 0.001;
     private static final double DEFAULT_INJECTION_RA_SENSITIVITY_THRESHOLD = 0.0;
-    private static final PstRangeDecrease DEFAULT_PST_DECREASE = PstRangeDecrease.DISABLED;
+    private static final PstRangeShrinking DEFAULT_PST_RANGE_SHRINKING = PstRangeShrinking.DISABLED;
     // Attributes
     private int maxMipIterations = DEFAULT_MAX_MIP_ITERATIONS;
     private double pstPenaltyCost = DEFAULT_PST_PENALTY_COST;
@@ -41,7 +41,7 @@ public class RangeActionsOptimizationParameters {
     private double injectionRaPenaltyCost = DEFAULT_INJECTION_RA_PENALTY_COST;
     private double injectionRaSensitivityThreshold = DEFAULT_INJECTION_RA_SENSITIVITY_THRESHOLD;
     private LinearOptimizationSolver linearOptimizationSolver = new LinearOptimizationSolver();
-    private PstRangeDecrease pstVariationGradualDecrease = DEFAULT_PST_DECREASE;
+    private PstRangeShrinking pstRangeShrinking = DEFAULT_PST_RANGE_SHRINKING;
 
     // Enum
     public enum PstModel {
@@ -50,7 +50,7 @@ public class RangeActionsOptimizationParameters {
     }
 
     // Refactor these names
-    public enum PstRangeDecrease {
+    public enum PstRangeShrinking {
         DISABLED,
         ENABLED,
         ENABLED_IN_FIRST_PRAO_AND_CRAO
@@ -180,12 +180,12 @@ public class RangeActionsOptimizationParameters {
         this.linearOptimizationSolver = linearOptimizationSolver;
     }
 
-    public void setPstRangeDecrease(PstRangeDecrease pstVariationGradualDecrease) {
-        this.pstVariationGradualDecrease = pstVariationGradualDecrease;
+    public void setPstRangeShrinking(PstRangeShrinking pstRangeShrinking) {
+        this.pstRangeShrinking = pstRangeShrinking;
     }
 
-    public PstRangeDecrease getPstRangeDecrease() {
-        return pstVariationGradualDecrease;
+    public PstRangeShrinking getPstRangeShrinking() {
+        return pstRangeShrinking;
     }
 
     public static RangeActionsOptimizationParameters load(PlatformConfig platformConfig) {
@@ -201,7 +201,7 @@ public class RangeActionsOptimizationParameters {
                     parameters.setHvdcSensitivityThreshold(config.getDoubleProperty(HVDC_SENSITIVITY_THRESHOLD, DEFAULT_HVDC_SENSITIVITY_THRESHOLD));
                     parameters.setInjectionRaPenaltyCost(config.getDoubleProperty(INJECTION_RA_PENALTY_COST, DEFAULT_INJECTION_RA_PENALTY_COST));
                     parameters.setInjectionRaSensitivityThreshold(config.getDoubleProperty(INJECTION_RA_SENSITIVITY_THRESHOLD, DEFAULT_INJECTION_RA_SENSITIVITY_THRESHOLD));
-                    parameters.setPstRangeDecrease(config.getEnumProperty(PST_RANGE_DECREASE, PstRangeDecrease.class, DEFAULT_PST_DECREASE));
+                    parameters.setPstRangeShrinking(config.getEnumProperty(PST_RANGE_SHRINKING, PstRangeShrinking.class, DEFAULT_PST_RANGE_SHRINKING));
                 });
         parameters.setLinearOptimizationSolver(LinearOptimizationSolver.load(platformConfig));
         return parameters;

--- a/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/parameters/RangeActionsOptimizationParameters.java
+++ b/ra-optimisation/rao-api/src/main/java/com/farao_community/farao/rao_api/parameters/RangeActionsOptimizationParameters.java
@@ -30,7 +30,7 @@ public class RangeActionsOptimizationParameters {
     private static final double DEFAULT_HVDC_SENSITIVITY_THRESHOLD = 0.0;
     private static final double DEFAULT_INJECTION_RA_PENALTY_COST = 0.001;
     private static final double DEFAULT_INJECTION_RA_SENSITIVITY_THRESHOLD = 0.0;
-    private static final PstVariationGradualDecrease DEFAULT_PST_DECREASE = PstVariationGradualDecrease.DISABLED;
+    private static final PstRangeDecrease DEFAULT_PST_DECREASE = PstRangeDecrease.DISABLED;
     // Attributes
     private int maxMipIterations = DEFAULT_MAX_MIP_ITERATIONS;
     private double pstPenaltyCost = DEFAULT_PST_PENALTY_COST;
@@ -41,7 +41,7 @@ public class RangeActionsOptimizationParameters {
     private double injectionRaPenaltyCost = DEFAULT_INJECTION_RA_PENALTY_COST;
     private double injectionRaSensitivityThreshold = DEFAULT_INJECTION_RA_SENSITIVITY_THRESHOLD;
     private LinearOptimizationSolver linearOptimizationSolver = new LinearOptimizationSolver();
-    private PstVariationGradualDecrease pstVariationGradualDecrease = DEFAULT_PST_DECREASE;
+    private PstRangeDecrease pstVariationGradualDecrease = DEFAULT_PST_DECREASE;
 
     // Enum
     public enum PstModel {
@@ -50,10 +50,10 @@ public class RangeActionsOptimizationParameters {
     }
 
     // Refactor these names
-    public enum PstVariationGradualDecrease {
+    public enum PstRangeDecrease {
         DISABLED,
-        ENABLED_FOR_ALL_STATE,
-        ENABLED_FOR_FIRST_PREVENTIVE_AND_CURATIVE
+        ENABLED,
+        ENABLED_FOR_FIRST_PREVENTIVE_AND_CURATIVE_ONLY
     }
 
     public static class LinearOptimizationSolver {
@@ -180,11 +180,11 @@ public class RangeActionsOptimizationParameters {
         this.linearOptimizationSolver = linearOptimizationSolver;
     }
 
-    public void setPstVariationGradualDecrease(PstVariationGradualDecrease pstVariationGradualDecrease) {
+    public void setPstVariationGradualDecrease(PstRangeDecrease pstVariationGradualDecrease) {
         this.pstVariationGradualDecrease = pstVariationGradualDecrease;
     }
 
-    public PstVariationGradualDecrease getPstVariationGradualDecrease() {
+    public PstRangeDecrease getPstVariationGradualDecrease() {
         return pstVariationGradualDecrease;
     }
 
@@ -201,7 +201,7 @@ public class RangeActionsOptimizationParameters {
                     parameters.setHvdcSensitivityThreshold(config.getDoubleProperty(HVDC_SENSITIVITY_THRESHOLD, DEFAULT_HVDC_SENSITIVITY_THRESHOLD));
                     parameters.setInjectionRaPenaltyCost(config.getDoubleProperty(INJECTION_RA_PENALTY_COST, DEFAULT_INJECTION_RA_PENALTY_COST));
                     parameters.setInjectionRaSensitivityThreshold(config.getDoubleProperty(INJECTION_RA_SENSITIVITY_THRESHOLD, DEFAULT_INJECTION_RA_SENSITIVITY_THRESHOLD));
-                    parameters.setPstVariationGradualDecrease(config.getEnumProperty(PST_VARIATION_GRADUAL_DECREASE, PstVariationGradualDecrease.class, DEFAULT_PST_DECREASE));
+                    parameters.setPstVariationGradualDecrease(config.getEnumProperty(PST_VARIATION_GRADUAL_DECREASE, PstRangeDecrease.class, DEFAULT_PST_DECREASE));
                 });
         parameters.setLinearOptimizationSolver(LinearOptimizationSolver.load(platformConfig));
         return parameters;

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoParametersTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoParametersTest.java
@@ -68,7 +68,7 @@ class JsonRaoParametersTest extends AbstractConverterTest {
         parameters.getRangeActionsOptimizationParameters().getLinearOptimizationSolver().setSolver(RangeActionsOptimizationParameters.Solver.SCIP);
         parameters.getRangeActionsOptimizationParameters().getLinearOptimizationSolver().setRelativeMipGap(1e-5);
         parameters.getRangeActionsOptimizationParameters().setPstModel(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS);
-        parameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED);
+        parameters.getRangeActionsOptimizationParameters().setRaRangeShrinking(RangeActionsOptimizationParameters.RaRangeShrinking.ENABLED);
         // TopologicalActions optimization parameters
         parameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(10);
         parameters.getTopoOptimizationParameters().setRelativeMinImpactThreshold(0.1);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoParametersTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoParametersTest.java
@@ -68,7 +68,7 @@ class JsonRaoParametersTest extends AbstractConverterTest {
         parameters.getRangeActionsOptimizationParameters().getLinearOptimizationSolver().setSolver(RangeActionsOptimizationParameters.Solver.SCIP);
         parameters.getRangeActionsOptimizationParameters().getLinearOptimizationSolver().setRelativeMipGap(1e-5);
         parameters.getRangeActionsOptimizationParameters().setPstModel(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS);
-        parameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
+        parameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED);
         // TopologicalActions optimization parameters
         parameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(10);
         parameters.getTopoOptimizationParameters().setRelativeMinImpactThreshold(0.1);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoParametersTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoParametersTest.java
@@ -68,7 +68,7 @@ class JsonRaoParametersTest extends AbstractConverterTest {
         parameters.getRangeActionsOptimizationParameters().getLinearOptimizationSolver().setSolver(RangeActionsOptimizationParameters.Solver.SCIP);
         parameters.getRangeActionsOptimizationParameters().getLinearOptimizationSolver().setRelativeMipGap(1e-5);
         parameters.getRangeActionsOptimizationParameters().setPstModel(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS);
-        parameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
+        parameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
         // TopologicalActions optimization parameters
         parameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(10);
         parameters.getTopoOptimizationParameters().setRelativeMinImpactThreshold(0.1);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoParametersTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoParametersTest.java
@@ -68,6 +68,7 @@ class JsonRaoParametersTest extends AbstractConverterTest {
         parameters.getRangeActionsOptimizationParameters().getLinearOptimizationSolver().setSolver(RangeActionsOptimizationParameters.Solver.SCIP);
         parameters.getRangeActionsOptimizationParameters().getLinearOptimizationSolver().setRelativeMipGap(1e-5);
         parameters.getRangeActionsOptimizationParameters().setPstModel(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS);
+        parameters.getRangeActionsOptimizationParameters().setMipModel(RangeActionsOptimizationParameters.MipModel.ALL);
         // TopologicalActions optimization parameters
         parameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(10);
         parameters.getTopoOptimizationParameters().setRelativeMinImpactThreshold(0.1);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoParametersTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoParametersTest.java
@@ -68,7 +68,7 @@ class JsonRaoParametersTest extends AbstractConverterTest {
         parameters.getRangeActionsOptimizationParameters().getLinearOptimizationSolver().setSolver(RangeActionsOptimizationParameters.Solver.SCIP);
         parameters.getRangeActionsOptimizationParameters().getLinearOptimizationSolver().setRelativeMipGap(1e-5);
         parameters.getRangeActionsOptimizationParameters().setPstModel(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS);
-        parameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ALL);
+        parameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ENABLED_FOR_ALL_STATE);
         // TopologicalActions optimization parameters
         parameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(10);
         parameters.getTopoOptimizationParameters().setRelativeMinImpactThreshold(0.1);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoParametersTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoParametersTest.java
@@ -68,7 +68,7 @@ class JsonRaoParametersTest extends AbstractConverterTest {
         parameters.getRangeActionsOptimizationParameters().getLinearOptimizationSolver().setSolver(RangeActionsOptimizationParameters.Solver.SCIP);
         parameters.getRangeActionsOptimizationParameters().getLinearOptimizationSolver().setRelativeMipGap(1e-5);
         parameters.getRangeActionsOptimizationParameters().setPstModel(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS);
-        parameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ENABLED_FOR_ALL_STATE);
+        parameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
         // TopologicalActions optimization parameters
         parameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(10);
         parameters.getTopoOptimizationParameters().setRelativeMinImpactThreshold(0.1);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoParametersTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/json/JsonRaoParametersTest.java
@@ -68,7 +68,7 @@ class JsonRaoParametersTest extends AbstractConverterTest {
         parameters.getRangeActionsOptimizationParameters().getLinearOptimizationSolver().setSolver(RangeActionsOptimizationParameters.Solver.SCIP);
         parameters.getRangeActionsOptimizationParameters().getLinearOptimizationSolver().setRelativeMipGap(1e-5);
         parameters.getRangeActionsOptimizationParameters().setPstModel(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS);
-        parameters.getRangeActionsOptimizationParameters().setMipModel(RangeActionsOptimizationParameters.MipModel.ALL);
+        parameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ALL);
         // TopologicalActions optimization parameters
         parameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(10);
         parameters.getTopoOptimizationParameters().setRelativeMinImpactThreshold(0.1);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersConfigTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersConfigTest.java
@@ -82,7 +82,7 @@ class RaoParametersConfigTest {
         assertEquals(44, params.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(7, params.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, params.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED, params.getPstVariationGradualDecrease());
+        assertEquals(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED, params.getPstRangeDecrease());
         assertEquals(33, params.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(8, params.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(22, params.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersConfigTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersConfigTest.java
@@ -82,7 +82,7 @@ class RaoParametersConfigTest {
         assertEquals(44, params.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(7, params.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, params.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.PstRangeShrinking.DISABLED, params.getPstRangeShrinking());
+        assertEquals(RangeActionsOptimizationParameters.RaRangeShrinking.DISABLED, params.getRaRangeShrinking());
         assertEquals(33, params.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(8, params.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(22, params.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersConfigTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersConfigTest.java
@@ -82,7 +82,7 @@ class RaoParametersConfigTest {
         assertEquals(44, params.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(7, params.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, params.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED, params.getPstRangeDecrease());
+        assertEquals(RangeActionsOptimizationParameters.PstRangeShrinking.DISABLED, params.getPstRangeShrinking());
         assertEquals(33, params.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(8, params.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(22, params.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersConfigTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersConfigTest.java
@@ -82,7 +82,7 @@ class RaoParametersConfigTest {
         assertEquals(44, params.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(7, params.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, params.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.MipModel.DISABLED, params.getMipModel());
+        assertEquals(RangeActionsOptimizationParameters.PstVariationGradualDecrease.DISABLED, params.getPstVariationGradualDecrease());
         assertEquals(33, params.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(8, params.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(22, params.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersConfigTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersConfigTest.java
@@ -82,7 +82,7 @@ class RaoParametersConfigTest {
         assertEquals(44, params.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(7, params.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, params.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.PstVariationGradualDecrease.DISABLED, params.getPstVariationGradualDecrease());
+        assertEquals(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED, params.getPstVariationGradualDecrease());
         assertEquals(33, params.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(8, params.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(22, params.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersConfigTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersConfigTest.java
@@ -82,6 +82,7 @@ class RaoParametersConfigTest {
         assertEquals(44, params.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(7, params.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, params.getPstModel());
+        assertEquals(RangeActionsOptimizationParameters.MipModel.DISABLED, params.getMipModel());
         assertEquals(33, params.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(8, params.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(22, params.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersYamlConfigTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersYamlConfigTest.java
@@ -52,7 +52,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.PstVariationGradualDecrease.DISABLED, rangeActionsOptimizationParameters.getPstVariationGradualDecrease());
+        assertEquals(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED, rangeActionsOptimizationParameters.getPstVariationGradualDecrease());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);
@@ -143,7 +143,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.PstVariationGradualDecrease.DISABLED, rangeActionsOptimizationParameters.getPstVariationGradualDecrease());
+        assertEquals(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED, rangeActionsOptimizationParameters.getPstVariationGradualDecrease());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);
@@ -222,7 +222,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ENABLED_FOR_ALL_STATE, rangeActionsOptimizationParameters.getPstVariationGradualDecrease());
+        assertEquals(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED, rangeActionsOptimizationParameters.getPstVariationGradualDecrease());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersYamlConfigTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersYamlConfigTest.java
@@ -52,7 +52,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.PstRangeShrinking.DISABLED, rangeActionsOptimizationParameters.getPstRangeShrinking());
+        assertEquals(RangeActionsOptimizationParameters.RaRangeShrinking.DISABLED, rangeActionsOptimizationParameters.getRaRangeShrinking());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);
@@ -143,7 +143,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.PstRangeShrinking.DISABLED, rangeActionsOptimizationParameters.getPstRangeShrinking());
+        assertEquals(RangeActionsOptimizationParameters.RaRangeShrinking.DISABLED, rangeActionsOptimizationParameters.getRaRangeShrinking());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);
@@ -222,7 +222,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED, rangeActionsOptimizationParameters.getPstRangeShrinking());
+        assertEquals(RangeActionsOptimizationParameters.RaRangeShrinking.ENABLED, rangeActionsOptimizationParameters.getRaRangeShrinking());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersYamlConfigTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersYamlConfigTest.java
@@ -222,7 +222,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ALL, rangeActionsOptimizationParameters.getPstVariationGradualDecrease());
+        assertEquals(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ENABLED_FOR_ALL_STATE, rangeActionsOptimizationParameters.getPstVariationGradualDecrease());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersYamlConfigTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersYamlConfigTest.java
@@ -52,7 +52,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.MipModel.DISABLED, rangeActionsOptimizationParameters.getMipModel());
+        assertEquals(RangeActionsOptimizationParameters.PstVariationGradualDecrease.DISABLED, rangeActionsOptimizationParameters.getPstVariationGradualDecrease());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);
@@ -143,7 +143,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.MipModel.DISABLED, rangeActionsOptimizationParameters.getMipModel());
+        assertEquals(RangeActionsOptimizationParameters.PstVariationGradualDecrease.DISABLED, rangeActionsOptimizationParameters.getPstVariationGradualDecrease());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);
@@ -222,7 +222,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.MipModel.ALL, rangeActionsOptimizationParameters.getMipModel());
+        assertEquals(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ALL, rangeActionsOptimizationParameters.getPstVariationGradualDecrease());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersYamlConfigTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersYamlConfigTest.java
@@ -52,7 +52,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED, rangeActionsOptimizationParameters.getPstVariationGradualDecrease());
+        assertEquals(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED, rangeActionsOptimizationParameters.getPstRangeDecrease());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);
@@ -143,7 +143,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED, rangeActionsOptimizationParameters.getPstVariationGradualDecrease());
+        assertEquals(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED, rangeActionsOptimizationParameters.getPstRangeDecrease());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);
@@ -222,7 +222,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED, rangeActionsOptimizationParameters.getPstVariationGradualDecrease());
+        assertEquals(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED, rangeActionsOptimizationParameters.getPstRangeDecrease());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersYamlConfigTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersYamlConfigTest.java
@@ -52,7 +52,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED, rangeActionsOptimizationParameters.getPstRangeDecrease());
+        assertEquals(RangeActionsOptimizationParameters.PstRangeShrinking.DISABLED, rangeActionsOptimizationParameters.getPstRangeShrinking());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);
@@ -143,7 +143,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED, rangeActionsOptimizationParameters.getPstRangeDecrease());
+        assertEquals(RangeActionsOptimizationParameters.PstRangeShrinking.DISABLED, rangeActionsOptimizationParameters.getPstRangeShrinking());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);
@@ -222,7 +222,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
-        assertEquals(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED, rangeActionsOptimizationParameters.getPstRangeDecrease());
+        assertEquals(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED, rangeActionsOptimizationParameters.getPstRangeShrinking());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);

--- a/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersYamlConfigTest.java
+++ b/ra-optimisation/rao-api/src/test/java/com/farao_community/farao/rao_api/parameters/RaoParametersYamlConfigTest.java
@@ -52,6 +52,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
+        assertEquals(RangeActionsOptimizationParameters.MipModel.DISABLED, rangeActionsOptimizationParameters.getMipModel());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);
@@ -142,6 +143,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
+        assertEquals(RangeActionsOptimizationParameters.MipModel.DISABLED, rangeActionsOptimizationParameters.getMipModel());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);
@@ -220,6 +222,7 @@ class RaoParametersYamlConfigTest extends AbstractConverterTest {
         assertEquals(0.02, rangeActionsOptimizationParameters.getPstPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getPstSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(RangeActionsOptimizationParameters.PstModel.APPROXIMATED_INTEGERS, rangeActionsOptimizationParameters.getPstModel());
+        assertEquals(RangeActionsOptimizationParameters.MipModel.ALL, rangeActionsOptimizationParameters.getMipModel());
         assertEquals(0.002, rangeActionsOptimizationParameters.getHvdcPenaltyCost(), DOUBLE_TOLERANCE);
         assertEquals(0.2, rangeActionsOptimizationParameters.getHvdcSensitivityThreshold(), DOUBLE_TOLERANCE);
         assertEquals(0.003, rangeActionsOptimizationParameters.getInjectionRaPenaltyCost(), DOUBLE_TOLERANCE);

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersSet_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersSet_v2.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 10.0,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "pst-variation-gradual-decrease" : "ENABLED_FOR_ALL_STATE",
+    "pst-variation-gradual-decrease" : "ENABLED",
     "hvdc-penalty-cost" : 1.0,
     "hvdc-sensitivity-threshold" : 0.3,
     "injection-ra-penalty-cost" : 1.2,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersSet_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersSet_v2.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 10.0,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "mip-model" : "ALL",
+    "pst-variation-gradual-decrease" : "ALL",
     "hvdc-penalty-cost" : 1.0,
     "hvdc-sensitivity-threshold" : 0.3,
     "injection-ra-penalty-cost" : 1.2,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersSet_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersSet_v2.json
@@ -12,11 +12,11 @@
     "pst-penalty-cost" : 10.0,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "ra-range-shrinking" : "ENABLED",
     "hvdc-penalty-cost" : 1.0,
     "hvdc-sensitivity-threshold" : 0.3,
     "injection-ra-penalty-cost" : 1.2,
     "injection-ra-sensitivity-threshold" : 0.7,
+    "ra-range-shrinking" : "ENABLED",
     "linear-optimization-solver" : {
       "solver" : "SCIP",
       "relative-mip-gap" : 1.0E-5,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersSet_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersSet_v2.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 10.0,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "pst-variation-gradual-decrease" : "ENABLED",
+    "pst-range-decrease" : "ENABLED",
     "hvdc-penalty-cost" : 1.0,
     "hvdc-sensitivity-threshold" : 0.3,
     "injection-ra-penalty-cost" : 1.2,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersSet_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersSet_v2.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 10.0,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "pst-range-shrinking" : "ENABLED",
+    "ra-range-shrinking" : "ENABLED",
     "hvdc-penalty-cost" : 1.0,
     "hvdc-sensitivity-threshold" : 0.3,
     "injection-ra-penalty-cost" : 1.2,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersSet_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersSet_v2.json
@@ -12,6 +12,7 @@
     "pst-penalty-cost" : 10.0,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
+    "mip-model" : "ALL",
     "hvdc-penalty-cost" : 1.0,
     "hvdc-sensitivity-threshold" : 0.3,
     "injection-ra-penalty-cost" : 1.2,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersSet_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersSet_v2.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 10.0,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "pst-variation-gradual-decrease" : "ALL",
+    "pst-variation-gradual-decrease" : "ENABLED_FOR_ALL_STATE",
     "hvdc-penalty-cost" : 1.0,
     "hvdc-sensitivity-threshold" : 0.3,
     "injection-ra-penalty-cost" : 1.2,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersSet_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersSet_v2.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 10.0,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "pst-range-decrease" : "ENABLED",
+    "pst-range-shrinking" : "ENABLED",
     "hvdc-penalty-cost" : 1.0,
     "hvdc-sensitivity-threshold" : 0.3,
     "injection-ra-penalty-cost" : 1.2,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersWithExtension_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersWithExtension_v2.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.01,
     "pst-sensitivity-threshold" : 0.0,
     "pst-model" : "CONTINUOUS",
-    "mip-model" : "DISABLED",
+    "pst-variation-gradual-decrease" : "DISABLED",
     "hvdc-penalty-cost" : 0.001,
     "hvdc-sensitivity-threshold" : 0.0,
     "injection-ra-penalty-cost" : 0.001,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersWithExtension_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersWithExtension_v2.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.01,
     "pst-sensitivity-threshold" : 0.0,
     "pst-model" : "CONTINUOUS",
-    "pst-range-decrease" : "DISABLED",
+    "pst-range-shrinking" : "DISABLED",
     "hvdc-penalty-cost" : 0.001,
     "hvdc-sensitivity-threshold" : 0.0,
     "injection-ra-penalty-cost" : 0.001,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersWithExtension_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersWithExtension_v2.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.01,
     "pst-sensitivity-threshold" : 0.0,
     "pst-model" : "CONTINUOUS",
-    "pst-variation-gradual-decrease" : "DISABLED",
+    "pst-range-decrease" : "DISABLED",
     "hvdc-penalty-cost" : 0.001,
     "hvdc-sensitivity-threshold" : 0.0,
     "injection-ra-penalty-cost" : 0.001,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersWithExtension_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersWithExtension_v2.json
@@ -12,6 +12,7 @@
     "pst-penalty-cost" : 0.01,
     "pst-sensitivity-threshold" : 0.0,
     "pst-model" : "CONTINUOUS",
+    "mip-model" : "DISABLED",
     "hvdc-penalty-cost" : 0.001,
     "hvdc-sensitivity-threshold" : 0.0,
     "injection-ra-penalty-cost" : 0.001,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersWithExtension_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersWithExtension_v2.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.01,
     "pst-sensitivity-threshold" : 0.0,
     "pst-model" : "CONTINUOUS",
-    "pst-range-shrinking" : "DISABLED",
+    "ra-range-shrinking" : "DISABLED",
     "hvdc-penalty-cost" : 0.001,
     "hvdc-sensitivity-threshold" : 0.0,
     "injection-ra-penalty-cost" : 0.001,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParametersWithExtension_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParametersWithExtension_v2.json
@@ -12,11 +12,11 @@
     "pst-penalty-cost" : 0.01,
     "pst-sensitivity-threshold" : 0.0,
     "pst-model" : "CONTINUOUS",
-    "ra-range-shrinking" : "DISABLED",
     "hvdc-penalty-cost" : 0.001,
     "hvdc-sensitivity-threshold" : 0.0,
     "injection-ra-penalty-cost" : 0.001,
     "injection-ra-sensitivity-threshold" : 0.0,
+    "ra-range-shrinking" : "DISABLED",
     "linear-optimization-solver" : {
       "solver" : "CBC",
       "relative-mip-gap" : 1.0E-4,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withExtensions.json
@@ -12,6 +12,7 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
+    "mip-model" : "DISABLED",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withExtensions.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "mip-model" : "DISABLED",
+    "pst-variation-gradual-decrease" : "DISABLED",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withExtensions.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "pst-range-decrease" : "DISABLED",
+    "pst-range-shrinking" : "DISABLED",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withExtensions.json
@@ -12,11 +12,11 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "ra-range-shrinking" : "DISABLED",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,
     "injection-ra-sensitivity-threshold" : 0.3,
+    "ra-range-shrinking" : "DISABLED",
     "linear-optimization-solver" : {
       "solver" : "XPRESS",
       "relative-mip-gap" : 0.004,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withExtensions.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "pst-variation-gradual-decrease" : "DISABLED",
+    "pst-range-decrease" : "DISABLED",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withExtensions.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "pst-range-shrinking" : "DISABLED",
+    "ra-range-shrinking" : "DISABLED",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withOLFParams.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withOLFParams.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.01,
     "pst-sensitivity-threshold" : 0.0,
     "pst-model" : "CONTINUOUS",
-    "mip-model" : "DISABLED",
+    "pst-variation-gradual-decrease" : "DISABLED",
     "hvdc-penalty-cost" : 0.001,
     "hvdc-sensitivity-threshold" : 0.0,
     "injection-ra-penalty-cost" : 0.001,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withOLFParams.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withOLFParams.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.01,
     "pst-sensitivity-threshold" : 0.0,
     "pst-model" : "CONTINUOUS",
-    "pst-range-decrease" : "DISABLED",
+    "pst-range-shrinking" : "DISABLED",
     "hvdc-penalty-cost" : 0.001,
     "hvdc-sensitivity-threshold" : 0.0,
     "injection-ra-penalty-cost" : 0.001,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withOLFParams.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withOLFParams.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.01,
     "pst-sensitivity-threshold" : 0.0,
     "pst-model" : "CONTINUOUS",
-    "pst-variation-gradual-decrease" : "DISABLED",
+    "pst-range-decrease" : "DISABLED",
     "hvdc-penalty-cost" : 0.001,
     "hvdc-sensitivity-threshold" : 0.0,
     "injection-ra-penalty-cost" : 0.001,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withOLFParams.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withOLFParams.json
@@ -12,6 +12,7 @@
     "pst-penalty-cost" : 0.01,
     "pst-sensitivity-threshold" : 0.0,
     "pst-model" : "CONTINUOUS",
+    "mip-model" : "DISABLED",
     "hvdc-penalty-cost" : 0.001,
     "hvdc-sensitivity-threshold" : 0.0,
     "injection-ra-penalty-cost" : 0.001,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withOLFParams.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withOLFParams.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.01,
     "pst-sensitivity-threshold" : 0.0,
     "pst-model" : "CONTINUOUS",
-    "pst-range-shrinking" : "DISABLED",
+    "ra-range-shrinking" : "DISABLED",
     "hvdc-penalty-cost" : 0.001,
     "hvdc-sensitivity-threshold" : 0.0,
     "injection-ra-penalty-cost" : 0.001,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withOLFParams.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withOLFParams.json
@@ -12,11 +12,11 @@
     "pst-penalty-cost" : 0.01,
     "pst-sensitivity-threshold" : 0.0,
     "pst-model" : "CONTINUOUS",
-    "ra-range-shrinking" : "DISABLED",
     "hvdc-penalty-cost" : 0.001,
     "hvdc-sensitivity-threshold" : 0.0,
     "injection-ra-penalty-cost" : 0.001,
     "injection-ra-sensitivity-threshold" : 0.0,
+    "ra-range-shrinking" : "DISABLED",
     "linear-optimization-solver" : {
       "solver" : "CBC",
       "relative-mip-gap" : 1.0E-4,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withPartialExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withPartialExtensions.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "pst-variation-gradual-decrease" : "ENABLED",
+    "pst-range-decrease" : "ENABLED",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withPartialExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withPartialExtensions.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "pst-range-shrinking" : "ENABLED",
+    "ra-range-shrinking" : "ENABLED",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withPartialExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withPartialExtensions.json
@@ -12,11 +12,11 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "ra-range-shrinking" : "ENABLED",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,
     "injection-ra-sensitivity-threshold" : 0.3,
+    "ra-range-shrinking" : "ENABLED",
     "linear-optimization-solver" : {
       "solver" : "CBC",
       "relative-mip-gap" : 0.004,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withPartialExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withPartialExtensions.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "pst-variation-gradual-decrease" : "ALL",
+    "pst-variation-gradual-decrease" : "ENABLED_FOR_ALL_STATE",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withPartialExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withPartialExtensions.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "mip-model" : "ALL",
+    "pst-variation-gradual-decrease" : "ALL",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withPartialExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withPartialExtensions.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "pst-range-decrease" : "ENABLED",
+    "pst-range-shrinking" : "ENABLED",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withPartialExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withPartialExtensions.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "pst-variation-gradual-decrease" : "ENABLED_FOR_ALL_STATE",
+    "pst-variation-gradual-decrease" : "ENABLED",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withPartialExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withPartialExtensions.json
@@ -12,6 +12,7 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
+    "mip-model" : "ALL",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withoutExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withoutExtensions.json
@@ -12,6 +12,7 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
+    "mip-model" : "DISABLED",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withoutExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withoutExtensions.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "mip-model" : "DISABLED",
+    "pst-variation-gradual-decrease" : "DISABLED",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withoutExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withoutExtensions.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "pst-range-decrease" : "DISABLED",
+    "pst-range-shrinking" : "DISABLED",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withoutExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withoutExtensions.json
@@ -12,11 +12,11 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "ra-range-shrinking" : "DISABLED",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,
     "injection-ra-sensitivity-threshold" : 0.3,
+    "ra-range-shrinking" : "DISABLED",
     "linear-optimization-solver" : {
       "solver" : "XPRESS",
       "relative-mip-gap" : 0.004,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withoutExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withoutExtensions.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "pst-variation-gradual-decrease" : "DISABLED",
+    "pst-range-decrease" : "DISABLED",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withoutExtensions.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_config_withoutExtensions.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.02,
     "pst-sensitivity-threshold" : 0.2,
     "pst-model" : "APPROXIMATED_INTEGERS",
-    "pst-range-shrinking" : "DISABLED",
+    "ra-range-shrinking" : "DISABLED",
     "hvdc-penalty-cost" : 0.002,
     "hvdc-sensitivity-threshold" : 0.2,
     "injection-ra-penalty-cost" : 0.003,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_v2.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.01,
     "pst-sensitivity-threshold" : 0.0,
     "pst-model" : "CONTINUOUS",
-    "mip-model" : "DISABLED",
+    "pst-variation-gradual-decrease" : "DISABLED",
     "hvdc-penalty-cost" : 0.001,
     "hvdc-sensitivity-threshold" : 0.0,
     "injection-ra-penalty-cost" : 0.001,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_v2.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.01,
     "pst-sensitivity-threshold" : 0.0,
     "pst-model" : "CONTINUOUS",
-    "pst-range-decrease" : "DISABLED",
+    "pst-range-shrinking" : "DISABLED",
     "hvdc-penalty-cost" : 0.001,
     "hvdc-sensitivity-threshold" : 0.0,
     "injection-ra-penalty-cost" : 0.001,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_v2.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.01,
     "pst-sensitivity-threshold" : 0.0,
     "pst-model" : "CONTINUOUS",
-    "pst-variation-gradual-decrease" : "DISABLED",
+    "pst-range-decrease" : "DISABLED",
     "hvdc-penalty-cost" : 0.001,
     "hvdc-sensitivity-threshold" : 0.0,
     "injection-ra-penalty-cost" : 0.001,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_v2.json
@@ -12,6 +12,7 @@
     "pst-penalty-cost" : 0.01,
     "pst-sensitivity-threshold" : 0.0,
     "pst-model" : "CONTINUOUS",
+    "mip-model" : "DISABLED",
     "hvdc-penalty-cost" : 0.001,
     "hvdc-sensitivity-threshold" : 0.0,
     "injection-ra-penalty-cost" : 0.001,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_v2.json
@@ -12,7 +12,7 @@
     "pst-penalty-cost" : 0.01,
     "pst-sensitivity-threshold" : 0.0,
     "pst-model" : "CONTINUOUS",
-    "pst-range-shrinking" : "DISABLED",
+    "ra-range-shrinking" : "DISABLED",
     "hvdc-penalty-cost" : 0.001,
     "hvdc-sensitivity-threshold" : 0.0,
     "injection-ra-penalty-cost" : 0.001,

--- a/ra-optimisation/rao-api/src/test/resources/RaoParameters_v2.json
+++ b/ra-optimisation/rao-api/src/test/resources/RaoParameters_v2.json
@@ -12,11 +12,11 @@
     "pst-penalty-cost" : 0.01,
     "pst-sensitivity-threshold" : 0.0,
     "pst-model" : "CONTINUOUS",
-    "ra-range-shrinking" : "DISABLED",
     "hvdc-penalty-cost" : 0.001,
     "hvdc-sensitivity-threshold" : 0.0,
     "injection-ra-penalty-cost" : 0.001,
     "injection-ra-sensitivity-threshold" : 0.0,
+    "ra-range-shrinking" : "DISABLED",
     "linear-optimization-solver" : {
       "solver" : "CBC",
       "relative-mip-gap" : 1.0E-4,

--- a/ra-optimisation/rao-api/src/test/resources/config_withPartialExtensions.yml
+++ b/ra-optimisation/rao-api/src/test/resources/config_withPartialExtensions.yml
@@ -8,7 +8,7 @@ rao-range-actions-optimization:
     pst-penalty-cost: 0.02
     pst-sensitivity-threshold: 0.2
     pst-model: APPROXIMATED_INTEGERS
-    pst-range-decrease: ENABLED
+    pst-range-shrinking: ENABLED
     hvdc-penalty-cost: 0.002
     hvdc-sensitivity-threshold: 0.2
     injection-ra-penalty-cost: 0.003

--- a/ra-optimisation/rao-api/src/test/resources/config_withPartialExtensions.yml
+++ b/ra-optimisation/rao-api/src/test/resources/config_withPartialExtensions.yml
@@ -8,7 +8,7 @@ rao-range-actions-optimization:
     pst-penalty-cost: 0.02
     pst-sensitivity-threshold: 0.2
     pst-model: APPROXIMATED_INTEGERS
-    pst-variation-gradual-decrease: ENABLED_FOR_ALL_STATE
+    pst-variation-gradual-decrease: ENABLED
     hvdc-penalty-cost: 0.002
     hvdc-sensitivity-threshold: 0.2
     injection-ra-penalty-cost: 0.003

--- a/ra-optimisation/rao-api/src/test/resources/config_withPartialExtensions.yml
+++ b/ra-optimisation/rao-api/src/test/resources/config_withPartialExtensions.yml
@@ -8,7 +8,7 @@ rao-range-actions-optimization:
     pst-penalty-cost: 0.02
     pst-sensitivity-threshold: 0.2
     pst-model: APPROXIMATED_INTEGERS
-    pst-variation-gradual-decrease: ENABLED
+    pst-range-decrease: ENABLED
     hvdc-penalty-cost: 0.002
     hvdc-sensitivity-threshold: 0.2
     injection-ra-penalty-cost: 0.003

--- a/ra-optimisation/rao-api/src/test/resources/config_withPartialExtensions.yml
+++ b/ra-optimisation/rao-api/src/test/resources/config_withPartialExtensions.yml
@@ -8,6 +8,7 @@ rao-range-actions-optimization:
     pst-penalty-cost: 0.02
     pst-sensitivity-threshold: 0.2
     pst-model: APPROXIMATED_INTEGERS
+    mip-model: ALL
     hvdc-penalty-cost: 0.002
     hvdc-sensitivity-threshold: 0.2
     injection-ra-penalty-cost: 0.003

--- a/ra-optimisation/rao-api/src/test/resources/config_withPartialExtensions.yml
+++ b/ra-optimisation/rao-api/src/test/resources/config_withPartialExtensions.yml
@@ -8,7 +8,7 @@ rao-range-actions-optimization:
     pst-penalty-cost: 0.02
     pst-sensitivity-threshold: 0.2
     pst-model: APPROXIMATED_INTEGERS
-    pst-range-shrinking: ENABLED
+    ra-range-shrinking: ENABLED
     hvdc-penalty-cost: 0.002
     hvdc-sensitivity-threshold: 0.2
     injection-ra-penalty-cost: 0.003

--- a/ra-optimisation/rao-api/src/test/resources/config_withPartialExtensions.yml
+++ b/ra-optimisation/rao-api/src/test/resources/config_withPartialExtensions.yml
@@ -8,7 +8,7 @@ rao-range-actions-optimization:
     pst-penalty-cost: 0.02
     pst-sensitivity-threshold: 0.2
     pst-model: APPROXIMATED_INTEGERS
-    pst-variation-gradual-decrease: ALL
+    pst-variation-gradual-decrease: ENABLED_FOR_ALL_STATE
     hvdc-penalty-cost: 0.002
     hvdc-sensitivity-threshold: 0.2
     injection-ra-penalty-cost: 0.003

--- a/ra-optimisation/rao-api/src/test/resources/config_withPartialExtensions.yml
+++ b/ra-optimisation/rao-api/src/test/resources/config_withPartialExtensions.yml
@@ -8,7 +8,7 @@ rao-range-actions-optimization:
     pst-penalty-cost: 0.02
     pst-sensitivity-threshold: 0.2
     pst-model: APPROXIMATED_INTEGERS
-    mip-model: ALL
+    pst-variation-gradual-decrease: ALL
     hvdc-penalty-cost: 0.002
     hvdc-sensitivity-threshold: 0.2
     injection-ra-penalty-cost: 0.003

--- a/ra-optimisation/rao-api/src/test/resources/config_withoutExtensions.yml
+++ b/ra-optimisation/rao-api/src/test/resources/config_withoutExtensions.yml
@@ -10,7 +10,7 @@ rao-range-actions-optimization:
     pst-penalty-cost: 0.02
     pst-sensitivity-threshold: 0.2
     pst-model: APPROXIMATED_INTEGERS
-    mip-model: DISABLED
+    pst-variation-gradual-decrease: DISABLED
     hvdc-penalty-cost: 0.002
     hvdc-sensitivity-threshold: 0.2
     injection-ra-penalty-cost: 0.003

--- a/ra-optimisation/rao-api/src/test/resources/config_withoutExtensions.yml
+++ b/ra-optimisation/rao-api/src/test/resources/config_withoutExtensions.yml
@@ -10,7 +10,7 @@ rao-range-actions-optimization:
     pst-penalty-cost: 0.02
     pst-sensitivity-threshold: 0.2
     pst-model: APPROXIMATED_INTEGERS
-    pst-range-decrease: DISABLED
+    pst-range-shrinking: DISABLED
     hvdc-penalty-cost: 0.002
     hvdc-sensitivity-threshold: 0.2
     injection-ra-penalty-cost: 0.003

--- a/ra-optimisation/rao-api/src/test/resources/config_withoutExtensions.yml
+++ b/ra-optimisation/rao-api/src/test/resources/config_withoutExtensions.yml
@@ -10,7 +10,7 @@ rao-range-actions-optimization:
     pst-penalty-cost: 0.02
     pst-sensitivity-threshold: 0.2
     pst-model: APPROXIMATED_INTEGERS
-    pst-range-shrinking: DISABLED
+    ra-range-shrinking: DISABLED
     hvdc-penalty-cost: 0.002
     hvdc-sensitivity-threshold: 0.2
     injection-ra-penalty-cost: 0.003

--- a/ra-optimisation/rao-api/src/test/resources/config_withoutExtensions.yml
+++ b/ra-optimisation/rao-api/src/test/resources/config_withoutExtensions.yml
@@ -10,6 +10,7 @@ rao-range-actions-optimization:
     pst-penalty-cost: 0.02
     pst-sensitivity-threshold: 0.2
     pst-model: APPROXIMATED_INTEGERS
+    mip-model: DISABLED
     hvdc-penalty-cost: 0.002
     hvdc-sensitivity-threshold: 0.2
     injection-ra-penalty-cost: 0.003

--- a/ra-optimisation/rao-api/src/test/resources/config_withoutExtensions.yml
+++ b/ra-optimisation/rao-api/src/test/resources/config_withoutExtensions.yml
@@ -10,7 +10,7 @@ rao-range-actions-optimization:
     pst-penalty-cost: 0.02
     pst-sensitivity-threshold: 0.2
     pst-model: APPROXIMATED_INTEGERS
-    pst-variation-gradual-decrease: DISABLED
+    pst-range-decrease: DISABLED
     hvdc-penalty-cost: 0.002
     hvdc-sensitivity-threshold: 0.2
     injection-ra-penalty-cost: 0.003

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParameters.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParameters.java
@@ -30,18 +30,18 @@ public final class TreeParameters {
     private final double targetObjectiveValue;
     private final int maximumSearchDepth;
     private final int leavesInParallel;
-    private final boolean decreasePstRange;
+    private final boolean pstRangeShrinking;
 
     public TreeParameters(StopCriterion stopCriterion,
                            double targetObjectiveValue,
                            int maximumSearchDepth,
                            int leavesInParallel,
-                          boolean decreasePstRange) {
+                          boolean pstRangeShrinking) {
         this.stopCriterion = stopCriterion;
         this.targetObjectiveValue = targetObjectiveValue;
         this.maximumSearchDepth = maximumSearchDepth;
         this.leavesInParallel = leavesInParallel;
-        this.decreasePstRange = decreasePstRange;
+        this.pstRangeShrinking = pstRangeShrinking;
     }
 
     public StopCriterion getStopCriterion() {
@@ -60,27 +60,27 @@ public final class TreeParameters {
         return leavesInParallel;
     }
 
-    public boolean getDecreasePstRange() {
-        return decreasePstRange;
+    public boolean getPstRangeShrinking() {
+        return pstRangeShrinking;
     }
 
     public static TreeParameters buildForPreventivePerimeter(RaoParameters parameters) {
-        RangeActionsOptimizationParameters.PstRangeDecrease pstRangeDecrease = parameters.getRangeActionsOptimizationParameters().getPstRangeDecrease();
-        boolean decreasePstRange = pstRangeDecrease.equals(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED_IN_FIRST_PRAO_AND_CRAO) ||
-            pstRangeDecrease.equals(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
+        RangeActionsOptimizationParameters.PstRangeShrinking pstRangeShrinking = parameters.getRangeActionsOptimizationParameters().getPstRangeShrinking();
+        boolean shouldShrinkPstRange = pstRangeShrinking.equals(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED_IN_FIRST_PRAO_AND_CRAO) ||
+            pstRangeShrinking.equals(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED);
         switch (parameters.getObjectiveFunctionParameters().getPreventiveStopCriterion()) {
             case MIN_OBJECTIVE:
                 return new TreeParameters(StopCriterion.MIN_OBJECTIVE,
                     0.0, // value does not matter
                     parameters.getTopoOptimizationParameters().getMaxSearchTreeDepth(),
                     parameters.getMultithreadingParameters().getPreventiveLeavesInParallel(),
-                    decreasePstRange);
+                    shouldShrinkPstRange);
             case SECURE:
                 return new TreeParameters(StopCriterion.AT_TARGET_OBJECTIVE_VALUE,
                     0.0, // secure
                     parameters.getTopoOptimizationParameters().getMaxSearchTreeDepth(),
                     parameters.getMultithreadingParameters().getPreventiveLeavesInParallel(),
-                    decreasePstRange);
+                    shouldShrinkPstRange);
             default:
                 throw new FaraoException("Unknown preventive stop criterion: " + parameters.getObjectiveFunctionParameters().getPreventiveStopCriterion());
         }
@@ -109,31 +109,31 @@ public final class TreeParameters {
             default:
                 throw new FaraoException("Unknown curative stop criterion: " + parameters.getObjectiveFunctionParameters().getCurativeStopCriterion());
         }
-        RangeActionsOptimizationParameters.PstRangeDecrease pstRangeDecrease = parameters.getRangeActionsOptimizationParameters().getPstRangeDecrease();
-        boolean decreasePstRange = pstRangeDecrease.equals(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED_IN_FIRST_PRAO_AND_CRAO) ||
-            pstRangeDecrease.equals(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
+        RangeActionsOptimizationParameters.PstRangeShrinking pstRangeShrinking = parameters.getRangeActionsOptimizationParameters().getPstRangeShrinking();
+        boolean shouldShrinkPstRange = pstRangeShrinking.equals(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED_IN_FIRST_PRAO_AND_CRAO) ||
+            pstRangeShrinking.equals(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED);
         return new TreeParameters(stopCriterion,
             targetObjectiveValue,
                 parameters.getTopoOptimizationParameters().getMaxSearchTreeDepth(),
                 parameters.getMultithreadingParameters().getCurativeLeavesInParallel(),
-            decreasePstRange);
+            shouldShrinkPstRange);
     }
 
     public static TreeParameters buildForSecondPreventivePerimeter(RaoParameters parameters) {
-        boolean decreasePstRange = parameters.getRangeActionsOptimizationParameters().getPstRangeDecrease().equals(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
+        boolean pstRangeShrinking = parameters.getRangeActionsOptimizationParameters().getPstRangeShrinking().equals(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED);
         if (parameters.getObjectiveFunctionParameters().getPreventiveStopCriterion().equals(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE)
             && !parameters.getObjectiveFunctionParameters().getCurativeStopCriterion().equals(ObjectiveFunctionParameters.CurativeStopCriterion.MIN_OBJECTIVE)) {
             return new TreeParameters(StopCriterion.AT_TARGET_OBJECTIVE_VALUE,
                 0.0, // secure
                 parameters.getTopoOptimizationParameters().getMaxSearchTreeDepth(),
                 parameters.getMultithreadingParameters().getPreventiveLeavesInParallel(),
-                decreasePstRange);
+                pstRangeShrinking);
         } else {
             return new TreeParameters(StopCriterion.MIN_OBJECTIVE,
                 0.0, // value does not matter
                 parameters.getTopoOptimizationParameters().getMaxSearchTreeDepth(),
                 parameters.getMultithreadingParameters().getPreventiveLeavesInParallel(),
-                decreasePstRange);
+                pstRangeShrinking);
         }
     }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParameters.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParameters.java
@@ -30,18 +30,18 @@ public final class TreeParameters {
     private final double targetObjectiveValue;
     private final int maximumSearchDepth;
     private final int leavesInParallel;
-    private final boolean pstRangeShrinking;
+    private final boolean raRangeShrinking;
 
     public TreeParameters(StopCriterion stopCriterion,
-                           double targetObjectiveValue,
-                           int maximumSearchDepth,
-                           int leavesInParallel,
-                          boolean pstRangeShrinking) {
+                          double targetObjectiveValue,
+                          int maximumSearchDepth,
+                          int leavesInParallel,
+                          boolean raRangeShrinking) {
         this.stopCriterion = stopCriterion;
         this.targetObjectiveValue = targetObjectiveValue;
         this.maximumSearchDepth = maximumSearchDepth;
         this.leavesInParallel = leavesInParallel;
-        this.pstRangeShrinking = pstRangeShrinking;
+        this.raRangeShrinking = raRangeShrinking;
     }
 
     public StopCriterion getStopCriterion() {
@@ -60,27 +60,27 @@ public final class TreeParameters {
         return leavesInParallel;
     }
 
-    public boolean getPstRangeShrinking() {
-        return pstRangeShrinking;
+    public boolean getRaRangeShrinking() {
+        return raRangeShrinking;
     }
 
     public static TreeParameters buildForPreventivePerimeter(RaoParameters parameters) {
-        RangeActionsOptimizationParameters.PstRangeShrinking pstRangeShrinking = parameters.getRangeActionsOptimizationParameters().getPstRangeShrinking();
-        boolean shouldShrinkPstRange = pstRangeShrinking.equals(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED_IN_FIRST_PRAO_AND_CRAO) ||
-            pstRangeShrinking.equals(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED);
+        RangeActionsOptimizationParameters.RaRangeShrinking raRangeShrinking = parameters.getRangeActionsOptimizationParameters().getRaRangeShrinking();
+        boolean shouldShrinkRaRange = raRangeShrinking.equals(RangeActionsOptimizationParameters.RaRangeShrinking.ENABLED_IN_FIRST_PRAO_AND_CRAO) ||
+            raRangeShrinking.equals(RangeActionsOptimizationParameters.RaRangeShrinking.ENABLED);
         switch (parameters.getObjectiveFunctionParameters().getPreventiveStopCriterion()) {
             case MIN_OBJECTIVE:
                 return new TreeParameters(StopCriterion.MIN_OBJECTIVE,
                     0.0, // value does not matter
                     parameters.getTopoOptimizationParameters().getMaxSearchTreeDepth(),
                     parameters.getMultithreadingParameters().getPreventiveLeavesInParallel(),
-                    shouldShrinkPstRange);
+                    shouldShrinkRaRange);
             case SECURE:
                 return new TreeParameters(StopCriterion.AT_TARGET_OBJECTIVE_VALUE,
                     0.0, // secure
                     parameters.getTopoOptimizationParameters().getMaxSearchTreeDepth(),
                     parameters.getMultithreadingParameters().getPreventiveLeavesInParallel(),
-                    shouldShrinkPstRange);
+                    shouldShrinkRaRange);
             default:
                 throw new FaraoException("Unknown preventive stop criterion: " + parameters.getObjectiveFunctionParameters().getPreventiveStopCriterion());
         }
@@ -109,31 +109,31 @@ public final class TreeParameters {
             default:
                 throw new FaraoException("Unknown curative stop criterion: " + parameters.getObjectiveFunctionParameters().getCurativeStopCriterion());
         }
-        RangeActionsOptimizationParameters.PstRangeShrinking pstRangeShrinking = parameters.getRangeActionsOptimizationParameters().getPstRangeShrinking();
-        boolean shouldShrinkPstRange = pstRangeShrinking.equals(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED_IN_FIRST_PRAO_AND_CRAO) ||
-            pstRangeShrinking.equals(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED);
+        RangeActionsOptimizationParameters.RaRangeShrinking raRangeShrinking = parameters.getRangeActionsOptimizationParameters().getRaRangeShrinking();
+        boolean shouldShrinkRaRange = raRangeShrinking.equals(RangeActionsOptimizationParameters.RaRangeShrinking.ENABLED_IN_FIRST_PRAO_AND_CRAO) ||
+            raRangeShrinking.equals(RangeActionsOptimizationParameters.RaRangeShrinking.ENABLED);
         return new TreeParameters(stopCriterion,
             targetObjectiveValue,
-                parameters.getTopoOptimizationParameters().getMaxSearchTreeDepth(),
-                parameters.getMultithreadingParameters().getCurativeLeavesInParallel(),
-            shouldShrinkPstRange);
+            parameters.getTopoOptimizationParameters().getMaxSearchTreeDepth(),
+            parameters.getMultithreadingParameters().getCurativeLeavesInParallel(),
+            shouldShrinkRaRange);
     }
 
     public static TreeParameters buildForSecondPreventivePerimeter(RaoParameters parameters) {
-        boolean pstRangeShrinking = parameters.getRangeActionsOptimizationParameters().getPstRangeShrinking().equals(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED);
+        boolean raRangeShrinking = parameters.getRangeActionsOptimizationParameters().getRaRangeShrinking().equals(RangeActionsOptimizationParameters.RaRangeShrinking.ENABLED);
         if (parameters.getObjectiveFunctionParameters().getPreventiveStopCriterion().equals(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE)
             && !parameters.getObjectiveFunctionParameters().getCurativeStopCriterion().equals(ObjectiveFunctionParameters.CurativeStopCriterion.MIN_OBJECTIVE)) {
             return new TreeParameters(StopCriterion.AT_TARGET_OBJECTIVE_VALUE,
                 0.0, // secure
                 parameters.getTopoOptimizationParameters().getMaxSearchTreeDepth(),
                 parameters.getMultithreadingParameters().getPreventiveLeavesInParallel(),
-                pstRangeShrinking);
+                raRangeShrinking);
         } else {
             return new TreeParameters(StopCriterion.MIN_OBJECTIVE,
                 0.0, // value does not matter
                 parameters.getTopoOptimizationParameters().getMaxSearchTreeDepth(),
                 parameters.getMultithreadingParameters().getPreventiveLeavesInParallel(),
-                pstRangeShrinking);
+                raRangeShrinking);
         }
     }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParameters.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParameters.java
@@ -118,7 +118,7 @@ public final class TreeParameters {
         } else {
             stopCriterion = StopCriterion.MIN_OBJECTIVE;
         }
-        boolean capPstVariation = parameters.getRangeActionsOptimizationParameters().getPstVariationGradualDecrease().equals(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ALL);
+        boolean capPstVariation = parameters.getRangeActionsOptimizationParameters().getPstVariationGradualDecrease().equals(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ENABLED_FOR_ALL_STATE);
         return new TreeParameters(stopCriterion,
             0.0,
             parameters.getTopoOptimizationParameters().getMaxSearchTreeDepth(),

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParameters.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParameters.java
@@ -71,7 +71,7 @@ public final class TreeParameters {
         } else if (!parameters.getObjectiveFunctionParameters().getPreventiveStopCriterion().equals(ObjectiveFunctionParameters.PreventiveStopCriterion.MIN_OBJECTIVE)) {
             throw new FaraoException("Unknown preventive stop criterion: " + parameters.getObjectiveFunctionParameters().getPreventiveStopCriterion());
         }
-        boolean capPstVariation = !parameters.getRangeActionsOptimizationParameters().getPstVariationGradualDecrease().equals(RangeActionsOptimizationParameters.PstVariationGradualDecrease.DISABLED);
+        boolean capPstVariation = !parameters.getRangeActionsOptimizationParameters().getPstVariationGradualDecrease().equals(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED);
         return new TreeParameters(stopCriterion,
             0.0,
             parameters.getTopoOptimizationParameters().getMaxSearchTreeDepth(),
@@ -102,7 +102,7 @@ public final class TreeParameters {
             default:
                 throw new FaraoException("Unknown curative stop criterion: " + parameters.getObjectiveFunctionParameters().getCurativeStopCriterion());
         }
-        boolean capPstVariation = !parameters.getRangeActionsOptimizationParameters().getPstVariationGradualDecrease().equals(RangeActionsOptimizationParameters.PstVariationGradualDecrease.DISABLED);
+        boolean capPstVariation = !parameters.getRangeActionsOptimizationParameters().getPstVariationGradualDecrease().equals(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED);
         return new TreeParameters(stopCriterion,
             targetObjectiveValue,
                 parameters.getTopoOptimizationParameters().getMaxSearchTreeDepth(),
@@ -118,7 +118,7 @@ public final class TreeParameters {
         } else {
             stopCriterion = StopCriterion.MIN_OBJECTIVE;
         }
-        boolean capPstVariation = parameters.getRangeActionsOptimizationParameters().getPstVariationGradualDecrease().equals(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ENABLED_FOR_ALL_STATE);
+        boolean capPstVariation = parameters.getRangeActionsOptimizationParameters().getPstVariationGradualDecrease().equals(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
         return new TreeParameters(stopCriterion,
             0.0,
             parameters.getTopoOptimizationParameters().getMaxSearchTreeDepth(),

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
@@ -96,7 +96,7 @@ public final class IteratingLinearOptimizer {
             );
             previousResult = currentResult;
 
-            Pair<IteratingLinearOptimizationResultImpl, Boolean> mipShouldStop = updateBestResultAndCheckStopCondition(parameters.getPstRangeShrinking(), linearProblem, input, iteration, currentResult, bestResult);
+            Pair<IteratingLinearOptimizationResultImpl, Boolean> mipShouldStop = updateBestResultAndCheckStopCondition(parameters.getRaRangeShrinking(), linearProblem, input, iteration, currentResult, bestResult);
             if (mipShouldStop.getRight()) {
                 return bestResult;
             } else {
@@ -223,7 +223,7 @@ public final class IteratingLinearOptimizer {
         );
     }
 
-    private static Pair<IteratingLinearOptimizationResultImpl, Boolean> updateBestResultAndCheckStopCondition(boolean pstRangeShrinking, LinearProblem linearProblem, IteratingLinearOptimizerInput input, int iteration, IteratingLinearOptimizationResultImpl currentResult, IteratingLinearOptimizationResultImpl bestResult) {
+    private static Pair<IteratingLinearOptimizationResultImpl, Boolean> updateBestResultAndCheckStopCondition(boolean raRangeShrinking, LinearProblem linearProblem, IteratingLinearOptimizerInput input, int iteration, IteratingLinearOptimizationResultImpl currentResult, IteratingLinearOptimizationResultImpl bestResult) {
         if (currentResult.getCost() < bestResult.getCost()) {
             logBetterResult(iteration, currentResult);
             linearProblem.updateBetweenSensiIteration(currentResult.getBranchResult(), currentResult.getSensitivityResult(), currentResult.getRangeActionActivationResult());
@@ -231,10 +231,10 @@ public final class IteratingLinearOptimizer {
         }
         logWorseResult(iteration, bestResult, currentResult);
         applyRangeActions(bestResult, input);
-        if (pstRangeShrinking) {
+        if (raRangeShrinking) {
             linearProblem.updateBetweenSensiIteration(currentResult.getBranchResult(), currentResult.getSensitivityResult(), currentResult.getRangeActionActivationResult());
         }
-        return Pair.of(bestResult, !pstRangeShrinking);
+        return Pair.of(bestResult, !raRangeShrinking);
     }
 
     private static void logBetterResult(int iteration, ObjectiveFunctionResult currentObjectiveFunctionResult) {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
@@ -99,6 +99,7 @@ public final class IteratingLinearOptimizer {
                 linearProblem.updateBetweenSensiIteration(bestResult.getBranchResult(), bestResult.getSensitivityResult(), bestResult.getRangeActionActivationResult());
             } else {
                 logWorseResult(iteration, bestResult, currentResult);
+                bestResult.setNbOfIteration(iteration);
                 linearProblem.updateBetweenSensiIteration(currentResult.getBranchResult(), currentResult.getSensitivityResult(), currentResult.getRangeActionActivationResult());
             }
         }
@@ -232,7 +233,7 @@ public final class IteratingLinearOptimizer {
 
     private static void logWorseResult(int iteration, ObjectiveFunctionResult bestResult, ObjectiveFunctionResult currentResult) {
         TECHNICAL_LOGS.info(
-                "Iteration {}: linear optimization found a worse result than previous iteration, with a cost increasing from {} to {} (functional: from {} to {})",
+                "Iteration {}: linear optimization found a worse result than best iteration, with a cost increasing from {} to {} (functional: from {} to {})",
                 iteration,
                 formatDouble(bestResult.getCost()),
                 formatDouble(currentResult.getCost()),

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
@@ -55,6 +55,7 @@ public final class IteratingLinearOptimizer {
 
         for (int iteration = 1; iteration <= parameters.getMaxNumberOfIterations(); iteration++) {
             LinearProblemStatus solveStatus = solveLinearProblem(linearProblem, iteration);
+            bestResult.setNbOfIteration(iteration);
             if (solveStatus == LinearProblemStatus.FEASIBLE) {
                 TECHNICAL_LOGS.warn("The solver was interrupted. A feasible solution has been produced.");
             } else if (solveStatus != LinearProblemStatus.OPTIMAL) {
@@ -99,7 +100,6 @@ public final class IteratingLinearOptimizer {
                 linearProblem.updateBetweenSensiIteration(bestResult.getBranchResult(), bestResult.getSensitivityResult(), bestResult.getRangeActionActivationResult());
             } else {
                 logWorseResult(iteration, bestResult, currentResult);
-                bestResult.setNbOfIteration(iteration);
                 linearProblem.updateBetweenSensiIteration(currentResult.getBranchResult(), currentResult.getSensitivityResult(), currentResult.getRangeActionActivationResult());
             }
         }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
@@ -96,11 +96,11 @@ public final class IteratingLinearOptimizer {
             );
             previousResult = currentResult;
 
-            Pair<IteratingLinearOptimizationResultImpl, Boolean> mipShouldStop = updateBestResultAndCheckStopCondition(parameters.getDecreasePstRange(), linearProblem, input, iteration, currentResult, bestResult);
-            if (mipShouldStop.getValue().equals(Boolean.TRUE)) {
+            Pair<IteratingLinearOptimizationResultImpl, Boolean> mipShouldStop = updateBestResultAndCheckStopCondition(parameters.getPstRangeShrinking(), linearProblem, input, iteration, currentResult, bestResult);
+            if (mipShouldStop.getRight()) {
                 return bestResult;
             } else {
-                bestResult = mipShouldStop.getKey();
+                bestResult = mipShouldStop.getLeft();
             }
         }
         bestResult.setStatus(LinearProblemStatus.MAX_ITERATION_REACHED);
@@ -223,7 +223,7 @@ public final class IteratingLinearOptimizer {
         );
     }
 
-    private static Pair<IteratingLinearOptimizationResultImpl, Boolean> updateBestResultAndCheckStopCondition(boolean decreasePstRange, LinearProblem linearProblem, IteratingLinearOptimizerInput input, int iteration, IteratingLinearOptimizationResultImpl currentResult, IteratingLinearOptimizationResultImpl bestResult) {
+    private static Pair<IteratingLinearOptimizationResultImpl, Boolean> updateBestResultAndCheckStopCondition(boolean pstRangeShrinking, LinearProblem linearProblem, IteratingLinearOptimizerInput input, int iteration, IteratingLinearOptimizationResultImpl currentResult, IteratingLinearOptimizationResultImpl bestResult) {
         if (currentResult.getCost() < bestResult.getCost()) {
             logBetterResult(iteration, currentResult);
             linearProblem.updateBetweenSensiIteration(currentResult.getBranchResult(), currentResult.getSensitivityResult(), currentResult.getRangeActionActivationResult());
@@ -231,10 +231,10 @@ public final class IteratingLinearOptimizer {
         }
         logWorseResult(iteration, bestResult, currentResult);
         applyRangeActions(bestResult, input);
-        if (decreasePstRange) {
+        if (pstRangeShrinking) {
             linearProblem.updateBetweenSensiIteration(currentResult.getBranchResult(), currentResult.getSensitivityResult(), currentResult.getRangeActionActivationResult());
         }
-        return Pair.of(bestResult, !decreasePstRange);
+        return Pair.of(bestResult, !pstRangeShrinking);
     }
 
     private static void logBetterResult(int iteration, ObjectiveFunctionResult currentObjectiveFunctionResult) {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
@@ -100,6 +100,7 @@ public final class IteratingLinearOptimizer {
                 linearProblem.updateBetweenSensiIteration(bestResult.getBranchResult(), bestResult.getSensitivityResult(), bestResult.getRangeActionActivationResult());
             } else {
                 logWorseResult(iteration, bestResult, currentResult);
+                applyRangeActions(bestResult, input);
                 linearProblem.updateBetweenSensiIteration(currentResult.getBranchResult(), currentResult.getSensitivityResult(), currentResult.getRangeActionActivationResult());
             }
         }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
@@ -44,6 +44,8 @@ public final class IteratingLinearOptimizer {
                 0,
                 input.getObjectiveFunction());
 
+        IteratingLinearOptimizationResultImpl lastResult = bestResult;
+
         SensitivityComputer sensitivityComputer = null;
 
         LinearProblem linearProblem = LinearProblem.create()
@@ -71,7 +73,7 @@ public final class IteratingLinearOptimizer {
 
             currentRangeActionActivationResult = resolveIfApproximatedPstTaps(bestResult, linearProblem, iteration, currentRangeActionActivationResult, input, parameters);
 
-            if (!hasRemedialActionsChanged(currentRangeActionActivationResult, bestResult, input.getOptimizationPerimeter())) {
+            if (!hasRemedialActionsChanged(currentRangeActionActivationResult, lastResult, input.getOptimizationPerimeter())) {
                 // If the solution has not changed, no need to run a new sensitivity computation and iteration can stop
                 TECHNICAL_LOGS.info("Iteration {}: same results as previous iterations, optimal solution found", iteration);
                 return bestResult;
@@ -90,7 +92,7 @@ public final class IteratingLinearOptimizer {
                     iteration,
                     input.getObjectiveFunction()
             );
-
+            lastResult = currentResult;
             if (currentResult.getCost() <= bestResult.getCost()) {
                 logBetterResult(iteration, currentResult);
                 bestResult = currentResult;

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
@@ -91,15 +91,14 @@ public final class IteratingLinearOptimizer {
                     input.getObjectiveFunction()
             );
 
-            if (currentResult.getCost() >= bestResult.getCost()) {
+            if (currentResult.getCost() <= bestResult.getCost()) {
+                logBetterResult(iteration, currentResult);
+                bestResult = currentResult;
+                linearProblem.updateBetweenSensiIteration(bestResult.getBranchResult(), bestResult.getSensitivityResult(), bestResult.getRangeActionActivationResult());
+            } else {
                 logWorseResult(iteration, bestResult, currentResult);
-                applyRangeActions(bestResult, input);
-                return bestResult;
+                linearProblem.updateBetweenSensiIteration(currentResult.getBranchResult(), currentResult.getSensitivityResult(), currentResult.getRangeActionActivationResult());
             }
-
-            logBetterResult(iteration, currentResult);
-            bestResult = currentResult;
-            linearProblem.updateBetweenSensiIteration(bestResult.getBranchResult(), bestResult.getSensitivityResult(), bestResult.getRangeActionActivationResult());
         }
         bestResult.setStatus(LinearProblemStatus.MAX_ITERATION_REACHED);
         return bestResult;

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
@@ -97,24 +97,19 @@ public final class IteratingLinearOptimizer {
             boolean capPstVariation = parameters.getCapPstVariation();
             if (capPstVariation) {
                 lastResult = currentResult;
-                if (currentResult.getCost() <= bestResult.getCost()) {
-                    logBetterResult(iteration, currentResult);
-                    bestResult = currentResult;
-                    linearProblem.updateBetweenSensiIteration(bestResult.getBranchResult(), bestResult.getSensitivityResult(), bestResult.getRangeActionActivationResult());
-                } else {
-                    logWorseResult(iteration, bestResult, currentResult);
-                    applyRangeActions(bestResult, input);
-                    linearProblem.updateBetweenSensiIteration(currentResult.getBranchResult(), currentResult.getSensitivityResult(), currentResult.getRangeActionActivationResult());
-                }
-            } else {
-                if (currentResult.getCost() >= bestResult.getCost()) {
-                    logWorseResult(iteration, bestResult, currentResult);
-                    applyRangeActions(bestResult, input);
-                    return bestResult;
-                }
+            }
+            if (currentResult.getCost() < bestResult.getCost()) {
                 logBetterResult(iteration, currentResult);
                 bestResult = currentResult;
                 linearProblem.updateBetweenSensiIteration(bestResult.getBranchResult(), bestResult.getSensitivityResult(), bestResult.getRangeActionActivationResult());
+            } else {
+                logWorseResult(iteration, bestResult, currentResult);
+                applyRangeActions(bestResult, input);
+                if (capPstVariation) {
+                    linearProblem.updateBetweenSensiIteration(currentResult.getBranchResult(), currentResult.getSensitivityResult(), currentResult.getRangeActionActivationResult());
+                } else {
+                    return bestResult;
+                }
             }
         }
         bestResult.setStatus(LinearProblemStatus.MAX_ITERATION_REACHED);

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizer.java
@@ -93,15 +93,28 @@ public final class IteratingLinearOptimizer {
                     iteration,
                     input.getObjectiveFunction()
             );
-            lastResult = currentResult;
-            if (currentResult.getCost() <= bestResult.getCost()) {
+
+            boolean capPstVariation = parameters.getCapPstVariation();
+            if (capPstVariation) {
+                lastResult = currentResult;
+                if (currentResult.getCost() <= bestResult.getCost()) {
+                    logBetterResult(iteration, currentResult);
+                    bestResult = currentResult;
+                    linearProblem.updateBetweenSensiIteration(bestResult.getBranchResult(), bestResult.getSensitivityResult(), bestResult.getRangeActionActivationResult());
+                } else {
+                    logWorseResult(iteration, bestResult, currentResult);
+                    applyRangeActions(bestResult, input);
+                    linearProblem.updateBetweenSensiIteration(currentResult.getBranchResult(), currentResult.getSensitivityResult(), currentResult.getRangeActionActivationResult());
+                }
+            } else {
+                if (currentResult.getCost() >= bestResult.getCost()) {
+                    logWorseResult(iteration, bestResult, currentResult);
+                    applyRangeActions(bestResult, input);
+                    return bestResult;
+                }
                 logBetterResult(iteration, currentResult);
                 bestResult = currentResult;
                 linearProblem.updateBetweenSensiIteration(bestResult.getBranchResult(), bestResult.getSensitivityResult(), bestResult.getRangeActionActivationResult());
-            } else {
-                logWorseResult(iteration, bestResult, currentResult);
-                applyRangeActions(bestResult, input);
-                linearProblem.updateBetweenSensiIteration(currentResult.getBranchResult(), currentResult.getSensitivityResult(), currentResult.getRangeActionActivationResult());
             }
         }
         bestResult.setStatus(LinearProblemStatus.MAX_ITERATION_REACHED);

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFiller.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFiller.java
@@ -50,7 +50,7 @@ public class CoreProblemFiller implements ProblemFiller {
     private final RangeActionsOptimizationParameters rangeActionParameters;
     private final Unit unit;
     private int iteration = 0;
-    private static final double RANGE_DECREASE_RATE = 0.667;
+    private static final double RANGE_SHRINK_RATE = 0.667;
 
     public CoreProblemFiller(OptimizationPerimeter optimizationContext,
                              RangeActionSetpointResult prePerimeterRangeActionSetpoints,
@@ -254,8 +254,8 @@ public class CoreProblemFiller implements ProblemFiller {
         List<Double> minAndMaxAbsoluteAndRelativeSetpoints = getMinAndMaxAbsoluteAndRelativeSetpoints(rangeAction);
         double minAbsoluteSetpoint = Math.max(minAndMaxAbsoluteAndRelativeSetpoints.get(0), -LinearProblem.infinity());
         double maxAbsoluteSetpoint = Math.min(minAndMaxAbsoluteAndRelativeSetpoints.get(1), LinearProblem.infinity());
-        double constrainedSetPointRange = (maxAbsoluteSetpoint - minAbsoluteSetpoint) * Math.pow(RANGE_DECREASE_RATE, iteration);
-        FaraoMPConstraint iterativeShrink = linearProblem.getRangeActionRelativeSetpointConstraint(rangeAction, state, LinearProblem.PstRangeShrinking.TRUE);
+        double constrainedSetPointRange = (maxAbsoluteSetpoint - minAbsoluteSetpoint) * Math.pow(RANGE_SHRINK_RATE, iteration);
+        FaraoMPConstraint iterativeShrink = linearProblem.getRangeActionRelativeSetpointConstraint(rangeAction, state, LinearProblem.RaRangeShrinking.TRUE);
         double lb = previousSetPointValue - constrainedSetPointRange;
         double ub = previousSetPointValue + constrainedSetPointRange;
         if (iterativeShrink != null) {
@@ -266,7 +266,7 @@ public class CoreProblemFiller implements ProblemFiller {
             if (setPointVariable == null) {
                 throw new FaraoException(format("Range action variable for %s has not been defined yet.", rangeAction.getId()));
             }
-            iterativeShrink = linearProblem.addRangeActionRelativeSetpointConstraint(lb, ub, rangeAction, state, LinearProblem.PstRangeShrinking.TRUE);
+            iterativeShrink = linearProblem.addRangeActionRelativeSetpointConstraint(lb, ub, rangeAction, state, LinearProblem.RaRangeShrinking.TRUE);
             iterativeShrink.setCoefficient(setPointVariable, 1);
         }
     }
@@ -333,7 +333,7 @@ public class CoreProblemFiller implements ProblemFiller {
             maxAbsoluteSetpoint = Math.min(maxAbsoluteSetpoint, LinearProblem.infinity());
             minRelativeSetpoint = Math.max(minRelativeSetpoint, -LinearProblem.infinity());
             maxRelativeSetpoint = Math.min(maxRelativeSetpoint, LinearProblem.infinity());
-            FaraoMPConstraint relSetpointConstraint = linearProblem.addRangeActionRelativeSetpointConstraint(minRelativeSetpoint, maxRelativeSetpoint, rangeAction, state, LinearProblem.PstRangeShrinking.FALSE);
+            FaraoMPConstraint relSetpointConstraint = linearProblem.addRangeActionRelativeSetpointConstraint(minRelativeSetpoint, maxRelativeSetpoint, rangeAction, state, LinearProblem.RaRangeShrinking.FALSE);
             relSetpointConstraint.setCoefficient(setPointVariable, 1);
             relSetpointConstraint.setCoefficient(previousSetpointVariable, -1);
 

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFiller.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFiller.java
@@ -244,7 +244,7 @@ public class CoreProblemFiller implements ProblemFiller {
     }
 
     private void updateRangeActionConstraints(LinearProblem linearProblem, RangeActionActivationResult rangeActionActivationResult) {
-        iteration += 1;
+        iteration++;
         optimizationContext.getRangeActionsPerState().entrySet().stream()
             .sorted(Comparator.comparingInt(e -> e.getKey().getInstant().getOrder()))
             .forEach(entry ->

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFiller.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFiller.java
@@ -259,17 +259,18 @@ public class CoreProblemFiller implements ProblemFiller {
         double minAbsoluteSetpoint = Math.max(minAndMaxAbsoluteAndRelativeSetpoints.get(0), -LinearProblem.infinity());
         double maxAbsoluteSetpoint = Math.min(minAndMaxAbsoluteAndRelativeSetpoints.get(1), LinearProblem.infinity());
         double setPointRange = Math.abs(minAbsoluteSetpoint) + Math.abs(maxAbsoluteSetpoint);
+        double constrainedSetPointRange = setPointRange * Math.pow(RANGE_DIMINUTION_RATE, iteration);
         FaraoMPConstraint iterativeShrink = linearProblem.getRangeActionRelativeSetpointConstraint(rangeAction, state, "iterative_shrink");
         if (iterativeShrink != null) {
-            iterativeShrink.setLb(previousSetPointValue - setPointRange * Math.pow(RANGE_DIMINUTION_RATE, iteration));
-            iterativeShrink.setUb(previousSetPointValue + setPointRange * Math.pow(RANGE_DIMINUTION_RATE, iteration));
+            iterativeShrink.setLb(previousSetPointValue - constrainedSetPointRange);
+            iterativeShrink.setUb(previousSetPointValue + constrainedSetPointRange);
         } else {
             FaraoMPVariable setPointVariable = linearProblem.getRangeActionSetpointVariable(rangeAction, state);
             if (setPointVariable == null) {
                 throw new FaraoException(format("Range action variable for %s has not been defined yet.", rangeAction.getId()));
             }
-            FaraoMPConstraint newIterativeShrink = linearProblem.addRangeActionRelativeSetpointConstraint(-setPointRange * Math.pow(RANGE_DIMINUTION_RATE, iteration) + previousSetPointValue,
-                setPointRange * Math.pow(RANGE_DIMINUTION_RATE, iteration) + previousSetPointValue, rangeAction, state, "iterative_shrink");
+            FaraoMPConstraint newIterativeShrink = linearProblem.addRangeActionRelativeSetpointConstraint(-constrainedSetPointRange + previousSetPointValue,
+                constrainedSetPointRange + previousSetPointValue, rangeAction, state, "iterative_shrink");
             newIterativeShrink.setCoefficient(setPointVariable, 1);
         }
     }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblem.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblem.java
@@ -58,6 +58,22 @@ public final class LinearProblem {
         UPPER_BOUND
     }
 
+    public enum PstRangeDecrease {
+        TRUE("iterative-shrink"),
+        FALSE("");
+
+        private final String name;
+
+        PstRangeDecrease(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
     public static LinearProblemBuilder create() {
         return new LinearProblemBuilder();
     }
@@ -128,12 +144,12 @@ public final class LinearProblem {
         return solver.getVariable(rangeActionSetpointVariableId(rangeAction, state));
     }
 
-    public FaraoMPConstraint addRangeActionRelativeSetpointConstraint(double lb, double ub, RangeAction<?> rangeAction, State state, String string) {
-        return solver.makeConstraint(lb, ub, rangeActionRelativeSetpointConstraintId(rangeAction, state, string));
+    public FaraoMPConstraint addRangeActionRelativeSetpointConstraint(double lb, double ub, RangeAction<?> rangeAction, State state, PstRangeDecrease pstRangeDecrease) {
+        return solver.makeConstraint(lb, ub, rangeActionRelativeSetpointConstraintId(rangeAction, state, pstRangeDecrease));
     }
 
-    public FaraoMPConstraint getRangeActionRelativeSetpointConstraint(RangeAction<?> rangeAction, State state, String string) {
-        return solver.getConstraint(rangeActionRelativeSetpointConstraintId(rangeAction, state, string));
+    public FaraoMPConstraint getRangeActionRelativeSetpointConstraint(RangeAction<?> rangeAction, State state, PstRangeDecrease pstRangeDecrease) {
+        return solver.getConstraint(rangeActionRelativeSetpointConstraintId(rangeAction, state, pstRangeDecrease));
     }
 
     public FaraoMPVariable addRangeActionVariationBinary(RangeAction<?> rangeAction, State state) {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblem.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblem.java
@@ -58,13 +58,13 @@ public final class LinearProblem {
         UPPER_BOUND
     }
 
-    public enum PstRangeDecrease {
+    public enum PstRangeShrinking {
         TRUE("iterative-shrink"),
         FALSE("");
 
         private final String name;
 
-        PstRangeDecrease(String name) {
+        PstRangeShrinking(String name) {
             this.name = name;
         }
 
@@ -144,12 +144,12 @@ public final class LinearProblem {
         return solver.getVariable(rangeActionSetpointVariableId(rangeAction, state));
     }
 
-    public FaraoMPConstraint addRangeActionRelativeSetpointConstraint(double lb, double ub, RangeAction<?> rangeAction, State state, PstRangeDecrease pstRangeDecrease) {
-        return solver.makeConstraint(lb, ub, rangeActionRelativeSetpointConstraintId(rangeAction, state, pstRangeDecrease));
+    public FaraoMPConstraint addRangeActionRelativeSetpointConstraint(double lb, double ub, RangeAction<?> rangeAction, State state, PstRangeShrinking pstRangeShrinking) {
+        return solver.makeConstraint(lb, ub, rangeActionRelativeSetpointConstraintId(rangeAction, state, pstRangeShrinking));
     }
 
-    public FaraoMPConstraint getRangeActionRelativeSetpointConstraint(RangeAction<?> rangeAction, State state, PstRangeDecrease pstRangeDecrease) {
-        return solver.getConstraint(rangeActionRelativeSetpointConstraintId(rangeAction, state, pstRangeDecrease));
+    public FaraoMPConstraint getRangeActionRelativeSetpointConstraint(RangeAction<?> rangeAction, State state, PstRangeShrinking pstRangeShrinking) {
+        return solver.getConstraint(rangeActionRelativeSetpointConstraintId(rangeAction, state, pstRangeShrinking));
     }
 
     public FaraoMPVariable addRangeActionVariationBinary(RangeAction<?> rangeAction, State state) {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblem.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblem.java
@@ -128,8 +128,12 @@ public final class LinearProblem {
         return solver.getVariable(rangeActionSetpointVariableId(rangeAction, state));
     }
 
-    public FaraoMPConstraint addRangeActionRelativeSetpointConstraint(double lb, double ub, RangeAction<?> rangeAction, State state) {
-        return solver.makeConstraint(lb, ub, rangeActionRelativeSetpointConstraintId(rangeAction, state));
+    public FaraoMPConstraint addRangeActionRelativeSetpointConstraint(double lb, double ub, RangeAction<?> rangeAction, State state, String string) {
+        return solver.makeConstraint(lb, ub, rangeActionRelativeSetpointConstraintId(rangeAction, state, string));
+    }
+
+    public FaraoMPConstraint getRangeActionRelativeSetpointConstraint(RangeAction<?> rangeAction, State state, String string) {
+        return solver.getConstraint(rangeActionRelativeSetpointConstraintId(rangeAction, state, string));
     }
 
     public FaraoMPVariable addRangeActionVariationBinary(RangeAction<?> rangeAction, State state) {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblem.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblem.java
@@ -58,13 +58,13 @@ public final class LinearProblem {
         UPPER_BOUND
     }
 
-    public enum PstRangeShrinking {
+    public enum RaRangeShrinking {
         TRUE("iterative-shrink"),
         FALSE("");
 
         private final String name;
 
-        PstRangeShrinking(String name) {
+        RaRangeShrinking(String name) {
             this.name = name;
         }
 
@@ -144,12 +144,12 @@ public final class LinearProblem {
         return solver.getVariable(rangeActionSetpointVariableId(rangeAction, state));
     }
 
-    public FaraoMPConstraint addRangeActionRelativeSetpointConstraint(double lb, double ub, RangeAction<?> rangeAction, State state, PstRangeShrinking pstRangeShrinking) {
-        return solver.makeConstraint(lb, ub, rangeActionRelativeSetpointConstraintId(rangeAction, state, pstRangeShrinking));
+    public FaraoMPConstraint addRangeActionRelativeSetpointConstraint(double lb, double ub, RangeAction<?> rangeAction, State state, RaRangeShrinking raRangeShrinking) {
+        return solver.makeConstraint(lb, ub, rangeActionRelativeSetpointConstraintId(rangeAction, state, raRangeShrinking));
     }
 
-    public FaraoMPConstraint getRangeActionRelativeSetpointConstraint(RangeAction<?> rangeAction, State state, PstRangeShrinking pstRangeShrinking) {
-        return solver.getConstraint(rangeActionRelativeSetpointConstraintId(rangeAction, state, pstRangeShrinking));
+    public FaraoMPConstraint getRangeActionRelativeSetpointConstraint(RangeAction<?> rangeAction, State state, RaRangeShrinking raRangeShrinking) {
+        return solver.getConstraint(rangeActionRelativeSetpointConstraintId(rangeAction, state, raRangeShrinking));
     }
 
     public FaraoMPVariable addRangeActionVariationBinary(RangeAction<?> rangeAction, State state) {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblemIdGenerator.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblemIdGenerator.java
@@ -60,8 +60,8 @@ public final class LinearProblemIdGenerator {
         return rangeAction.getId() + SEPARATOR + state.getId() + SEPARATOR + SET_POINT + SEPARATOR + VARIABLE_SUFFIX;
     }
 
-    public static String rangeActionRelativeSetpointConstraintId(RangeAction<?> rangeAction, State state) {
-        return rangeAction.getId() + SEPARATOR + state.getId() + SEPARATOR + RELATIVE + SEPARATOR + SET_POINT + SEPARATOR + CONSTRAINT_SUFFIX;
+    public static String rangeActionRelativeSetpointConstraintId(RangeAction<?> rangeAction, State state, String string) {
+        return rangeAction.getId() + SEPARATOR + state.getId() + SEPARATOR + RELATIVE + SEPARATOR + SET_POINT + SEPARATOR + string + CONSTRAINT_SUFFIX;
     }
 
     public static String pstTapVariableVariationId(RangeAction<?> rangeAction, State state, LinearProblem.VariationDirectionExtension upwardOrDownward) {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblemIdGenerator.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblemIdGenerator.java
@@ -60,8 +60,8 @@ public final class LinearProblemIdGenerator {
         return rangeAction.getId() + SEPARATOR + state.getId() + SEPARATOR + SET_POINT + SEPARATOR + VARIABLE_SUFFIX;
     }
 
-    public static String rangeActionRelativeSetpointConstraintId(RangeAction<?> rangeAction, State state, LinearProblem.PstRangeDecrease pstRangeDecrease) {
-        return rangeAction.getId() + SEPARATOR + state.getId() + SEPARATOR + RELATIVE + SEPARATOR + SET_POINT + SEPARATOR + pstRangeDecrease.toString() + CONSTRAINT_SUFFIX;
+    public static String rangeActionRelativeSetpointConstraintId(RangeAction<?> rangeAction, State state, LinearProblem.PstRangeShrinking pstRangeShrinking) {
+        return rangeAction.getId() + SEPARATOR + state.getId() + SEPARATOR + RELATIVE + SEPARATOR + SET_POINT + SEPARATOR + pstRangeShrinking.toString() + CONSTRAINT_SUFFIX;
     }
 
     public static String pstTapVariableVariationId(RangeAction<?> rangeAction, State state, LinearProblem.VariationDirectionExtension upwardOrDownward) {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblemIdGenerator.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblemIdGenerator.java
@@ -60,8 +60,8 @@ public final class LinearProblemIdGenerator {
         return rangeAction.getId() + SEPARATOR + state.getId() + SEPARATOR + SET_POINT + SEPARATOR + VARIABLE_SUFFIX;
     }
 
-    public static String rangeActionRelativeSetpointConstraintId(RangeAction<?> rangeAction, State state, String string) {
-        return rangeAction.getId() + SEPARATOR + state.getId() + SEPARATOR + RELATIVE + SEPARATOR + SET_POINT + SEPARATOR + string + CONSTRAINT_SUFFIX;
+    public static String rangeActionRelativeSetpointConstraintId(RangeAction<?> rangeAction, State state, LinearProblem.PstRangeDecrease pstRangeDecrease) {
+        return rangeAction.getId() + SEPARATOR + state.getId() + SEPARATOR + RELATIVE + SEPARATOR + SET_POINT + SEPARATOR + pstRangeDecrease.toString() + CONSTRAINT_SUFFIX;
     }
 
     public static String pstTapVariableVariationId(RangeAction<?> rangeAction, State state, LinearProblem.VariationDirectionExtension upwardOrDownward) {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblemIdGenerator.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblemIdGenerator.java
@@ -60,8 +60,8 @@ public final class LinearProblemIdGenerator {
         return rangeAction.getId() + SEPARATOR + state.getId() + SEPARATOR + SET_POINT + SEPARATOR + VARIABLE_SUFFIX;
     }
 
-    public static String rangeActionRelativeSetpointConstraintId(RangeAction<?> rangeAction, State state, LinearProblem.PstRangeShrinking pstRangeShrinking) {
-        return rangeAction.getId() + SEPARATOR + state.getId() + SEPARATOR + RELATIVE + SEPARATOR + SET_POINT + SEPARATOR + pstRangeShrinking.toString() + CONSTRAINT_SUFFIX;
+    public static String rangeActionRelativeSetpointConstraintId(RangeAction<?> rangeAction, State state, LinearProblem.RaRangeShrinking raRangeShrinking) {
+        return rangeAction.getId() + SEPARATOR + state.getId() + SEPARATOR + RELATIVE + SEPARATOR + SET_POINT + SEPARATOR + raRangeShrinking.toString() + CONSTRAINT_SUFFIX;
     }
 
     public static String pstTapVariableVariationId(RangeAction<?> rangeAction, State state, LinearProblem.VariationDirectionExtension upwardOrDownward) {

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/parameters/IteratingLinearOptimizerParameters.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/parameters/IteratingLinearOptimizerParameters.java
@@ -32,7 +32,7 @@ public final class IteratingLinearOptimizerParameters {
     private final RangeActionsOptimizationParameters.LinearOptimizationSolver solverParameters;
 
     private final int maxNumberOfIterations;
-    private final boolean pstRangeShrinking;
+    private final boolean raRangeShrinking;
 
     private IteratingLinearOptimizerParameters(ObjectiveFunctionParameters.ObjectiveFunctionType objectiveFunction,
                                                RangeActionsOptimizationParameters rangeActionParameters,
@@ -43,7 +43,7 @@ public final class IteratingLinearOptimizerParameters {
                                                RangeActionLimitationParameters raLimitationParameters,
                                                RangeActionsOptimizationParameters.LinearOptimizationSolver solverParameters,
                                                int maxNumberOfIterations,
-                                               boolean pstRangeShrinking) {
+                                               boolean raRangeShrinking) {
         this.objectiveFunction = objectiveFunction;
         this.rangeActionParameters = rangeActionParameters;
         this.mnecParameters = mnecParameters;
@@ -53,7 +53,7 @@ public final class IteratingLinearOptimizerParameters {
         this.raLimitationParameters = raLimitationParameters;
         this.solverParameters = solverParameters;
         this.maxNumberOfIterations = maxNumberOfIterations;
-        this.pstRangeShrinking = pstRangeShrinking;
+        this.raRangeShrinking = raRangeShrinking;
     }
 
     public ObjectiveFunctionParameters.ObjectiveFunctionType getObjectiveFunction() {
@@ -113,8 +113,8 @@ public final class IteratingLinearOptimizerParameters {
         return maxNumberOfIterations;
     }
 
-    public boolean getPstRangeShrinking() {
-        return pstRangeShrinking;
+    public boolean getRaRangeShrinking() {
+        return raRangeShrinking;
     }
 
     public static LinearOptimizerParametersBuilder create() {
@@ -132,7 +132,7 @@ public final class IteratingLinearOptimizerParameters {
         private RangeActionLimitationParameters raLimitationParameters;
         private RangeActionsOptimizationParameters.LinearOptimizationSolver solverParameters;
         private int maxNumberOfIterations;
-        private boolean pstRangeShrinking;
+        private boolean raRangeShrinking;
 
         public LinearOptimizerParametersBuilder withObjectiveFunction(ObjectiveFunctionParameters.ObjectiveFunctionType objectiveFunction) {
             this.objectiveFunction = objectiveFunction;
@@ -179,8 +179,8 @@ public final class IteratingLinearOptimizerParameters {
             return this;
         }
 
-        public LinearOptimizerParametersBuilder withPstRangeShrinking(boolean pstRangeShrinking) {
-            this.pstRangeShrinking = pstRangeShrinking;
+        public LinearOptimizerParametersBuilder withRaRangeShrinking(boolean raRangeShrinking) {
+            this.raRangeShrinking = raRangeShrinking;
             return this;
         }
 
@@ -199,7 +199,7 @@ public final class IteratingLinearOptimizerParameters {
                 raLimitationParameters,
                 solverParameters,
                 maxNumberOfIterations,
-                pstRangeShrinking);
+                raRangeShrinking);
         }
     }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/parameters/IteratingLinearOptimizerParameters.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/parameters/IteratingLinearOptimizerParameters.java
@@ -32,6 +32,7 @@ public final class IteratingLinearOptimizerParameters {
     private final RangeActionsOptimizationParameters.LinearOptimizationSolver solverParameters;
 
     private final int maxNumberOfIterations;
+    private final boolean capPstVariation;
 
     private IteratingLinearOptimizerParameters(ObjectiveFunctionParameters.ObjectiveFunctionType objectiveFunction,
                                                RangeActionsOptimizationParameters rangeActionParameters,
@@ -41,7 +42,8 @@ public final class IteratingLinearOptimizerParameters {
                                                UnoptimizedCnecParameters unoptimizedCnecParameters,
                                                RangeActionLimitationParameters raLimitationParameters,
                                                RangeActionsOptimizationParameters.LinearOptimizationSolver solverParameters,
-                                               int maxNumberOfIterations) {
+                                               int maxNumberOfIterations,
+                                               boolean capPstVariation) {
         this.objectiveFunction = objectiveFunction;
         this.rangeActionParameters = rangeActionParameters;
         this.mnecParameters = mnecParameters;
@@ -51,6 +53,7 @@ public final class IteratingLinearOptimizerParameters {
         this.raLimitationParameters = raLimitationParameters;
         this.solverParameters = solverParameters;
         this.maxNumberOfIterations = maxNumberOfIterations;
+        this.capPstVariation = capPstVariation;
     }
 
     public ObjectiveFunctionParameters.ObjectiveFunctionType getObjectiveFunction() {
@@ -110,6 +113,10 @@ public final class IteratingLinearOptimizerParameters {
         return maxNumberOfIterations;
     }
 
+    public boolean getCapPstVariation() {
+        return capPstVariation;
+    }
+
     public static LinearOptimizerParametersBuilder create() {
         return new LinearOptimizerParametersBuilder();
     }
@@ -125,6 +132,7 @@ public final class IteratingLinearOptimizerParameters {
         private RangeActionLimitationParameters raLimitationParameters;
         private RangeActionsOptimizationParameters.LinearOptimizationSolver solverParameters;
         private int maxNumberOfIterations;
+        private boolean capPstVariation;
 
         public LinearOptimizerParametersBuilder withObjectiveFunction(ObjectiveFunctionParameters.ObjectiveFunctionType objectiveFunction) {
             this.objectiveFunction = objectiveFunction;
@@ -171,6 +179,11 @@ public final class IteratingLinearOptimizerParameters {
             return this;
         }
 
+        public LinearOptimizerParametersBuilder withCapPstVariation(boolean capPstVariation) {
+            this.capPstVariation = capPstVariation;
+            return this;
+        }
+
         public IteratingLinearOptimizerParameters build() {
             if (objectiveFunction.relativePositiveMargins() && maxMinRelativeMarginParameters == null) {
                 throw new FaraoException("An objective function with relative margins requires parameters on relative margins.");
@@ -185,7 +198,8 @@ public final class IteratingLinearOptimizerParameters {
                 unoptimizedCnecParameters,
                 raLimitationParameters,
                 solverParameters,
-                maxNumberOfIterations);
+                maxNumberOfIterations,
+                capPstVariation);
         }
     }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/parameters/IteratingLinearOptimizerParameters.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/parameters/IteratingLinearOptimizerParameters.java
@@ -32,7 +32,7 @@ public final class IteratingLinearOptimizerParameters {
     private final RangeActionsOptimizationParameters.LinearOptimizationSolver solverParameters;
 
     private final int maxNumberOfIterations;
-    private final boolean capPstVariation;
+    private final boolean decreasePstRange;
 
     private IteratingLinearOptimizerParameters(ObjectiveFunctionParameters.ObjectiveFunctionType objectiveFunction,
                                                RangeActionsOptimizationParameters rangeActionParameters,
@@ -43,7 +43,7 @@ public final class IteratingLinearOptimizerParameters {
                                                RangeActionLimitationParameters raLimitationParameters,
                                                RangeActionsOptimizationParameters.LinearOptimizationSolver solverParameters,
                                                int maxNumberOfIterations,
-                                               boolean capPstVariation) {
+                                               boolean decreasePstRange) {
         this.objectiveFunction = objectiveFunction;
         this.rangeActionParameters = rangeActionParameters;
         this.mnecParameters = mnecParameters;
@@ -53,7 +53,7 @@ public final class IteratingLinearOptimizerParameters {
         this.raLimitationParameters = raLimitationParameters;
         this.solverParameters = solverParameters;
         this.maxNumberOfIterations = maxNumberOfIterations;
-        this.capPstVariation = capPstVariation;
+        this.decreasePstRange = decreasePstRange;
     }
 
     public ObjectiveFunctionParameters.ObjectiveFunctionType getObjectiveFunction() {
@@ -113,8 +113,8 @@ public final class IteratingLinearOptimizerParameters {
         return maxNumberOfIterations;
     }
 
-    public boolean getCapPstVariation() {
-        return capPstVariation;
+    public boolean getDecreasePstRange() {
+        return decreasePstRange;
     }
 
     public static LinearOptimizerParametersBuilder create() {
@@ -132,7 +132,7 @@ public final class IteratingLinearOptimizerParameters {
         private RangeActionLimitationParameters raLimitationParameters;
         private RangeActionsOptimizationParameters.LinearOptimizationSolver solverParameters;
         private int maxNumberOfIterations;
-        private boolean capPstVariation;
+        private boolean decreasePstRange;
 
         public LinearOptimizerParametersBuilder withObjectiveFunction(ObjectiveFunctionParameters.ObjectiveFunctionType objectiveFunction) {
             this.objectiveFunction = objectiveFunction;
@@ -179,8 +179,8 @@ public final class IteratingLinearOptimizerParameters {
             return this;
         }
 
-        public LinearOptimizerParametersBuilder withCapPstVariation(boolean capPstVariation) {
-            this.capPstVariation = capPstVariation;
+        public LinearOptimizerParametersBuilder withPstRangeDecrease(boolean decreasePstRange) {
+            this.decreasePstRange = decreasePstRange;
             return this;
         }
 
@@ -199,7 +199,7 @@ public final class IteratingLinearOptimizerParameters {
                 raLimitationParameters,
                 solverParameters,
                 maxNumberOfIterations,
-                capPstVariation);
+                decreasePstRange);
         }
     }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/parameters/IteratingLinearOptimizerParameters.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/parameters/IteratingLinearOptimizerParameters.java
@@ -32,7 +32,7 @@ public final class IteratingLinearOptimizerParameters {
     private final RangeActionsOptimizationParameters.LinearOptimizationSolver solverParameters;
 
     private final int maxNumberOfIterations;
-    private final boolean decreasePstRange;
+    private final boolean pstRangeShrinking;
 
     private IteratingLinearOptimizerParameters(ObjectiveFunctionParameters.ObjectiveFunctionType objectiveFunction,
                                                RangeActionsOptimizationParameters rangeActionParameters,
@@ -43,7 +43,7 @@ public final class IteratingLinearOptimizerParameters {
                                                RangeActionLimitationParameters raLimitationParameters,
                                                RangeActionsOptimizationParameters.LinearOptimizationSolver solverParameters,
                                                int maxNumberOfIterations,
-                                               boolean decreasePstRange) {
+                                               boolean pstRangeShrinking) {
         this.objectiveFunction = objectiveFunction;
         this.rangeActionParameters = rangeActionParameters;
         this.mnecParameters = mnecParameters;
@@ -53,7 +53,7 @@ public final class IteratingLinearOptimizerParameters {
         this.raLimitationParameters = raLimitationParameters;
         this.solverParameters = solverParameters;
         this.maxNumberOfIterations = maxNumberOfIterations;
-        this.decreasePstRange = decreasePstRange;
+        this.pstRangeShrinking = pstRangeShrinking;
     }
 
     public ObjectiveFunctionParameters.ObjectiveFunctionType getObjectiveFunction() {
@@ -113,8 +113,8 @@ public final class IteratingLinearOptimizerParameters {
         return maxNumberOfIterations;
     }
 
-    public boolean getDecreasePstRange() {
-        return decreasePstRange;
+    public boolean getPstRangeShrinking() {
+        return pstRangeShrinking;
     }
 
     public static LinearOptimizerParametersBuilder create() {
@@ -132,7 +132,7 @@ public final class IteratingLinearOptimizerParameters {
         private RangeActionLimitationParameters raLimitationParameters;
         private RangeActionsOptimizationParameters.LinearOptimizationSolver solverParameters;
         private int maxNumberOfIterations;
-        private boolean decreasePstRange;
+        private boolean pstRangeShrinking;
 
         public LinearOptimizerParametersBuilder withObjectiveFunction(ObjectiveFunctionParameters.ObjectiveFunctionType objectiveFunction) {
             this.objectiveFunction = objectiveFunction;
@@ -179,8 +179,8 @@ public final class IteratingLinearOptimizerParameters {
             return this;
         }
 
-        public LinearOptimizerParametersBuilder withPstRangeDecrease(boolean decreasePstRange) {
-            this.decreasePstRange = decreasePstRange;
+        public LinearOptimizerParametersBuilder withPstRangeShrinking(boolean pstRangeShrinking) {
+            this.pstRangeShrinking = pstRangeShrinking;
             return this;
         }
 
@@ -199,7 +199,7 @@ public final class IteratingLinearOptimizerParameters {
                 raLimitationParameters,
                 solverParameters,
                 maxNumberOfIterations,
-                decreasePstRange);
+                pstRangeShrinking);
         }
     }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/Leaf.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/Leaf.java
@@ -215,7 +215,7 @@ public class Leaf implements OptimizationResult {
                     .withRaLimitationParameters(getRaLimitationParameters(searchTreeInput.getOptimizationPerimeter(), parameters))
                     .withSolverParameters(parameters.getSolverParameters())
                     .withMaxNumberOfIterations(parameters.getMaxNumberOfIterations())
-                    .withPstRangeDecrease(parameters.getTreeParameters().getDecreasePstRange())
+                    .withPstRangeShrinking(parameters.getTreeParameters().getPstRangeShrinking())
                     .build();
 
             postOptimResult = IteratingLinearOptimizer.optimize(linearOptimizerInput, linearOptimizerParameters);

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/Leaf.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/Leaf.java
@@ -215,7 +215,7 @@ public class Leaf implements OptimizationResult {
                     .withRaLimitationParameters(getRaLimitationParameters(searchTreeInput.getOptimizationPerimeter(), parameters))
                     .withSolverParameters(parameters.getSolverParameters())
                     .withMaxNumberOfIterations(parameters.getMaxNumberOfIterations())
-                    .withPstRangeShrinking(parameters.getTreeParameters().getPstRangeShrinking())
+                    .withRaRangeShrinking(parameters.getTreeParameters().getRaRangeShrinking())
                     .build();
 
             postOptimResult = IteratingLinearOptimizer.optimize(linearOptimizerInput, linearOptimizerParameters);

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/Leaf.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/Leaf.java
@@ -215,7 +215,7 @@ public class Leaf implements OptimizationResult {
                     .withRaLimitationParameters(getRaLimitationParameters(searchTreeInput.getOptimizationPerimeter(), parameters))
                     .withSolverParameters(parameters.getSolverParameters())
                     .withMaxNumberOfIterations(parameters.getMaxNumberOfIterations())
-                    .withCapPstVariation(parameters.getTreeParameters().getCapPstVariation())
+                    .withPstRangeDecrease(parameters.getTreeParameters().getDecreasePstRange())
                     .build();
 
             postOptimResult = IteratingLinearOptimizer.optimize(linearOptimizerInput, linearOptimizerParameters);

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/Leaf.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/Leaf.java
@@ -215,6 +215,7 @@ public class Leaf implements OptimizationResult {
                     .withRaLimitationParameters(getRaLimitationParameters(searchTreeInput.getOptimizationPerimeter(), parameters))
                     .withSolverParameters(parameters.getSolverParameters())
                     .withMaxNumberOfIterations(parameters.getMaxNumberOfIterations())
+                    .withCapPstVariation(parameters.getTreeParameters().getCapPstVariation())
                     .build();
 
             postOptimResult = IteratingLinearOptimizer.optimize(linearOptimizerInput, linearOptimizerParameters);

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParametersTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParametersTest.java
@@ -28,7 +28,7 @@ class TreeParametersTest {
         raoParameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(6);
         raoParameters.getMultithreadingParameters().setPreventiveLeavesInParallel(4);
         raoParameters.getMultithreadingParameters().setCurativeLeavesInParallel(2);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED);
     }
 
     @Test
@@ -40,51 +40,51 @@ class TreeParametersTest {
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
         assertEquals(4, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-        assertFalse(treeParameters.getCapPstVariation());
+        assertFalse(treeParameters.getDecreasePstRange());
 
         // test with secure, and different values of the parameters
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);
         raoParameters.getMultithreadingParameters().setPreventiveLeavesInParallel(8);
         raoParameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(15);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED_FOR_FIRST_PREVENTIVE_AND_CURATIVE_ONLY);
+        raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED_IN_FIRST_PRAO_AND_CRAO);
         treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
         assertEquals(0, treeParameters.getTargetObjectiveValue(), DOUBLE_TOLERANCE);
         assertEquals(8, treeParameters.getLeavesInParallel());
         assertEquals(15, treeParameters.getMaximumSearchDepth());
-        assertTrue(treeParameters.getCapPstVariation());
+        assertTrue(treeParameters.getDecreasePstRange());
 
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
         treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters);
-        assertTrue(treeParameters.getCapPstVariation());
+        assertTrue(treeParameters.getDecreasePstRange());
     }
 
     @Test
     void testCurativeMinObjective() {
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.MIN_OBJECTIVE);
         raoParameters.getNotOptimizedCnecsParameters().setDoNotOptimizeCurativeCnecsForTsosWithoutCras(false);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED);
         TreeParameters treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters, 100.0);
 
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
         assertEquals(2, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-        assertFalse(treeParameters.getCapPstVariation());
+        assertFalse(treeParameters.getDecreasePstRange());
     }
 
     @Test
     void testCurativeSecureStopCriterion() {
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.SECURE);
         raoParameters.getMultithreadingParameters().setCurativeLeavesInParallel(16);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED_FOR_FIRST_PREVENTIVE_AND_CURATIVE_ONLY);
+        raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED_IN_FIRST_PRAO_AND_CRAO);
         TreeParameters treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters, 100.0);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
         assertEquals(0., treeParameters.getTargetObjectiveValue(), DOUBLE_TOLERANCE);
         assertEquals(16, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-        assertTrue(treeParameters.getCapPstVariation());
+        assertTrue(treeParameters.getDecreasePstRange());
     }
 
     @Test
@@ -92,14 +92,14 @@ class TreeParametersTest {
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.PREVENTIVE_OBJECTIVE);
         raoParameters.getObjectiveFunctionParameters().setCurativeMinObjImprovement(35);
         raoParameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(0);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
         TreeParameters treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters, 100.0);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
         assertEquals(65, treeParameters.getTargetObjectiveValue(), DOUBLE_TOLERANCE);
         assertEquals(2, treeParameters.getLeavesInParallel());
         assertEquals(0, treeParameters.getMaximumSearchDepth());
-        assertTrue(treeParameters.getCapPstVariation());
+        assertTrue(treeParameters.getDecreasePstRange());
     }
 
     @Test
@@ -134,36 +134,36 @@ class TreeParametersTest {
         // test with min objective
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.MIN_OBJECTIVE);
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.MIN_OBJECTIVE);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED);
         TreeParameters treeParameters = TreeParameters.buildForSecondPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
         assertEquals(4, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-        assertFalse(treeParameters.getCapPstVariation());
+        assertFalse(treeParameters.getDecreasePstRange());
 
         // test with secure
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.SECURE);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED_FOR_FIRST_PREVENTIVE_AND_CURATIVE_ONLY);
+        raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED_IN_FIRST_PRAO_AND_CRAO);
         treeParameters = TreeParameters.buildForSecondPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
         assertEquals(0, treeParameters.getTargetObjectiveValue(), DOUBLE_TOLERANCE);
         assertEquals(4, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-        assertFalse(treeParameters.getCapPstVariation());
+        assertFalse(treeParameters.getDecreasePstRange());
 
         // other combinations
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.MIN_OBJECTIVE);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
         treeParameters = TreeParameters.buildForSecondPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
         assertEquals(4, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-        assertTrue(treeParameters.getCapPstVariation());
+        assertTrue(treeParameters.getDecreasePstRange());
 
         // still another combination
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParametersTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParametersTest.java
@@ -46,7 +46,7 @@ class TreeParametersTest {
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);
         raoParameters.getMultithreadingParameters().setPreventiveLeavesInParallel(8);
         raoParameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(15);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.FIRST_PREV_AND_CURATIVE_ONLY);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ENABLED_FOR_FIRST_PREVENTIVE_AND_CURATIVE);
         treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
@@ -55,7 +55,7 @@ class TreeParametersTest {
         assertEquals(15, treeParameters.getMaximumSearchDepth());
         assertTrue(treeParameters.getCapPstVariation());
 
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ALL);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ENABLED_FOR_ALL_STATE);
         treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters);
         assertTrue(treeParameters.getCapPstVariation());
     }
@@ -77,7 +77,7 @@ class TreeParametersTest {
     void testCurativeSecureStopCriterion() {
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.SECURE);
         raoParameters.getMultithreadingParameters().setCurativeLeavesInParallel(16);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.FIRST_PREV_AND_CURATIVE_ONLY);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ENABLED_FOR_FIRST_PREVENTIVE_AND_CURATIVE);
         TreeParameters treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters, 100.0);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
@@ -92,7 +92,7 @@ class TreeParametersTest {
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.PREVENTIVE_OBJECTIVE);
         raoParameters.getObjectiveFunctionParameters().setCurativeMinObjImprovement(35);
         raoParameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(0);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ALL);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ENABLED_FOR_ALL_STATE);
         TreeParameters treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters, 100.0);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
@@ -145,7 +145,7 @@ class TreeParametersTest {
         // test with secure
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.SECURE);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.FIRST_PREV_AND_CURATIVE_ONLY);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ENABLED_FOR_FIRST_PREVENTIVE_AND_CURATIVE);
         treeParameters = TreeParameters.buildForSecondPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
@@ -157,7 +157,7 @@ class TreeParametersTest {
         // other combinations
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.MIN_OBJECTIVE);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ALL);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ENABLED_FOR_ALL_STATE);
         treeParameters = TreeParameters.buildForSecondPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParametersTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParametersTest.java
@@ -7,6 +7,7 @@
 package com.farao_community.farao.search_tree_rao.commons.parameters;
 
 import com.farao_community.farao.rao_api.parameters.ObjectiveFunctionParameters;
+import com.farao_community.farao.rao_api.parameters.RangeActionsOptimizationParameters;
 import com.farao_community.farao.rao_api.parameters.RaoParameters;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ class TreeParametersTest {
         raoParameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(6);
         raoParameters.getMultithreadingParameters().setPreventiveLeavesInParallel(4);
         raoParameters.getMultithreadingParameters().setCurativeLeavesInParallel(2);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.DISABLED);
     }
 
     @Test
@@ -38,41 +40,51 @@ class TreeParametersTest {
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
         assertEquals(4, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
+        assertFalse(treeParameters.getCapPstVariation());
 
         // test with secure, and different values of the parameters
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);
         raoParameters.getMultithreadingParameters().setPreventiveLeavesInParallel(8);
         raoParameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(15);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.FIRST_PREV_AND_CURATIVE_ONLY);
         treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
         assertEquals(0, treeParameters.getTargetObjectiveValue(), DOUBLE_TOLERANCE);
         assertEquals(8, treeParameters.getLeavesInParallel());
         assertEquals(15, treeParameters.getMaximumSearchDepth());
+        assertTrue(treeParameters.getCapPstVariation());
+
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ALL);
+        treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters);
+        assertTrue(treeParameters.getCapPstVariation());
     }
 
     @Test
     void testCurativeMinObjective() {
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.MIN_OBJECTIVE);
         raoParameters.getNotOptimizedCnecsParameters().setDoNotOptimizeCurativeCnecsForTsosWithoutCras(false);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.DISABLED);
         TreeParameters treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters, 100.0);
 
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
         assertEquals(2, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
+        assertFalse(treeParameters.getCapPstVariation());
     }
 
     @Test
     void testCurativeSecureStopCriterion() {
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.SECURE);
         raoParameters.getMultithreadingParameters().setCurativeLeavesInParallel(16);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.FIRST_PREV_AND_CURATIVE_ONLY);
         TreeParameters treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters, 100.0);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
         assertEquals(0., treeParameters.getTargetObjectiveValue(), DOUBLE_TOLERANCE);
         assertEquals(16, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-
+        assertTrue(treeParameters.getCapPstVariation());
     }
 
     @Test
@@ -80,12 +92,14 @@ class TreeParametersTest {
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.PREVENTIVE_OBJECTIVE);
         raoParameters.getObjectiveFunctionParameters().setCurativeMinObjImprovement(35);
         raoParameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(0);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ALL);
         TreeParameters treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters, 100.0);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
         assertEquals(65, treeParameters.getTargetObjectiveValue(), DOUBLE_TOLERANCE);
         assertEquals(2, treeParameters.getLeavesInParallel());
         assertEquals(0, treeParameters.getMaximumSearchDepth());
+        assertTrue(treeParameters.getCapPstVariation());
     }
 
     @Test
@@ -120,30 +134,36 @@ class TreeParametersTest {
         // test with min objective
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.MIN_OBJECTIVE);
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.MIN_OBJECTIVE);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.DISABLED);
         TreeParameters treeParameters = TreeParameters.buildForSecondPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
         assertEquals(4, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
+        assertFalse(treeParameters.getCapPstVariation());
 
         // test with secure
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.SECURE);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.FIRST_PREV_AND_CURATIVE_ONLY);
         treeParameters = TreeParameters.buildForSecondPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
         assertEquals(0, treeParameters.getTargetObjectiveValue(), DOUBLE_TOLERANCE);
         assertEquals(4, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
+        assertFalse(treeParameters.getCapPstVariation());
 
         // other combinations
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.MIN_OBJECTIVE);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ALL);
         treeParameters = TreeParameters.buildForSecondPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
         assertEquals(4, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
+        assertTrue(treeParameters.getCapPstVariation());
 
         // still another combination
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParametersTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParametersTest.java
@@ -28,7 +28,7 @@ class TreeParametersTest {
         raoParameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(6);
         raoParameters.getMultithreadingParameters().setPreventiveLeavesInParallel(4);
         raoParameters.getMultithreadingParameters().setCurativeLeavesInParallel(2);
-        raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.DISABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setRaRangeShrinking(RangeActionsOptimizationParameters.RaRangeShrinking.DISABLED);
     }
 
     @Test
@@ -40,51 +40,51 @@ class TreeParametersTest {
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
         assertEquals(4, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-        assertFalse(treeParameters.getPstRangeShrinking());
+        assertFalse(treeParameters.getRaRangeShrinking());
 
         // test with secure, and different values of the parameters
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);
         raoParameters.getMultithreadingParameters().setPreventiveLeavesInParallel(8);
         raoParameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(15);
-        raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED_IN_FIRST_PRAO_AND_CRAO);
+        raoParameters.getRangeActionsOptimizationParameters().setRaRangeShrinking(RangeActionsOptimizationParameters.RaRangeShrinking.ENABLED_IN_FIRST_PRAO_AND_CRAO);
         treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
         assertEquals(0, treeParameters.getTargetObjectiveValue(), DOUBLE_TOLERANCE);
         assertEquals(8, treeParameters.getLeavesInParallel());
         assertEquals(15, treeParameters.getMaximumSearchDepth());
-        assertTrue(treeParameters.getPstRangeShrinking());
+        assertTrue(treeParameters.getRaRangeShrinking());
 
-        raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setRaRangeShrinking(RangeActionsOptimizationParameters.RaRangeShrinking.ENABLED);
         treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters);
-        assertTrue(treeParameters.getPstRangeShrinking());
+        assertTrue(treeParameters.getRaRangeShrinking());
     }
 
     @Test
     void testCurativeMinObjective() {
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.MIN_OBJECTIVE);
         raoParameters.getNotOptimizedCnecsParameters().setDoNotOptimizeCurativeCnecsForTsosWithoutCras(false);
-        raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.DISABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setRaRangeShrinking(RangeActionsOptimizationParameters.RaRangeShrinking.DISABLED);
         TreeParameters treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters, 100.0);
 
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
         assertEquals(2, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-        assertFalse(treeParameters.getPstRangeShrinking());
+        assertFalse(treeParameters.getRaRangeShrinking());
     }
 
     @Test
     void testCurativeSecureStopCriterion() {
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.SECURE);
         raoParameters.getMultithreadingParameters().setCurativeLeavesInParallel(16);
-        raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED_IN_FIRST_PRAO_AND_CRAO);
+        raoParameters.getRangeActionsOptimizationParameters().setRaRangeShrinking(RangeActionsOptimizationParameters.RaRangeShrinking.ENABLED_IN_FIRST_PRAO_AND_CRAO);
         TreeParameters treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters, 100.0);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
         assertEquals(0., treeParameters.getTargetObjectiveValue(), DOUBLE_TOLERANCE);
         assertEquals(16, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-        assertTrue(treeParameters.getPstRangeShrinking());
+        assertTrue(treeParameters.getRaRangeShrinking());
     }
 
     @Test
@@ -92,14 +92,14 @@ class TreeParametersTest {
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.PREVENTIVE_OBJECTIVE);
         raoParameters.getObjectiveFunctionParameters().setCurativeMinObjImprovement(35);
         raoParameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(0);
-        raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setRaRangeShrinking(RangeActionsOptimizationParameters.RaRangeShrinking.ENABLED);
         TreeParameters treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters, 100.0);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
         assertEquals(65, treeParameters.getTargetObjectiveValue(), DOUBLE_TOLERANCE);
         assertEquals(2, treeParameters.getLeavesInParallel());
         assertEquals(0, treeParameters.getMaximumSearchDepth());
-        assertTrue(treeParameters.getPstRangeShrinking());
+        assertTrue(treeParameters.getRaRangeShrinking());
     }
 
     @Test
@@ -134,36 +134,36 @@ class TreeParametersTest {
         // test with min objective
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.MIN_OBJECTIVE);
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.MIN_OBJECTIVE);
-        raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.DISABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setRaRangeShrinking(RangeActionsOptimizationParameters.RaRangeShrinking.DISABLED);
         TreeParameters treeParameters = TreeParameters.buildForSecondPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
         assertEquals(4, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-        assertFalse(treeParameters.getPstRangeShrinking());
+        assertFalse(treeParameters.getRaRangeShrinking());
 
         // test with secure
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.SECURE);
-        raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED_IN_FIRST_PRAO_AND_CRAO);
+        raoParameters.getRangeActionsOptimizationParameters().setRaRangeShrinking(RangeActionsOptimizationParameters.RaRangeShrinking.ENABLED_IN_FIRST_PRAO_AND_CRAO);
         treeParameters = TreeParameters.buildForSecondPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
         assertEquals(0, treeParameters.getTargetObjectiveValue(), DOUBLE_TOLERANCE);
         assertEquals(4, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-        assertFalse(treeParameters.getPstRangeShrinking());
+        assertFalse(treeParameters.getRaRangeShrinking());
 
         // other combinations
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.MIN_OBJECTIVE);
-        raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setRaRangeShrinking(RangeActionsOptimizationParameters.RaRangeShrinking.ENABLED);
         treeParameters = TreeParameters.buildForSecondPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
         assertEquals(4, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-        assertTrue(treeParameters.getPstRangeShrinking());
+        assertTrue(treeParameters.getRaRangeShrinking());
 
         // still another combination
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParametersTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParametersTest.java
@@ -28,7 +28,7 @@ class TreeParametersTest {
         raoParameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(6);
         raoParameters.getMultithreadingParameters().setPreventiveLeavesInParallel(4);
         raoParameters.getMultithreadingParameters().setCurativeLeavesInParallel(2);
-        raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.DISABLED);
     }
 
     @Test
@@ -40,51 +40,51 @@ class TreeParametersTest {
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
         assertEquals(4, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-        assertFalse(treeParameters.getDecreasePstRange());
+        assertFalse(treeParameters.getPstRangeShrinking());
 
         // test with secure, and different values of the parameters
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);
         raoParameters.getMultithreadingParameters().setPreventiveLeavesInParallel(8);
         raoParameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(15);
-        raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED_IN_FIRST_PRAO_AND_CRAO);
+        raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED_IN_FIRST_PRAO_AND_CRAO);
         treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
         assertEquals(0, treeParameters.getTargetObjectiveValue(), DOUBLE_TOLERANCE);
         assertEquals(8, treeParameters.getLeavesInParallel());
         assertEquals(15, treeParameters.getMaximumSearchDepth());
-        assertTrue(treeParameters.getDecreasePstRange());
+        assertTrue(treeParameters.getPstRangeShrinking());
 
-        raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED);
         treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters);
-        assertTrue(treeParameters.getDecreasePstRange());
+        assertTrue(treeParameters.getPstRangeShrinking());
     }
 
     @Test
     void testCurativeMinObjective() {
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.MIN_OBJECTIVE);
         raoParameters.getNotOptimizedCnecsParameters().setDoNotOptimizeCurativeCnecsForTsosWithoutCras(false);
-        raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.DISABLED);
         TreeParameters treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters, 100.0);
 
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
         assertEquals(2, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-        assertFalse(treeParameters.getDecreasePstRange());
+        assertFalse(treeParameters.getPstRangeShrinking());
     }
 
     @Test
     void testCurativeSecureStopCriterion() {
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.SECURE);
         raoParameters.getMultithreadingParameters().setCurativeLeavesInParallel(16);
-        raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED_IN_FIRST_PRAO_AND_CRAO);
+        raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED_IN_FIRST_PRAO_AND_CRAO);
         TreeParameters treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters, 100.0);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
         assertEquals(0., treeParameters.getTargetObjectiveValue(), DOUBLE_TOLERANCE);
         assertEquals(16, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-        assertTrue(treeParameters.getDecreasePstRange());
+        assertTrue(treeParameters.getPstRangeShrinking());
     }
 
     @Test
@@ -92,14 +92,14 @@ class TreeParametersTest {
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.PREVENTIVE_OBJECTIVE);
         raoParameters.getObjectiveFunctionParameters().setCurativeMinObjImprovement(35);
         raoParameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(0);
-        raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED);
         TreeParameters treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters, 100.0);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
         assertEquals(65, treeParameters.getTargetObjectiveValue(), DOUBLE_TOLERANCE);
         assertEquals(2, treeParameters.getLeavesInParallel());
         assertEquals(0, treeParameters.getMaximumSearchDepth());
-        assertTrue(treeParameters.getDecreasePstRange());
+        assertTrue(treeParameters.getPstRangeShrinking());
     }
 
     @Test
@@ -134,36 +134,36 @@ class TreeParametersTest {
         // test with min objective
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.MIN_OBJECTIVE);
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.MIN_OBJECTIVE);
-        raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.DISABLED);
         TreeParameters treeParameters = TreeParameters.buildForSecondPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
         assertEquals(4, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-        assertFalse(treeParameters.getDecreasePstRange());
+        assertFalse(treeParameters.getPstRangeShrinking());
 
         // test with secure
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.SECURE);
-        raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED_IN_FIRST_PRAO_AND_CRAO);
+        raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED_IN_FIRST_PRAO_AND_CRAO);
         treeParameters = TreeParameters.buildForSecondPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
         assertEquals(0, treeParameters.getTargetObjectiveValue(), DOUBLE_TOLERANCE);
         assertEquals(4, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-        assertFalse(treeParameters.getDecreasePstRange());
+        assertFalse(treeParameters.getPstRangeShrinking());
 
         // other combinations
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.MIN_OBJECTIVE);
-        raoParameters.getRangeActionsOptimizationParameters().setPstRangeDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setPstRangeShrinking(RangeActionsOptimizationParameters.PstRangeShrinking.ENABLED);
         treeParameters = TreeParameters.buildForSecondPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
         assertEquals(4, treeParameters.getLeavesInParallel());
         assertEquals(6, treeParameters.getMaximumSearchDepth());
-        assertTrue(treeParameters.getDecreasePstRange());
+        assertTrue(treeParameters.getPstRangeShrinking());
 
         // still another combination
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParametersTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/commons/parameters/TreeParametersTest.java
@@ -28,7 +28,7 @@ class TreeParametersTest {
         raoParameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(6);
         raoParameters.getMultithreadingParameters().setPreventiveLeavesInParallel(4);
         raoParameters.getMultithreadingParameters().setCurativeLeavesInParallel(2);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.DISABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED);
     }
 
     @Test
@@ -46,7 +46,7 @@ class TreeParametersTest {
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);
         raoParameters.getMultithreadingParameters().setPreventiveLeavesInParallel(8);
         raoParameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(15);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ENABLED_FOR_FIRST_PREVENTIVE_AND_CURATIVE);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED_FOR_FIRST_PREVENTIVE_AND_CURATIVE_ONLY);
         treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
@@ -55,7 +55,7 @@ class TreeParametersTest {
         assertEquals(15, treeParameters.getMaximumSearchDepth());
         assertTrue(treeParameters.getCapPstVariation());
 
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ENABLED_FOR_ALL_STATE);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
         treeParameters = TreeParameters.buildForPreventivePerimeter(raoParameters);
         assertTrue(treeParameters.getCapPstVariation());
     }
@@ -64,7 +64,7 @@ class TreeParametersTest {
     void testCurativeMinObjective() {
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.MIN_OBJECTIVE);
         raoParameters.getNotOptimizedCnecsParameters().setDoNotOptimizeCurativeCnecsForTsosWithoutCras(false);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.DISABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED);
         TreeParameters treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters, 100.0);
 
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
@@ -77,7 +77,7 @@ class TreeParametersTest {
     void testCurativeSecureStopCriterion() {
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.SECURE);
         raoParameters.getMultithreadingParameters().setCurativeLeavesInParallel(16);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ENABLED_FOR_FIRST_PREVENTIVE_AND_CURATIVE);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED_FOR_FIRST_PREVENTIVE_AND_CURATIVE_ONLY);
         TreeParameters treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters, 100.0);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
@@ -92,7 +92,7 @@ class TreeParametersTest {
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.PREVENTIVE_OBJECTIVE);
         raoParameters.getObjectiveFunctionParameters().setCurativeMinObjImprovement(35);
         raoParameters.getTopoOptimizationParameters().setMaxSearchTreeDepth(0);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ENABLED_FOR_ALL_STATE);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
         TreeParameters treeParameters = TreeParameters.buildForCurativePerimeter(raoParameters, 100.0);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
@@ -134,7 +134,7 @@ class TreeParametersTest {
         // test with min objective
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.MIN_OBJECTIVE);
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.MIN_OBJECTIVE);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.DISABLED);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.DISABLED);
         TreeParameters treeParameters = TreeParameters.buildForSecondPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());
@@ -145,7 +145,7 @@ class TreeParametersTest {
         // test with secure
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.SECURE);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ENABLED_FOR_FIRST_PREVENTIVE_AND_CURATIVE);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED_FOR_FIRST_PREVENTIVE_AND_CURATIVE_ONLY);
         treeParameters = TreeParameters.buildForSecondPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.AT_TARGET_OBJECTIVE_VALUE, treeParameters.getStopCriterion());
@@ -157,7 +157,7 @@ class TreeParametersTest {
         // other combinations
         raoParameters.getObjectiveFunctionParameters().setPreventiveStopCriterion(ObjectiveFunctionParameters.PreventiveStopCriterion.SECURE);
         raoParameters.getObjectiveFunctionParameters().setCurativeStopCriterion(ObjectiveFunctionParameters.CurativeStopCriterion.MIN_OBJECTIVE);
-        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstVariationGradualDecrease.ENABLED_FOR_ALL_STATE);
+        raoParameters.getRangeActionsOptimizationParameters().setPstVariationGradualDecrease(RangeActionsOptimizationParameters.PstRangeDecrease.ENABLED);
         treeParameters = TreeParameters.buildForSecondPreventivePerimeter(raoParameters);
 
         assertEquals(TreeParameters.StopCriterion.MIN_OBJECTIVE, treeParameters.getStopCriterion());

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizerTest.java
@@ -99,7 +99,7 @@ class IteratingLinearOptimizerTest {
         when(rangeActionParameters.getPstModel()).thenReturn(RangeActionsOptimizationParameters.PstModel.CONTINUOUS);
         when(parameters.getRangeActionParameters()).thenReturn(rangeActionParameters);
         when(parameters.getObjectiveFunction()).thenReturn(ObjectiveFunctionParameters.ObjectiveFunctionType.MAX_MIN_MARGIN_IN_MEGAWATT);
-        when(parameters.getCapPstVariation()).thenReturn(false);
+        when(parameters.getDecreasePstRange()).thenReturn(false);
 
         linearProblem = Mockito.mock(LinearProblem.class);
         network = Mockito.mock(Network.class);
@@ -217,7 +217,7 @@ class IteratingLinearOptimizerTest {
 
     @Test
     void linearProblemDegradesTheSolutionButKeepsBestIteration() {
-        when(parameters.getCapPstVariation()).thenReturn(true);
+        when(parameters.getDecreasePstRange()).thenReturn(true);
         mockLinearProblem(Collections.nCopies(5, LinearProblemStatus.OPTIMAL), List.of(1., 2., 3., 4., 5.));
         mockFunctionalCost(100., 150., 140., 130., 120., 110.);
         prepareLinearProblemBuilder();
@@ -246,7 +246,7 @@ class IteratingLinearOptimizerTest {
 
     @Test
     void linearProblemFluctuatesButKeepsBestIteration() {
-        when(parameters.getCapPstVariation()).thenReturn(true);
+        when(parameters.getDecreasePstRange()).thenReturn(true);
         mockLinearProblem(Collections.nCopies(5, LinearProblemStatus.OPTIMAL), List.of(1., 2., 3., 4., 5.));
         mockFunctionalCost(100., 120., 105., 90., 100., 95.);
         prepareLinearProblemBuilder();
@@ -307,7 +307,7 @@ class IteratingLinearOptimizerTest {
 
     @Test
     void testUnapplyRangeAction() {
-        when(parameters.getCapPstVariation()).thenReturn(true);
+        when(parameters.getDecreasePstRange()).thenReturn(true);
         network = NetworkImportsUtil.import12NodesNetwork();
         when(input.getNetwork()).thenReturn(network);
         mockLinearProblem(Collections.nCopies(5, LinearProblemStatus.OPTIMAL), List.of(1., 2., 3., 4., 5.));

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizerTest.java
@@ -292,7 +292,7 @@ class IteratingLinearOptimizerTest {
     void testUnapplyRangeAction() {
         network = NetworkImportsUtil.import12NodesNetwork();
         when(input.getNetwork()).thenReturn(network);
-        mockLinearProblem(Collections.nCopies(5, LinearProblemStatus.OPTIMAL), List.of(1., 2., 3., 4., 4.4));
+        mockLinearProblem(Collections.nCopies(5, LinearProblemStatus.OPTIMAL), List.of(1., 2., 3., 4., 5.));
         mockFunctionalCost(100., 120., 105., 90., 100., 95.);
         Crac crac = CracFactory.findDefault().create("test-crac");
         rangeAction = crac.newPstRangeAction().withId("test-pst").withNetworkElement("BBE2AA1  BBE3AA1  1")
@@ -309,8 +309,6 @@ class IteratingLinearOptimizerTest {
         prepareLinearProblemBuilder();
 
         IteratingLinearOptimizer.optimize(input, parameters);
-        // assertEquals(3, network.getTwoWindingsTransformer("BBE2AA1  BBE3AA1  1").getPhaseTapChanger().getTapPosition());
-        // TODO Should be 3 but isn't ... It's always the last value line 295
-        // TODO Ask someone in the team, I don't get it (probably Peter because he wrote this part of the code)
+        assertEquals(3, network.getTwoWindingsTransformer("BBE2AA1  BBE3AA1  1").getPhaseTapChanger().getTapPosition());
     }
 }

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizerTest.java
@@ -292,8 +292,8 @@ class IteratingLinearOptimizerTest {
     void testUnapplyRangeAction() {
         network = NetworkImportsUtil.import12NodesNetwork();
         when(input.getNetwork()).thenReturn(network);
-        mockLinearProblem(List.of(LinearProblemStatus.OPTIMAL, LinearProblemStatus.OPTIMAL), List.of(1., 2.));
-        mockFunctionalCost(100., 90., 100.);
+        mockLinearProblem(Collections.nCopies(5, LinearProblemStatus.OPTIMAL), List.of(1., 2., 3., 4., 4.4));
+        mockFunctionalCost(100., 120., 105., 90., 100., 95.);
         Crac crac = CracFactory.findDefault().create("test-crac");
         rangeAction = crac.newPstRangeAction().withId("test-pst").withNetworkElement("BBE2AA1  BBE3AA1  1")
                 .withInitialTap(0)
@@ -306,16 +306,11 @@ class IteratingLinearOptimizerTest {
         when(input.getPrePerimeterSetpoints()).thenReturn(rangeActionSetpointResult);
         rangeActionActivationResult = new RangeActionActivationResultImpl(rangeActionSetpointResult);
         when(input.getRaActivationFromParentLeaf()).thenReturn(rangeActionActivationResult);
-        MPVariableMock absVariationMpVarMock = Mockito.mock(MPVariableMock.class);
-        when(absVariationMpVarMock.solutionValue()).thenReturn(1.);
-        when(linearProblem.getAbsoluteRangeActionVariationVariable(rangeAction, optimizedState)).thenReturn(absVariationMpVarMock);
-        MPVariableMock setpointMpVarMock = Mockito.mock(MPVariableMock.class);
-        when(setpointMpVarMock.solutionValue()).thenReturn(1.);
-        when(linearProblem.getRangeActionSetpointVariable(rangeAction, optimizedState)).thenReturn(setpointMpVarMock);
-        network.getTwoWindingsTransformer("BBE2AA1  BBE3AA1  1").getPhaseTapChanger().setTapPosition(5);
         prepareLinearProblemBuilder();
 
-        LinearOptimizationResult result = IteratingLinearOptimizer.optimize(input, parameters);
-        assertEquals(1, network.getTwoWindingsTransformer("BBE2AA1  BBE3AA1  1").getPhaseTapChanger().getTapPosition());
+        IteratingLinearOptimizer.optimize(input, parameters);
+        // assertEquals(3, network.getTwoWindingsTransformer("BBE2AA1  BBE3AA1  1").getPhaseTapChanger().getTapPosition());
+        // TODO Should be 3 but isn't ... It's always the last value line 295
+        // TODO Ask someone in the team, I don't get it (probably Peter because he wrote this part of the code)
     }
 }

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizerTest.java
@@ -99,7 +99,7 @@ class IteratingLinearOptimizerTest {
         when(rangeActionParameters.getPstModel()).thenReturn(RangeActionsOptimizationParameters.PstModel.CONTINUOUS);
         when(parameters.getRangeActionParameters()).thenReturn(rangeActionParameters);
         when(parameters.getObjectiveFunction()).thenReturn(ObjectiveFunctionParameters.ObjectiveFunctionType.MAX_MIN_MARGIN_IN_MEGAWATT);
-        when(parameters.getPstRangeShrinking()).thenReturn(false);
+        when(parameters.getRaRangeShrinking()).thenReturn(false);
 
         linearProblem = Mockito.mock(LinearProblem.class);
         network = Mockito.mock(Network.class);
@@ -217,7 +217,7 @@ class IteratingLinearOptimizerTest {
 
     @Test
     void linearProblemDegradesTheSolutionButKeepsBestIteration() {
-        when(parameters.getPstRangeShrinking()).thenReturn(true);
+        when(parameters.getRaRangeShrinking()).thenReturn(true);
         mockLinearProblem(Collections.nCopies(5, LinearProblemStatus.OPTIMAL), List.of(1., 2., 3., 4., 5.));
         mockFunctionalCost(100., 150., 140., 130., 120., 110.);
         prepareLinearProblemBuilder();
@@ -246,7 +246,7 @@ class IteratingLinearOptimizerTest {
 
     @Test
     void linearProblemFluctuatesButKeepsBestIteration() {
-        when(parameters.getPstRangeShrinking()).thenReturn(true);
+        when(parameters.getRaRangeShrinking()).thenReturn(true);
         mockLinearProblem(Collections.nCopies(5, LinearProblemStatus.OPTIMAL), List.of(1., 2., 3., 4., 5.));
         mockFunctionalCost(100., 120., 105., 90., 100., 95.);
         prepareLinearProblemBuilder();
@@ -307,7 +307,7 @@ class IteratingLinearOptimizerTest {
 
     @Test
     void testUnapplyRangeAction() {
-        when(parameters.getPstRangeShrinking()).thenReturn(true);
+        when(parameters.getRaRangeShrinking()).thenReturn(true);
         network = NetworkImportsUtil.import12NodesNetwork();
         when(input.getNetwork()).thenReturn(network);
         mockLinearProblem(Collections.nCopies(5, LinearProblemStatus.OPTIMAL), List.of(1., 2., 3., 4., 5.));

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/IteratingLinearOptimizerTest.java
@@ -99,7 +99,7 @@ class IteratingLinearOptimizerTest {
         when(rangeActionParameters.getPstModel()).thenReturn(RangeActionsOptimizationParameters.PstModel.CONTINUOUS);
         when(parameters.getRangeActionParameters()).thenReturn(rangeActionParameters);
         when(parameters.getObjectiveFunction()).thenReturn(ObjectiveFunctionParameters.ObjectiveFunctionType.MAX_MIN_MARGIN_IN_MEGAWATT);
-        when(parameters.getDecreasePstRange()).thenReturn(false);
+        when(parameters.getPstRangeShrinking()).thenReturn(false);
 
         linearProblem = Mockito.mock(LinearProblem.class);
         network = Mockito.mock(Network.class);
@@ -217,7 +217,7 @@ class IteratingLinearOptimizerTest {
 
     @Test
     void linearProblemDegradesTheSolutionButKeepsBestIteration() {
-        when(parameters.getDecreasePstRange()).thenReturn(true);
+        when(parameters.getPstRangeShrinking()).thenReturn(true);
         mockLinearProblem(Collections.nCopies(5, LinearProblemStatus.OPTIMAL), List.of(1., 2., 3., 4., 5.));
         mockFunctionalCost(100., 150., 140., 130., 120., 110.);
         prepareLinearProblemBuilder();
@@ -246,7 +246,7 @@ class IteratingLinearOptimizerTest {
 
     @Test
     void linearProblemFluctuatesButKeepsBestIteration() {
-        when(parameters.getDecreasePstRange()).thenReturn(true);
+        when(parameters.getPstRangeShrinking()).thenReturn(true);
         mockLinearProblem(Collections.nCopies(5, LinearProblemStatus.OPTIMAL), List.of(1., 2., 3., 4., 5.));
         mockFunctionalCost(100., 120., 105., 90., 100., 95.);
         prepareLinearProblemBuilder();
@@ -307,7 +307,7 @@ class IteratingLinearOptimizerTest {
 
     @Test
     void testUnapplyRangeAction() {
-        when(parameters.getDecreasePstRange()).thenReturn(true);
+        when(parameters.getPstRangeShrinking()).thenReturn(true);
         network = NetworkImportsUtil.import12NodesNetwork();
         when(input.getNetwork()).thenReturn(network);
         mockLinearProblem(Collections.nCopies(5, LinearProblemStatus.OPTIMAL), List.of(1., 2., 3., 4., 5.));

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFillerTest.java
@@ -11,7 +11,6 @@ import com.farao_community.farao.commons.Unit;
 import com.farao_community.farao.data.crac_api.State;
 import com.farao_community.farao.data.crac_api.cnec.FlowCnec;
 import com.farao_community.farao.data.crac_api.cnec.Side;
-import com.farao_community.farao.data.crac_api.range_action.PstRangeAction;
 import com.farao_community.farao.data.crac_api.range_action.RangeAction;
 import com.farao_community.farao.rao_api.parameters.RangeActionsOptimizationParameters;
 import com.farao_community.farao.rao_api.parameters.RaoParameters;
@@ -400,7 +399,7 @@ class CoreProblemFillerTest extends AbstractFillerTest {
         updateLinearProblem();
 
         // some additional data
-        final double currentAlpha = ((PstRangeAction) pstRangeAction).convertTapToAngle(network.getTwoWindingsTransformer(RANGE_ACTION_ELEMENT_ID).getPhaseTapChanger().getTapPosition());
+        final double currentAlpha = pstRangeAction.convertTapToAngle(network.getTwoWindingsTransformer(RANGE_ACTION_ELEMENT_ID).getPhaseTapChanger().getTapPosition());
 
         FaraoMPVariable setPointVariable = linearProblem.getRangeActionSetpointVariable(pstRangeAction, state);
 
@@ -427,14 +426,14 @@ class CoreProblemFillerTest extends AbstractFillerTest {
         assertNull(flowConstraint2);
 
         // check the number of variables and constraints
-        // total number of variables 4 :
+        // total number of variables 3 :
         //      - 1 per CNEC (flow)
         //      - 2 per range action (set-point and variation)
         // total number of constraints 4 :
         //      - 1 per CNEC (flow constraint)
-        //      - 2 per range action (absolute variation constraints)
+        //      - 3 per range action (absolute variation constraints and iterative relative variation constraint: 1 more each time the problem is updated)
         assertEquals(3, linearProblem.numVariables());
-        assertEquals(3, linearProblem.numConstraints());
+        assertEquals(4, linearProblem.numConstraints());
     }
 
     @Test
@@ -445,7 +444,7 @@ class CoreProblemFillerTest extends AbstractFillerTest {
         updateLinearProblem();
 
         // some additional data
-        final double currentAlpha = ((PstRangeAction) pstRangeAction).convertTapToAngle(network.getTwoWindingsTransformer(RANGE_ACTION_ELEMENT_ID).getPhaseTapChanger().getTapPosition());
+        final double currentAlpha = pstRangeAction.convertTapToAngle(network.getTwoWindingsTransformer(RANGE_ACTION_ELEMENT_ID).getPhaseTapChanger().getTapPosition());
 
         FaraoMPVariable setPointVariable = linearProblem.getRangeActionSetpointVariable(pstRangeAction, state);
 
@@ -472,14 +471,14 @@ class CoreProblemFillerTest extends AbstractFillerTest {
         assertEquals(-SENSI_CNEC2_IT2, flowConstraint2.getCoefficient(setPointVariable), DOUBLE_TOLERANCE);
 
         // check the number of variables and constraints
-        // total number of variables 4 :
+        // total number of variables 3 :
         //      - 1 per CNEC (flow)
         //      - 2 per range action (set-point and variation)
         // total number of constraints 4 :
         //      - 1 per CNEC (flow constraint)
-        //      - 2 per range action (absolute variation constraints)
+        //      - 3 per range action (absolute variation constraints and iterative relative variation constraint: 1 more each time the problem is updated)
         assertEquals(3, linearProblem.numVariables());
-        assertEquals(3, linearProblem.numConstraints());
+        assertEquals(4, linearProblem.numConstraints());
     }
 
     @Test

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFillerTest.java
@@ -431,8 +431,12 @@ class CoreProblemFillerTest extends AbstractFillerTest {
         //      - 2 per range action (set-point and variation)
         // total number of constraints 4 :
         //      - 1 per CNEC (flow constraint)
-        //      - 3 per range action (absolute variation constraints and iterative relative variation constraint: 1 more each time the problem is updated)
+        //      - 3 per range action (absolute variation constraints and iterative relative variation constraint: created before 2nd iteration)
         assertEquals(3, linearProblem.numVariables());
+        assertEquals(4, linearProblem.numConstraints());
+
+        // assert that no other constraint is created after 2nd iteration
+        updateLinearProblem();
         assertEquals(4, linearProblem.numConstraints());
     }
 
@@ -476,8 +480,12 @@ class CoreProblemFillerTest extends AbstractFillerTest {
         //      - 2 per range action (set-point and variation)
         // total number of constraints 4 :
         //      - 1 per CNEC (flow constraint)
-        //      - 3 per range action (absolute variation constraints and iterative relative variation constraint: 1 more each time the problem is updated)
+        //      - 3 per range action (absolute variation constraints and iterative relative variation constraint: created before 2nd iteration)
         assertEquals(3, linearProblem.numVariables());
+        assertEquals(4, linearProblem.numConstraints());
+
+        // assert that no other constraint is created after 2nd iteration
+        updateLinearProblem();
         assertEquals(4, linearProblem.numConstraints());
     }
 

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
@@ -25,6 +25,7 @@ import com.farao_community.farao.rao_api.parameters.ObjectiveFunctionParameters;
 import com.farao_community.farao.rao_api.parameters.RaoParameters;
 import com.farao_community.farao.search_tree_rao.commons.SensitivityComputer;
 import com.farao_community.farao.search_tree_rao.commons.optimization_perimeters.OptimizationPerimeter;
+import com.farao_community.farao.search_tree_rao.commons.parameters.TreeParameters;
 import com.farao_community.farao.search_tree_rao.linear_optimisation.algorithms.IteratingLinearOptimizer;
 import com.farao_community.farao.search_tree_rao.commons.objective_function_evaluator.ObjectiveFunction;
 import com.farao_community.farao.search_tree_rao.commons.NetworkActionCombination;
@@ -307,6 +308,8 @@ class LeafTest {
         when(searchTreeInput.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunction.class));
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
+        when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
+        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
         rootLeaf.optimize(searchTreeInput, searchTreeParameters);
         assertEquals(Leaf.Status.OPTIMIZED, rootLeaf.getStatus());
     }
@@ -352,6 +355,8 @@ class LeafTest {
         when(searchTreeInput.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunction.class));
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
+        when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
+        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
@@ -420,6 +425,8 @@ class LeafTest {
         when(searchTreeInput.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunction.class));
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
+        when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
+        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
         double expectedFunctionalCost = 3.;
@@ -454,6 +461,8 @@ class LeafTest {
         when(searchTreeInput.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunction.class));
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
+        when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
+        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
         double expectedVirtualCost = 3.;
@@ -497,6 +506,8 @@ class LeafTest {
         when(searchTreeInput.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunction.class));
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
+        when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
+        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
         FlowCnec flowCnec = Mockito.mock(FlowCnec.class);
@@ -573,6 +584,8 @@ class LeafTest {
         when(searchTreeInput.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunction.class));
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
+        when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
+        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
@@ -656,6 +669,8 @@ class LeafTest {
         when(searchTreeInput.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunction.class));
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
+        when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
+        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
         assertEquals(sensitivityStatus, leaf.getSensitivityStatus());
@@ -691,6 +706,8 @@ class LeafTest {
         when(searchTreeInput.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunction.class));
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
+        when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
+        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
@@ -737,6 +754,8 @@ class LeafTest {
         when(searchTreeInput.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunction.class));
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
+        when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
+        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
@@ -755,6 +774,8 @@ class LeafTest {
         when(searchTreeInput.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunction.class));
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
+        when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
+        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
         prepareLinearProblemBuilder(Mockito.mock(IteratingLinearOptimizationResultImpl.class));
         rootLeaf.optimize(searchTreeInput, searchTreeParameters);
         rootLeaf.finalizeOptimization();
@@ -782,6 +803,8 @@ class LeafTest {
         when(searchTreeInput.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunction.class));
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
+        when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
+        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
         when(linearOptimizationResult.getCost()).thenReturn(-100.5);

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
@@ -309,7 +309,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
         rootLeaf.optimize(searchTreeInput, searchTreeParameters);
         assertEquals(Leaf.Status.OPTIMIZED, rootLeaf.getStatus());
     }
@@ -356,7 +356,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
@@ -426,7 +426,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
         double expectedFunctionalCost = 3.;
@@ -462,7 +462,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
         double expectedVirtualCost = 3.;
@@ -507,7 +507,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
         FlowCnec flowCnec = Mockito.mock(FlowCnec.class);
@@ -585,7 +585,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
@@ -670,7 +670,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
         assertEquals(sensitivityStatus, leaf.getSensitivityStatus());
@@ -707,7 +707,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
@@ -755,7 +755,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
@@ -775,7 +775,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
         prepareLinearProblemBuilder(Mockito.mock(IteratingLinearOptimizationResultImpl.class));
         rootLeaf.optimize(searchTreeInput, searchTreeParameters);
         rootLeaf.finalizeOptimization();
@@ -804,7 +804,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getCapPstVariation()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
         when(linearOptimizationResult.getCost()).thenReturn(-100.5);

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
@@ -309,7 +309,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         rootLeaf.optimize(searchTreeInput, searchTreeParameters);
         assertEquals(Leaf.Status.OPTIMIZED, rootLeaf.getStatus());
     }
@@ -356,7 +356,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
@@ -426,7 +426,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
         double expectedFunctionalCost = 3.;
@@ -462,7 +462,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
         double expectedVirtualCost = 3.;
@@ -507,7 +507,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
         FlowCnec flowCnec = Mockito.mock(FlowCnec.class);
@@ -585,7 +585,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
@@ -670,7 +670,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
         assertEquals(sensitivityStatus, leaf.getSensitivityStatus());
@@ -707,7 +707,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
@@ -755,7 +755,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
@@ -775,7 +775,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         prepareLinearProblemBuilder(Mockito.mock(IteratingLinearOptimizationResultImpl.class));
         rootLeaf.optimize(searchTreeInput, searchTreeParameters);
         rootLeaf.finalizeOptimization();
@@ -804,7 +804,7 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getDecreasePstRange()).thenReturn(false);
+        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
         when(linearOptimizationResult.getCost()).thenReturn(-100.5);

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
@@ -309,7 +309,6 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         rootLeaf.optimize(searchTreeInput, searchTreeParameters);
         assertEquals(Leaf.Status.OPTIMIZED, rootLeaf.getStatus());
     }
@@ -356,7 +355,6 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
@@ -426,7 +424,6 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
         double expectedFunctionalCost = 3.;
@@ -462,7 +459,6 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
         double expectedVirtualCost = 3.;
@@ -507,7 +503,6 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
         FlowCnec flowCnec = Mockito.mock(FlowCnec.class);
@@ -585,7 +580,6 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
@@ -670,7 +664,6 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
         assertEquals(sensitivityStatus, leaf.getSensitivityStatus());
@@ -707,7 +700,6 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
@@ -755,7 +747,6 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
 
@@ -775,7 +766,6 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         prepareLinearProblemBuilder(Mockito.mock(IteratingLinearOptimizationResultImpl.class));
         rootLeaf.optimize(searchTreeInput, searchTreeParameters);
         rootLeaf.finalizeOptimization();
@@ -804,7 +794,6 @@ class LeafTest {
         SearchTreeParameters searchTreeParameters = Mockito.mock(SearchTreeParameters.class);
         when(searchTreeParameters.getObjectiveFunction()).thenReturn(Mockito.mock(ObjectiveFunctionParameters.ObjectiveFunctionType.class));
         when(searchTreeParameters.getTreeParameters()).thenReturn(Mockito.mock(TreeParameters.class));
-        when(searchTreeParameters.getTreeParameters().getPstRangeShrinking()).thenReturn(false);
         prepareLinearProblemBuilder(linearOptimizationResult);
         leaf.optimize(searchTreeInput, searchTreeParameters);
         when(linearOptimizationResult.getCost()).thenReturn(-100.5);

--- a/util/src/main/java/com/farao_community/farao/util/MultipleNetworkPool.java
+++ b/util/src/main/java/com/farao_community/farao/util/MultipleNetworkPool.java
@@ -54,7 +54,7 @@ public class MultipleNetworkPool extends AbstractNetworkPool {
             return;
         }
 
-        TECHNICAL_LOGS.debug("Filling network pool with '{}' new cop'{}' of network '{}' on variant '{}'", clonesToAdd, clonesToAdd == 1 ? "y" : "ies", network.getId(), targetVariant);
+        TECHNICAL_LOGS.debug("Filling network pool with {} new cop{} of network {} on variant {}", clonesToAdd, clonesToAdd == 1 ? "y" : "ies", network.getId(), targetVariant);
 
         String initialVariant = network.getVariantManager().getWorkingVariantId();
         network.getVariantManager().setWorkingVariant(targetVariant);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Feature

**What is the current behavior?** *(You can also link to an open issue here)*

The Rao currently assumes that the impact of a PST on a CNEC is linear. But in AC mode, this approximation is not true.
Therefore, the MIP can choose a solution which is in fact worse than the previous iteration. Currently, when this happens the MIP stops and keeps the best iteration (the last one).  

**What is the new behavior?**

This PR allows the MIP to continue even though it found a worse solution. It keeps in mind the best solution and continue until it reaches max_iteration. 

Moreover, we diminish the pst relative variation at each iteration to avoid the MIP to behave as seen on the left picture below. 

![parabole](https://user-images.githubusercontent.com/102529366/236166030-6d251e94-4e0f-4bbc-9950-2dd621ce7384.png)

The factor 2/3 has been chosen to allow, if needed, the PST to come back to its initial tap. Here is an example of the new behavior:
The PST has 32 taps (-16 to +16). In initial state, its tap position is -16. After the 1st iteration, its tap position is +16 and the MIP has worsen the result. It will run 2nd iteration but for this iteration the PST can only go from tap -5.3 (tap 16 - 32 taps * 2/3) to tap +16. And for the next iterations, **its admissible range will shrink to : previous iteration tap +- 32 taps * (2/3)^current iteration number.**