### PR TITLE
Better handling of max RA

### DIFF
--- a/data/crac/crac-api/src/main/java/com/farao_community/farao/data/crac_api/range_action/HvdcRangeAction.java
+++ b/data/crac/crac-api/src/main/java/com/farao_community/farao/data/crac_api/range_action/HvdcRangeAction.java
@@ -8,6 +8,7 @@
 package com.farao_community.farao.data.crac_api.range_action;
 
 import com.farao_community.farao.data.crac_api.NetworkElement;
+import com.powsybl.iidm.network.Network;
 
 /**
  * A range action interface specifying an action on a HVDC
@@ -21,4 +22,6 @@ public interface HvdcRangeAction extends StandardRangeAction<HvdcRangeAction> {
      * Get the HVDC Network Element on which the remedial action applies
      */
     NetworkElement getNetworkElement();
+
+    boolean isAngleDroopActivePowerControlEnabled(Network network);
 }

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/HvdcRangeActionImpl.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/HvdcRangeActionImpl.java
@@ -124,7 +124,7 @@ public class HvdcRangeActionImpl extends AbstractRangeAction<HvdcRangeAction> im
         }
     }
 
-    private boolean isAngleDroopActivePowerControlEnabled(Network network) {
+    public boolean isAngleDroopActivePowerControlEnabled(Network network) {
         HvdcAngleDroopActivePowerControl hvdcAngleDroopActivePowerControl = getHvdcLine(network).getExtension(HvdcAngleDroopActivePowerControl.class);
         return (hvdcAngleDroopActivePowerControl != null) && hvdcAngleDroopActivePowerControl.isEnabled();
     }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/AutomatonSimulator.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/castor/algorithm/AutomatonSimulator.java
@@ -441,7 +441,7 @@ public final class AutomatonSimulator {
         Set<HvdcRangeAction> hvdcRasWithControl = alignedRa.stream()
             .filter(HvdcRangeAction.class::isInstance)
             .map(HvdcRangeAction.class::cast)
-            .filter(hvdcRa -> isAngleDroopActivePowerControlEnabled(hvdcRa, network))
+            .filter(hvdcRa -> hvdcRa.isAngleDroopActivePowerControlEnabled(network))
             .collect(Collectors.toSet());
 
         if (hvdcRasWithControl.isEmpty()) {
@@ -505,12 +505,6 @@ public final class AutomatonSimulator {
         network.getVariantManager().removeVariant(tmpVariant);
 
         return controls;
-    }
-
-    private static boolean isAngleDroopActivePowerControlEnabled(HvdcRangeAction hvdcRangeAction, Network network) {
-        HvdcLine hvdcLine = network.getHvdcLine(hvdcRangeAction.getNetworkElement().getId());
-        HvdcAngleDroopActivePowerControl hvdcAngleDroopActivePowerControl = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
-        return (hvdcAngleDroopActivePowerControl != null) && hvdcAngleDroopActivePowerControl.isEnabled();
     }
 
     /**

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/Leaf.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/Leaf.java
@@ -92,11 +92,12 @@ public class Leaf implements OptimizationResult {
          Network network,
          Set<NetworkAction> alreadyAppliedNetworkActionsInPrimaryState,
          NetworkActionCombination newCombinationToApply,
+         RangeActionActivationResult prePerimeterActivationResult,
          RangeActionSetpointResult prePerimeterSetpoints,
          AppliedRemedialActions appliedRemedialActionsInSecondaryStates) {
         this.optimizationPerimeter = optimizationPerimeter;
         this.network = network;
-        this.prePerimeterActivationResult = new RangeActionActivationResultImpl(prePerimeterSetpoints);
+        this.prePerimeterActivationResult = prePerimeterActivationResult;
         this.prePerimeterSetpoints = prePerimeterSetpoints;
         if (!Objects.isNull(newCombinationToApply)) {
             this.appliedNetworkActionsInPrimaryState = Stream.concat(
@@ -122,7 +123,7 @@ public class Leaf implements OptimizationResult {
          Network network,
          PrePerimeterResult prePerimeterOutput,
          AppliedRemedialActions appliedRemedialActionsInSecondaryStates) {
-        this(optimizationPerimeter, network, Collections.emptySet(), null, prePerimeterOutput, appliedRemedialActionsInSecondaryStates);
+        this(optimizationPerimeter, network, Collections.emptySet(), null, new RangeActionActivationResultImpl(prePerimeterOutput), prePerimeterOutput, appliedRemedialActionsInSecondaryStates);
         this.status = Status.EVALUATED;
         this.preOptimFlowResult = prePerimeterOutput;
         this.preOptimSensitivityResult = prePerimeterOutput;

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -98,7 +98,6 @@ public class SearchTree {
         if (input.getOptimizationPerimeter() instanceof CurativeOptimizationPerimeter) {
             this.bloomer = new SearchTreeBloomer(
                 input.getNetwork(),
-                input.getPrePerimeterResult(),
                 parameters.getRaLimitationParameters().getMaxCurativeRa(),
                 parameters.getRaLimitationParameters().getMaxCurativeTso(),
                 parameters.getRaLimitationParameters().getMaxCurativeTopoPerTso(),
@@ -111,7 +110,6 @@ public class SearchTree {
         } else {
             this.bloomer = new SearchTreeBloomer(
                 input.getNetwork(),
-                    input.getPrePerimeterResult(),
                 Integer.MAX_VALUE, //no limitation of RA in preventive
                 Integer.MAX_VALUE, //no limitation of RA in preventive
                 new HashMap<>(),   //no limitation of RA in preventive

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -105,7 +105,7 @@ public class SearchTree {
                 parameters.getNetworkActionParameters().skipNetworkActionFarFromMostLimitingElements(),
                 parameters.getNetworkActionParameters().getMaxNumberOfBoundariesForSkippingNetworkActions(),
                 parameters.getNetworkActionParameters().getNetworkActionCombinations(),
-                    input.getOptimizationPerimeter().getMainOptimizationState()
+                input.getOptimizationPerimeter().getMainOptimizationState()
             );
         } else {
             this.bloomer = new SearchTreeBloomer(
@@ -412,7 +412,7 @@ public class SearchTree {
             naCombination,
             shouldRangeActionBeRemoved ? new RangeActionActivationResultImpl(input.getPrePerimeterResult()) : previousDepthOptimalLeaf.getRangeActionActivationResult(),
             input.getPrePerimeterResult(),
-            shouldRangeActionBeRemoved ? input.getPreOptimizationAppliedRemedialActions() : getAppliedRemedialActions(previousDepthOptimalLeaf));
+            shouldRangeActionBeRemoved ? input.getPreOptimizationAppliedRemedialActions() : getPreviousDepthAppliedRemedialActionsBeforeNewLeafEvaluation(previousDepthOptimalLeaf));
     }
 
     private void optimizeLeaf(Leaf leaf) {
@@ -437,7 +437,7 @@ public class SearchTree {
         if (isRootLeaf) {
             sensitivityComputerBuilder.withAppliedRemedialActions(input.getPreOptimizationAppliedRemedialActions());
         } else {
-            sensitivityComputerBuilder.withAppliedRemedialActions(getAppliedRemedialActions(previousDepthOptimalLeaf));
+            sensitivityComputerBuilder.withAppliedRemedialActions(getPreviousDepthAppliedRemedialActionsBeforeNewLeafEvaluation(previousDepthOptimalLeaf));
         }
 
         if (parameters.getObjectiveFunction().relativePositiveMargins()) {
@@ -525,7 +525,7 @@ public class SearchTree {
             && (1 - Math.signum(previousDepthBestCost) * relativeImpact) * previousDepthBestCost > newCost; // enough relative impact
     }
 
-    private AppliedRemedialActions getAppliedRemedialActions(RangeActionActivationResult previousDepthRangeActionActivations) {
+    private AppliedRemedialActions getPreviousDepthAppliedRemedialActionsBeforeNewLeafEvaluation(RangeActionActivationResult previousDepthRangeActionActivations) {
         AppliedRemedialActions alreadyAppliedRa = input.getPreOptimizationAppliedRemedialActions().copy();
         if (input.getOptimizationPerimeter() instanceof GlobalOptimizationPerimeter) {
             input.getOptimizationPerimeter().getRangeActionsPerState().entrySet().stream()

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -277,22 +277,21 @@ public class SearchTree {
                 }
                 try {
                     if (combinationFulfillingStopCriterion.isEmpty() || deterministicNetworkActionCombinationComparison(naCombination, combinationFulfillingStopCriterion.get()) < 0) {
-                        // todo: Probably change the doc here
-                        // Apply range actions that has been changed by the previous leaf on the network to start next depth leaves
-                        // from previous optimal leaf starting point
-                        // TODO: we can wonder if it's better to do this here or at creation of each leaves or at each evaluation/optimization
-
-                        if (naCombinationsSorted.get(naCombination)) {
+                        boolean shouldRangeActionBeRemoved = naCombinationsSorted.get(naCombination);
+                        if (shouldRangeActionBeRemoved) {
+                            // Remove parentLeaf range actions to respect every maxRa or maxOperator limitation
                             previousDepthOptimalLeaf.getRangeActions().forEach(ra ->
                                 ra.apply(networkClone, input.getPrePerimeterResult().getRangeActionSetpointResult().getSetpoint(ra))
                             );
                         } else {
+                            // Apply range actions that has been changed by the previous leaf on the network to start next depth leaves
+                            // from previous optimal leaf starting point
                             input.getOptimizationPerimeter().getRangeActions()
                                 .forEach(ra ->
                                         ra.apply(networkClone, previousDepthOptimalLeaf.getOptimizedSetpoint(ra, input.getOptimizationPerimeter().getMainOptimizationState()))
                             );
                         }
-                        optimizeNextLeafAndUpdate(naCombination, naCombinationsSorted.get(naCombination), networkClone);
+                        optimizeNextLeafAndUpdate(naCombination, shouldRangeActionBeRemoved, networkClone);
 
                     } else {
                         topLevelLogger.info("Skipping {} optimization because earlier combination fulfills stop criterion.", naCombination.getConcatenatedId());

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -276,6 +276,7 @@ public class SearchTree {
                 }
                 try {
                     if (combinationFulfillingStopCriterion.isEmpty() || deterministicNetworkActionCombinationComparison(naCombination, combinationFulfillingStopCriterion.get()) < 0) {
+                        // todo: Probably change the doc here
                         // Apply range actions that has been changed by the previous leaf on the network to start next depth leaves
                         // from previous optimal leaf starting point
                         // TODO: we can wonder if it's better to do this here or at creation of each leaves or at each evaluation/optimization
@@ -288,10 +289,8 @@ public class SearchTree {
                             previousDepthOptimalLeaf.getRangeActions()
                                 .forEach(ra -> ra.apply(networkClone, previousDepthOptimalLeaf.getOptimizedSetpoint(ra, input.getOptimizationPerimeter().getMainOptimizationState())));
                         }
-                        // todo
-                        // set alreadyAppliedRa
-
                         optimizeNextLeafAndUpdate(naCombination, networkClone);
+
                     } else {
                         topLevelLogger.info("Skipping {} optimization because earlier combination fulfills stop criterion.", naCombination.getConcatenatedId());
                     }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -286,10 +286,10 @@ public class SearchTree {
                         } else {
                             // Apply range actions that has been changed by the previous leaf on the network to start next depth leaves
                             // from previous optimal leaf starting point
-                            input.getOptimizationPerimeter().getRangeActions()
+                            previousDepthOptimalLeaf.getRangeActions()
                                 .forEach(ra ->
                                         ra.apply(networkClone, previousDepthOptimalLeaf.getOptimizedSetpoint(ra, input.getOptimizationPerimeter().getMainOptimizationState()))
-                            );
+                                );
                         }
                         optimizeNextLeafAndUpdate(naCombination, shouldRangeActionBeRemoved, networkClone);
 

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -284,7 +284,7 @@ public class SearchTree {
                                 ra.apply(networkClone, input.getPrePerimeterResult().getRangeActionSetpointResult().getSetpoint(ra))
                             );
                         } else {
-                            // Apply range actions that has been changed by the previous leaf on the network to start next depth leaves
+                            // Apply range actions that have been changed by the previous leaf on the network to start next depth leaves
                             // from previous optimal leaf starting point
                             // todo : Not sure previousDepthOptimalLeaf.getRangeActions() returns what we expect, this needs to be investigated
                             previousDepthOptimalLeaf.getRangeActions()

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTree.java
@@ -280,12 +280,13 @@ public class SearchTree {
                         boolean shouldRangeActionBeRemoved = naCombinationsSorted.get(naCombination);
                         if (shouldRangeActionBeRemoved) {
                             // Remove parentLeaf range actions to respect every maxRa or maxOperator limitation
-                            previousDepthOptimalLeaf.getRangeActions().forEach(ra ->
+                            input.getOptimizationPerimeter().getRangeActions().forEach(ra ->
                                 ra.apply(networkClone, input.getPrePerimeterResult().getRangeActionSetpointResult().getSetpoint(ra))
                             );
                         } else {
                             // Apply range actions that has been changed by the previous leaf on the network to start next depth leaves
                             // from previous optimal leaf starting point
+                            // todo : Not sure previousDepthOptimalLeaf.getRangeActions() returns what we expect, this needs to be investigated
                             previousDepthOptimalLeaf.getRangeActions()
                                 .forEach(ra ->
                                         ra.apply(networkClone, previousDepthOptimalLeaf.getOptimizedSetpoint(ra, input.getOptimizationPerimeter().getMainOptimizationState()))

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
@@ -178,9 +178,10 @@ public final class SearchTreeBloomer {
                 if (naCombinationSize > maxNaPerTso.getOrDefault(tso, Integer.MAX_VALUE)) {
                     naShouldBeKept = false;
                     break;
-                } else {
-                    removeRangeActions = removeRangeActions || alreadyActivatedNetworkActionsSize + alreadyActivatedRangeActionsSize + naCombinationSize > maxRaPerTso.getOrDefault(tso, Integer.MAX_VALUE);
-                }
+                } else if (alreadyActivatedNetworkActionsSize + alreadyActivatedRangeActionsSize + naCombinationSize > maxRaPerTso.getOrDefault(tso, Integer.MAX_VALUE)){
+                    removeRangeActions = true;
+                    break;
+                    }
             }
             if (naShouldBeKept) {
                 filteredNaCombinations.put(naCombination, removeRangeActions);

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
@@ -202,8 +202,9 @@ public final class SearchTreeBloomer {
         for (Map.Entry<NetworkActionCombination, Boolean> entry : naCombinations.entrySet()) {
             NetworkActionCombination naCombination = entry.getKey();
             if (!exceedMaxNumberOfTsos(naCombination, alreadyActivatedTsos)) {
-                fromLeaf.getActivatedRangeActions(optimizedStateForNetworkActions).forEach(pst -> alreadyActivatedTsos.add(pst.getOperator()));
-                boolean removeRangeActions = exceedMaxNumberOfTsos(naCombination, alreadyActivatedTsos);
+                Set<String> alreadyActivatedTsosWithRangeActions = new HashSet<>(alreadyActivatedTsos);
+                fromLeaf.getActivatedRangeActions(optimizedStateForNetworkActions).forEach(pst -> alreadyActivatedTsosWithRangeActions.add(pst.getOperator()));
+                boolean removeRangeActions = exceedMaxNumberOfTsos(naCombination, alreadyActivatedTsosWithRangeActions);
                 filteredNaCombinations.put(naCombination, removeRangeActions || naCombinations.get(naCombination));
             }
         }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
@@ -68,27 +68,31 @@ public final class SearchTreeBloomer {
      * activated together.
      * <p>
      * Moreover, the bloom method ensure that the returned NetworkActionCombinations respect the following rules:
-     * - they do not exceed the maximum number of usable remedial actions
-     * - they do not exceed the maximum number of usable remedial actions (PST & topo) per operator
-     * - they do not exceed the maximum number of operators
-     * - they are not too far away from the most limiting CNEC
+     * <ul>
+     * <li>they do not exceed the maximum number of usable remedial actions</li>
+     * <li>they do not exceed the maximum number of usable remedial actions (PST & topo) per operator</li>
+     * <li>they do not exceed the maximum number of operators</li>
+     * <li>they are not too far away from the most limiting CNEC</li>
+     * </ul>
      */
-    List<NetworkActionCombination> bloom(Leaf fromLeaf, Set<NetworkAction> networkActions) {
+    Map<NetworkActionCombination, List<RangeAction<?>>> bloom(Leaf fromLeaf, Set<NetworkAction> networkActions) {
 
         // preDefined combinations
-        List<NetworkActionCombination> networkActionCombinations = preDefinedNaCombinations.stream()
+        Map<NetworkActionCombination, List<RangeAction<?>>> networkActionCombinations = preDefinedNaCombinations.stream()
             .distinct()
             .filter(naCombination -> networkActions.containsAll(naCombination.getNetworkActionSet()))
-            .collect(Collectors.toList());
+            .collect(Collectors.toMap(naCombination -> naCombination, naCombination -> new ArrayList<>()));
 
         // + individual available Network Actions
-        final List<NetworkActionCombination> finalNetworkActionCombinations = new ArrayList<>(networkActionCombinations);
+        final List<NetworkActionCombination> finalNetworkActionCombinations = new ArrayList<>(networkActionCombinations.keySet());
+        Map<NetworkActionCombination, List<RangeAction<?>>> auxNaCombinationsToRefactor = networkActionCombinations;
         networkActions.stream()
             .filter(na ->
                 finalNetworkActionCombinations.stream().noneMatch(naCombi -> naCombi.getNetworkActionSet().size() == 1 && naCombi.getNetworkActionSet().contains(na))
             )
-            .map(NetworkActionCombination::new)
-            .forEach(networkActionCombinations::add);
+            //.map(NetworkActionCombination::new)
+            .forEach(ra -> auxNaCombinationsToRefactor.put(new NetworkActionCombination(Set.of(ra)), new ArrayList<>()));
+        networkActionCombinations.putAll(auxNaCombinationsToRefactor);
 
         // filters
         // (idea: create one class per filter which implement a common interface)
@@ -103,10 +107,18 @@ public final class SearchTreeBloomer {
         return networkActionCombinations;
     }
 
-    List<NetworkActionCombination> removeAlreadyActivatedNetworkActions(List<NetworkActionCombination> naCombinations, Leaf fromLeaf) {
-        return naCombinations.stream()
+    private List<RangeAction<?>> selectRangeActionsToRemove(Set<RangeAction<?>> rangeActions, int numberOfRangeActionsToRemove) {
+        if (numberOfRangeActionsToRemove <= 0) {
+            return new ArrayList<>();
+        } else {
+            return new ArrayList<>();
+        }
+    }
+
+    Map<NetworkActionCombination, List<RangeAction<?>>> removeAlreadyActivatedNetworkActions(Map<NetworkActionCombination, List<RangeAction<?>>> naCombinations, Leaf fromLeaf) {
+        return naCombinations.keySet().stream()
             .filter(naCombination -> naCombination.getNetworkActionSet().stream().noneMatch(na -> fromLeaf.getActivatedNetworkActions().contains(na)))
-            .collect(Collectors.toList());
+            .collect(Collectors.toMap(naCombination -> naCombination, naCombinations::get));
     }
 
     /**
@@ -116,7 +128,7 @@ public final class SearchTreeBloomer {
      * no need to bloom on ra2. If the remedial action ra2 was relevant, the combination ra1+ra2 would have been
      * already selected in the previous depths.
      */
-    List<NetworkActionCombination> removeAlreadyTestedCombinations(List<NetworkActionCombination> naCombinations, Leaf fromLeaf) {
+    Map<NetworkActionCombination, List<RangeAction<?>>> removeAlreadyTestedCombinations(Map<NetworkActionCombination, List<RangeAction<?>>> naCombinations, Leaf fromLeaf) {
 
         List<NetworkAction> alreadyTestedNetworkActions = new ArrayList<>();
 
@@ -137,18 +149,24 @@ public final class SearchTreeBloomer {
             }
         }
 
-        return naCombinations.stream()
+        return naCombinations.keySet().stream()
             .filter(naCombination -> naCombination.getNetworkActionSet().size() != 1
                 || !alreadyTestedNetworkActions.contains(naCombination.getNetworkActionSet().iterator().next()))
-            .collect(Collectors.toList());
+                .collect(Collectors.toMap(naCombination -> naCombination, naCombinations::get));
     }
 
-    List<NetworkActionCombination> removeCombinationsWhichExceedMaxNumberOfRa(List<NetworkActionCombination> naCombinations, Leaf fromLeaf) {
-        int numberOfRangeActionsUsed = getNumberOfRangeActionsUsed(fromLeaf);
+    Map<NetworkActionCombination, List<RangeAction<?>>> removeCombinationsWhichExceedMaxNumberOfRa(Map<NetworkActionCombination, List<RangeAction<?>>> naCombinations, Leaf fromLeaf) {
 
-        List<NetworkActionCombination> filteredNaCombinations = naCombinations.stream()
-            .filter(naCombination -> naCombination.getNetworkActionSet().size() + fromLeaf.getActivatedNetworkActions().size() + numberOfRangeActionsUsed <= maxRa)
-            .collect(Collectors.toList());
+        Map<NetworkActionCombination, List<RangeAction<?>>> filteredNaCombinations = new HashMap<>();
+
+        for (Map.Entry<NetworkActionCombination, List<RangeAction<?>>> entry : naCombinations.entrySet()) {
+            NetworkActionCombination naCombination = entry.getKey();
+            int numberOfRangeActionsToRemove = naCombination.getNetworkActionSet().size() + (int) fromLeaf.getNumberOfActivatedRangeActions() - maxRa;
+            if ((fromLeaf.getNumberOfActivatedRangeActions() >= numberOfRangeActionsToRemove)&&(naCombination.getNetworkActionSet().size() <= maxRa)) {
+                List<RangeAction<?>> rangeActionsToRemove = selectRangeActionsToRemove(fromLeaf.getActivatedRangeActions(optimizedStateForNetworkActions), numberOfRangeActionsToRemove);
+                filteredNaCombinations.put(naCombination, rangeActionsToRemove);
+            }
+        }
 
         if (naCombinations.size() > filteredNaCombinations.size()) {
             TECHNICAL_LOGS.info("{} network action combinations have been filtered out because the max number of usable RAs has been reached", naCombinations.size() - filteredNaCombinations.size());
@@ -157,13 +175,25 @@ public final class SearchTreeBloomer {
         return filteredNaCombinations;
     }
 
-    List<NetworkActionCombination> removeCombinationsWhichExceedMaxNumberOfRaPerTso(List<NetworkActionCombination> naCombinations, Leaf fromLeaf) {
+    Map<NetworkActionCombination, List<RangeAction<?>>> removeCombinationsWhichExceedMaxNumberOfRaPerTso(Map<NetworkActionCombination, List<RangeAction<?>>> naCombinations, Leaf fromLeaf) {
 
         Map<String, Integer> maxNaPerTso = getMaxNetworkActionPerTso(fromLeaf);
-
-        List<NetworkActionCombination> filteredNaCombinations = naCombinations.stream()
-            .filter(naCombination -> !exceedMaxNumberOfRaPerTso(naCombination, maxNaPerTso))
-            .collect(Collectors.toList());
+        Map<NetworkActionCombination, List<RangeAction<?>>> filteredNaCombinations = new HashMap<>();
+        for (Map.Entry<String, Integer> tsoEntry : maxNaPerTso.entrySet()) {
+            String tso = tsoEntry.getKey();
+            // todo vérfier que getOperator renvoie bien tso
+            for (Map.Entry<NetworkActionCombination, List<RangeAction<?>>> entry : naCombinations.entrySet()) {
+                NetworkActionCombination naCombination = entry.getKey();
+                int numberOfRangeActionsToRemove = (int) (naCombination.getNetworkActionSet().stream().filter(networkAction-> networkAction.getOperator().equals(tso)).count() + fromLeaf.getActivatedRangeActions(optimizedStateForNetworkActions).stream().filter(ra -> ra.getOperator().equals(tso)).count() - maxRaPerTso.get(tso));
+                boolean isNaSizeOk = naCombination.getNetworkActionSet().stream().filter(na -> na.getOperator().equals(tso)).count() <= tsoEntry.getValue();
+                Set<RangeAction<?>> pstActivatedForTso = fromLeaf.getActivatedRangeActions(optimizedStateForNetworkActions).stream().filter(ra -> ra.getOperator().equals(tso)).collect(Collectors.toSet());
+                boolean isThereEnoughPstToRemove = pstActivatedForTso.size() >= numberOfRangeActionsToRemove;
+                if (isNaSizeOk && isThereEnoughPstToRemove) {
+                    List<RangeAction<?>> rangeActionsToRemove = selectRangeActionsToRemove(pstActivatedForTso, numberOfRangeActionsToRemove);
+                    filteredNaCombinations.put(naCombination, rangeActionsToRemove);
+                }
+            }
+        }
 
         if (naCombinations.size() > filteredNaCombinations.size()) {
             TECHNICAL_LOGS.info("{} network action combinations have been filtered out because the maximum number of network actions for their TSO has been reached", naCombinations.size() - filteredNaCombinations.size());
@@ -172,11 +202,11 @@ public final class SearchTreeBloomer {
         return filteredNaCombinations;
     }
 
-    List<NetworkActionCombination> removeCombinationsWhichExceedMaxNumberOfTsos(List<NetworkActionCombination> naCombinations, Leaf fromLeaf) {
+    Map<NetworkActionCombination, List<RangeAction<?>>> removeCombinationsWhichExceedMaxNumberOfTsos(Map<NetworkActionCombination, List<RangeAction<?>>> naCombinations, Leaf fromLeaf) {
 
         Set<String> alreadyActivatedTsos = getTsosWithActivatedNetworkActions(fromLeaf);
 
-        List<NetworkActionCombination> filteredNaCombinations = naCombinations.stream()
+        Map<NetworkActionCombination, List<RangeAction<?>>> filteredNaCombinations = naCombinations.keySet().stream()
             .filter(naCombination -> !exceedMaxNumberOfTsos(naCombination, alreadyActivatedTsos))
             .collect(Collectors.toList());
 
@@ -192,7 +222,7 @@ public final class SearchTreeBloomer {
      * feature, and setting the number of boundaries allowed between the network action and the limiting element.
      * The most limiting elements are the most limiting functional cost element, and all elements with a non-zero virtual cost.
      */
-    List<NetworkActionCombination> removeCombinationsFarFromMostLimitingElement(List<NetworkActionCombination> naCombinations, Leaf fromLeaf) {
+    Map<NetworkActionCombination, List<RangeAction<?>>> removeCombinationsFarFromMostLimitingElement(Map<NetworkActionCombination, List<RangeAction<?>>> naCombinations, Leaf fromLeaf) {
 
         if (!filterFarElements) {
             return naCombinations;
@@ -200,9 +230,9 @@ public final class SearchTreeBloomer {
 
         Set<Optional<Country>> worstCnecLocation = getOptimizedMostLimitingElementsLocation(fromLeaf);
 
-        List<NetworkActionCombination> filteredNaCombinations = naCombinations.stream()
+        Map<NetworkActionCombination, List<RangeAction<?>>> filteredNaCombinations = naCombinations.keySet().stream()
             .filter(naCombination -> naCombination.getNetworkActionSet().stream().anyMatch(na -> isNetworkActionCloseToLocations(na, worstCnecLocation, countryGraph)))
-            .collect(Collectors.toList());
+                .collect(Collectors.toMap(naCombination -> naCombination, naCombinations::get));
 
         if (naCombinations.size() > filteredNaCombinations.size()) {
             TECHNICAL_LOGS.info("{} network action combinations have been filtered out because they are too far from the most limiting element", naCombinations.size() - filteredNaCombinations.size());

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
@@ -178,10 +178,10 @@ public final class SearchTreeBloomer {
                 if (naCombinationSize > maxNaPerTso.getOrDefault(tso, Integer.MAX_VALUE)) {
                     naShouldBeKept = false;
                     break;
-                } else if (alreadyActivatedNetworkActionsSize + alreadyActivatedRangeActionsSize + naCombinationSize > maxRaPerTso.getOrDefault(tso, Integer.MAX_VALUE)){
+                } else if (alreadyActivatedNetworkActionsSize + alreadyActivatedRangeActionsSize + naCombinationSize > maxRaPerTso.getOrDefault(tso, Integer.MAX_VALUE)) {
                     removeRangeActions = true;
                     break;
-                    }
+                }
             }
             if (naShouldBeKept) {
                 filteredNaCombinations.put(naCombination, removeRangeActions);

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
@@ -57,10 +57,13 @@ public final class SearchTreeBloomer {
     }
 
     /**
-     * This method generates a list a of NetworkActionCombinations that would be available after this leaf inside the tree.
-     * The returned NetworkActionCombination are either individual NetworkAction as defined in the Crac, or predefined
+     * This method generates a map of NetworkActionCombinations and associated boolean.
+     * The networkActionCombinations generated would be available after this leaf inside the tree.
+     * They are either individual NetworkAction as defined in the Crac, or predefined
      * combinations of NetworkActions, defined in the SearchTreeRaoParameters and considered as being efficient when
      * activated together.
+     * If the associated boolean is false, the combination can be applied while keeping parentLeafRangeActions.
+     * If it is true, parentLeafRangeActions must be removed before applying the combination.
      * <p>
      * Moreover, the bloom method ensure that the returned NetworkActionCombinations respect the following rules:
      * <ul>

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
@@ -174,7 +174,8 @@ public final class SearchTreeBloomer {
             for (String tso : operators) {
                 int naCombinationSize = (int) naCombination.getNetworkActionSet().stream().filter(networkAction -> networkAction.getOperator().equals(tso)).count();
                 int alreadyActivatedRangeActionsSize = (int) fromLeaf.getActivatedRangeActions(optimizedStateForNetworkActions).stream().filter(ra -> ra.getOperator().equals(tso)).count();
-                int alreadyActivatedNetworkActionsSize = (int) fromLeaf.getActivatedNetworkActions().stream().filter(ra -> ra.getOperator().equals(tso)).count();
+                int alreadyActivatedNetworkActionsSize = (int) fromLeaf.getActivatedNetworkActions().stream().filter(na -> na.getOperator().equals(tso)).count();
+                // The number of already applied network actions is taken in account in getMaxNetworkActionPerTso
                 if (naCombinationSize > maxNaPerTso.getOrDefault(tso, Integer.MAX_VALUE)) {
                     naShouldBeKept = false;
                     break;

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
@@ -184,7 +184,7 @@ public final class SearchTreeBloomer {
                 }
             }
             if (naShouldBeKept) {
-                filteredNaCombinations.put(naCombination, removeRangeActions);
+                filteredNaCombinations.put(naCombination, removeRangeActions || naCombinations.get(naCombination));
             }
         }
 

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
@@ -80,14 +80,13 @@ public final class SearchTreeBloomer {
 
         // + individual available Network Actions
         final List<NetworkActionCombination> finalNetworkActionCombinations = new ArrayList<>(networkActionCombinations.keySet());
-        Map<NetworkActionCombination, Boolean> auxNaCombinationsToRefactor = networkActionCombinations;
+        Map<NetworkActionCombination, Boolean> effectivelyFinalNACombinations = networkActionCombinations;
         networkActions.stream()
             .filter(na ->
                 finalNetworkActionCombinations.stream().noneMatch(naCombi -> naCombi.getNetworkActionSet().size() == 1 && naCombi.getNetworkActionSet().contains(na))
             )
-            //.map(NetworkActionCombination::new)
-            .forEach(ra -> auxNaCombinationsToRefactor.put(new NetworkActionCombination(Set.of(ra)), false));
-        networkActionCombinations.putAll(auxNaCombinationsToRefactor);
+            .forEach(ra -> effectivelyFinalNACombinations.put(new NetworkActionCombination(Set.of(ra)), false));
+        networkActionCombinations.putAll(effectivelyFinalNACombinations);
 
         // filters
         // (idea: create one class per filter which implement a common interface)

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomer.java
@@ -141,7 +141,7 @@ public final class SearchTreeBloomer {
         return naCombinations.keySet().stream()
             .filter(naCombination -> naCombination.getNetworkActionSet().size() != 1
                 || !alreadyTestedNetworkActions.contains(naCombination.getNetworkActionSet().iterator().next()))
-                .collect(Collectors.toMap(naCombination -> naCombination, naCombinations::get));
+            .collect(Collectors.toMap(naCombination -> naCombination, naCombinations::get));
     }
 
     /**
@@ -199,7 +199,6 @@ public final class SearchTreeBloomer {
                     break;
                 } else if (numberOfAlreadyAppliedNetworkActionsForTso + numberOfAlreadyActivatedRangeActionsForTso + naCombinationSize > maxRaPerTso.getOrDefault(tso, Integer.MAX_VALUE)) {
                     removeRangeActions = true;
-                    break;
                 }
             }
             if (naShouldBeKept) {

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
@@ -113,7 +113,8 @@ class LeafTest {
     }
 
     private Leaf buildNotEvaluatedRootLeaf() {
-        return new Leaf(optimizationPerimeter, network, new HashSet<>(), new NetworkActionCombination(na1), prePerimeterResult, appliedRemedialActions);
+        RangeActionActivationResult rangeActionActivationResult = Mockito.mock(RangeActionActivationResult.class);
+        return new Leaf(optimizationPerimeter, network, new HashSet<>(), new NetworkActionCombination(na1), rangeActionActivationResult, prePerimeterResult, appliedRemedialActions);
     }
 
     private void prepareLinearProblemBuilder(IteratingLinearOptimizationResultImpl linearOptimizationResult) {
@@ -142,9 +143,10 @@ class LeafTest {
 
     @Test
     void testMultipleLeafsDefinition() {
+        RangeActionActivationResult rangeActionActivationResult = Mockito.mock(RangeActionActivationResult.class);
         Leaf rootLeaf = new Leaf(optimizationPerimeter, network, prePerimeterResult, appliedRemedialActions);
-        Leaf leaf1 = new Leaf(optimizationPerimeter, network, rootLeaf.getActivatedNetworkActions(), new NetworkActionCombination(na1), prePerimeterResult, appliedRemedialActions);
-        Leaf leaf2 = new Leaf(optimizationPerimeter, network, leaf1.getActivatedNetworkActions(), new NetworkActionCombination(na2), prePerimeterResult, appliedRemedialActions);
+        Leaf leaf1 = new Leaf(optimizationPerimeter, network, rootLeaf.getActivatedNetworkActions(), new NetworkActionCombination(na1), rangeActionActivationResult, prePerimeterResult, appliedRemedialActions);
+        Leaf leaf2 = new Leaf(optimizationPerimeter, network, leaf1.getActivatedNetworkActions(), new NetworkActionCombination(na2), rangeActionActivationResult, prePerimeterResult, appliedRemedialActions);
         assertEquals(1, leaf1.getActivatedNetworkActions().size());
         assertEquals(2, leaf2.getActivatedNetworkActions().size());
         assertTrue(leaf1.getActivatedNetworkActions().contains(na1));
@@ -160,9 +162,10 @@ class LeafTest {
 
     @Test
     void testMultipleLeafDefinitionWithSameNetworkAction() {
+        RangeActionActivationResult rangeActionActivationResult = Mockito.mock(RangeActionActivationResult.class);
         Leaf rootLeaf = new Leaf(optimizationPerimeter, network, prePerimeterResult, appliedRemedialActions);
-        Leaf leaf1 = new Leaf(optimizationPerimeter, network, rootLeaf.getActivatedNetworkActions(), new NetworkActionCombination(na1), prePerimeterResult, appliedRemedialActions);
-        Leaf leaf2 = new Leaf(optimizationPerimeter, network, leaf1.getActivatedNetworkActions(), new NetworkActionCombination(na1), prePerimeterResult, appliedRemedialActions);
+        Leaf leaf1 = new Leaf(optimizationPerimeter, network, rootLeaf.getActivatedNetworkActions(), new NetworkActionCombination(na1), rangeActionActivationResult, prePerimeterResult, appliedRemedialActions);
+        Leaf leaf2 = new Leaf(optimizationPerimeter, network, leaf1.getActivatedNetworkActions(), new NetworkActionCombination(na1), rangeActionActivationResult, prePerimeterResult, appliedRemedialActions);
         assertEquals(1, leaf2.getActivatedNetworkActions().size());
         assertTrue(leaf2.getActivatedNetworkActions().contains(na1));
         assertFalse(leaf2.isRoot());
@@ -182,7 +185,8 @@ class LeafTest {
     private Leaf prepareLeafForEvaluation(NetworkAction networkAction, ComputationStatus expectedSensitivityStatus, FlowResult expectedFlowResult, double expectedCost, List<FlowCnec> mostLimitingCnecs) {
         when(networkAction.apply(any())).thenReturn(true);
         Leaf rootLeaf = new Leaf(optimizationPerimeter, network, prePerimeterResult, appliedRemedialActions);
-        Leaf leaf = new Leaf(optimizationPerimeter, network, rootLeaf.getActivatedNetworkActions(), new NetworkActionCombination(networkAction), prePerimeterResult, appliedRemedialActions);
+        RangeActionActivationResult rangeActionActivationResult = Mockito.mock(RangeActionActivationResult.class);
+        Leaf leaf = new Leaf(optimizationPerimeter, network, rootLeaf.getActivatedNetworkActions(), new NetworkActionCombination(networkAction), rangeActionActivationResult, prePerimeterResult, appliedRemedialActions);
         SensitivityResult expectedSensitivityResult = Mockito.mock(SensitivityResult.class);
         when(sensitivityComputer.getSensitivityResult()).thenReturn(expectedSensitivityResult);
         when(expectedSensitivityResult.getSensitivityStatus()).thenReturn(expectedSensitivityStatus);
@@ -774,6 +778,7 @@ class LeafTest {
 
     @Test
     void testNonapplicableNa() {
+        RangeActionActivationResult rangeActionActivationResult = Mockito.mock(RangeActionActivationResult.class);
         NetworkActionCombination naCombinationToApply = Mockito.mock(NetworkActionCombination.class);
         NetworkAction na1 = Mockito.mock(NetworkAction.class);
         NetworkAction na2 = Mockito.mock(NetworkAction.class);
@@ -781,7 +786,7 @@ class LeafTest {
         when(na2.apply(any())).thenReturn(false);
         when(naCombinationToApply.getNetworkActionSet()).thenReturn(Set.of(na1, na2));
         Set<NetworkAction> alreadyAppliedNetworkActions = Set.of();
-        assertThrows(FaraoException.class, () -> new Leaf(optimizationPerimeter, network, alreadyAppliedNetworkActions, naCombinationToApply, prePerimeterResult, appliedRemedialActions));
+        assertThrows(FaraoException.class, () -> new Leaf(optimizationPerimeter, network, alreadyAppliedNetworkActions, naCombinationToApply, rangeActionActivationResult, prePerimeterResult, appliedRemedialActions));
     }
 
     @Test

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
@@ -22,7 +22,6 @@ import com.farao_community.farao.data.crac_api.range_action.RangeAction;
 import com.farao_community.farao.data.crac_impl.utils.NetworkImportsUtil;
 import com.farao_community.farao.data.rao_result_api.ComputationStatus;
 import com.farao_community.farao.rao_api.parameters.ObjectiveFunctionParameters;
-import com.farao_community.farao.rao_api.parameters.RaoParameters;
 import com.farao_community.farao.search_tree_rao.commons.SensitivityComputer;
 import com.farao_community.farao.search_tree_rao.commons.optimization_perimeters.OptimizationPerimeter;
 import com.farao_community.farao.search_tree_rao.commons.parameters.TreeParameters;
@@ -88,9 +87,6 @@ class LeafTest {
         na2 = Mockito.mock(NetworkAction.class);
         when(na1.apply(any())).thenReturn(true);
         when(na2.apply(any())).thenReturn(true);
-
-        // rao parameters
-        RaoParameters raoParameters = new RaoParameters();
 
         iteratingLinearOptimizer = Mockito.mock(IteratingLinearOptimizer.class);
         sensitivityComputer = Mockito.mock(SensitivityComputer.class);

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomerTest.java
@@ -22,7 +22,6 @@ import com.farao_community.farao.data.crac_api.usage_rule.UsageMethod;
 import com.farao_community.farao.data.crac_impl.utils.CommonCracCreation;
 import com.farao_community.farao.data.crac_impl.utils.NetworkImportsUtil;
 import com.farao_community.farao.search_tree_rao.commons.NetworkActionCombination;
-import com.farao_community.farao.search_tree_rao.result.api.RangeActionSetpointResult;
 import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import org.junit.jupiter.api.BeforeEach;
@@ -137,7 +136,7 @@ class SearchTreeBloomerTest {
         Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Collections.singleton(naFr1));
 
         // filter already activated NetworkAction
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         Map<NetworkActionCombination, Boolean> filteredNaCombinations = bloomer.removeAlreadyActivatedNetworkActions(naCombinations, previousLeaf);
 
         assertEquals(5, filteredNaCombinations.size());
@@ -159,7 +158,7 @@ class SearchTreeBloomerTest {
         Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Set.of(naFr1, naBe1));
 
         // filter already tested combinations
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, false, 0, preDefinedNaCombinations, pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, false, 0, preDefinedNaCombinations, pState);
         Map<NetworkActionCombination, Boolean> filteredNaCombinations = bloomer.removeAlreadyTestedCombinations(naCombinations, previousLeaf);
 
         assertEquals(5, filteredNaCombinations.size());
@@ -180,20 +179,20 @@ class SearchTreeBloomerTest {
         Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Collections.singleton(naFr1));
 
         // filter - max 4 RAs
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 4, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, 4, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         Map<NetworkActionCombination, Boolean> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(8, filteredNaCombination.size()); // no combination filtered
 
         // filter - max 3 RAs
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 3, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, 3, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(7, filteredNaCombination.size()); // one combination filtered
         assertFalse(filteredNaCombination.containsKey(comb3Be));
 
         // max 2 RAs
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 2, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, 2, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(4, filteredNaCombination.size());
@@ -203,7 +202,7 @@ class SearchTreeBloomerTest {
         assertTrue(filteredNaCombination.containsKey(indNl1));
 
         // max 1 RAs
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 1, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network,  1, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(0, filteredNaCombination.size()); // all combination filtered
@@ -226,7 +225,7 @@ class SearchTreeBloomerTest {
 
         // filter - max 2 topo in FR and DE
         Map<String, Integer> maxTopoPerTso = Map.of("fr", 2, "be", 2);
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,  Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>(), pState);
         Map<NetworkActionCombination, Boolean> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(6, filteredNaCombination.size()); // 2 combinations filtered
@@ -235,7 +234,7 @@ class SearchTreeBloomerTest {
 
         // filter - max 1 topo in FR
         maxTopoPerTso = Map.of("fr", 1);
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network,  Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(4, filteredNaCombination.size()); // 4 combinations filtered
@@ -246,7 +245,7 @@ class SearchTreeBloomerTest {
 
         // filter - max 1 RA in FR and max 2 RA in BE
         Map<String, Integer> maxRaPerTso = Map.of("fr", 1, "be", 2);
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), maxRaPerTso, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network,  Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), maxRaPerTso, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(3, filteredNaCombination.size());
@@ -257,7 +256,7 @@ class SearchTreeBloomerTest {
         // filter - max 2 topo in FR, max 0 topo in Nl and max 1 RA in BE
         maxTopoPerTso = Map.of("fr", 2, "nl", 0);
         maxRaPerTso = Map.of("be", 1);
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network,  Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(3, filteredNaCombination.size());
@@ -268,7 +267,7 @@ class SearchTreeBloomerTest {
         // filter - no RA in NL
         maxTopoPerTso = Map.of("fr", 10, "nl", 10, "be", 10);
         maxRaPerTso = Map.of("nl", 0);
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network,  Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(5, filteredNaCombination.size());
@@ -290,20 +289,20 @@ class SearchTreeBloomerTest {
         Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Collections.singleton(naFr1));
 
         // max 3 TSOs
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, 3, null, null, false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,  Integer.MAX_VALUE, 3, null, null, false, 0, new ArrayList<>(), pState);
         Map<NetworkActionCombination, Boolean> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
 
         assertEquals(8, filteredNaCombination.size()); // no combination filtered
 
         // max 2 TSOs
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, 2, null, null, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network,  Integer.MAX_VALUE, 2, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
 
         assertEquals(7, filteredNaCombination.size());
         assertFalse(filteredNaCombination.containsKey(comb2BeNl)); // one combination filtered
 
         // max 1 TSO
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, 1, null, null, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network,  Integer.MAX_VALUE, 1, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
 
         assertEquals(3, filteredNaCombination.size());
@@ -326,7 +325,7 @@ class SearchTreeBloomerTest {
 
         // test - no border cross, most limiting element is in BE/FR
         Mockito.when(previousLeaf.getMostLimitingElements(1)).thenReturn(List.of(crac.getFlowCnec("cnec1basecase"))); // be fr
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, true, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,  Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, true, 0, new ArrayList<>(), pState);
         Map<NetworkActionCombination, Boolean> filteredNaCombination = bloomer.removeCombinationsFarFromMostLimitingElement(naCombinations, previousLeaf);
 
         assertEquals(7, filteredNaCombination.size());
@@ -340,22 +339,24 @@ class SearchTreeBloomerTest {
 
         assertEquals(6, filteredNaCombination.size());
         List<NetworkActionCombination> list2 = List.of(indFr2, indDe1, indFrDe, indDeNl, comb2De, comb2FrDeBe);
-        list2.forEach(na -> assertTrue(finalFilteredNaCombination.containsKey(na)));
+        Map<NetworkActionCombination, Boolean> finalFilteredNaCombination2 = filteredNaCombination;
+        list2.forEach(na -> assertTrue(finalFilteredNaCombination2.containsKey(na)));
 
         // test - max 1 border cross, most limiting element is in BE
         Mockito.when(previousLeaf.getMostLimitingElements(1)).thenReturn(List.of(crac.getFlowCnec("cnecBe"))); // be
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network,  0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsFarFromMostLimitingElement(naCombinations, previousLeaf);
 
         assertEquals(9, filteredNaCombination.size());
         List<NetworkActionCombination> list3 = List.of(indFr2, indBe1, indNl1, indNlBe, indFrDe, indDeNl, comb3Be, comb2FrDeBe, comb2BeNl);
-        list3.forEach(na -> assertTrue(finalFilteredNaCombination.containsKey(na)));
+        Map<NetworkActionCombination, Boolean> finalFilteredNaCombination3 = filteredNaCombination;
+        list3.forEach(na -> assertTrue(finalFilteredNaCombination3.containsKey(na)));
     }
 
     @Test
     void testGetOptimizedMostLimitingElementsLocation() {
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,  0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
 
         Leaf leaf = mock(Leaf.class);
         Mockito.when(leaf.getVirtualCostNames()).thenReturn(Set.of("mnec", "lf"));
@@ -401,7 +402,7 @@ class SearchTreeBloomerTest {
         boundaries.add(new CountryBoundary(Country.DE, Country.AT));
         CountryGraph countryGraph = new CountryGraph(boundaries);
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,  0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.empty()), countryGraph));
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.FR)), countryGraph));
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.BE)), countryGraph));
@@ -409,11 +410,11 @@ class SearchTreeBloomerTest {
         assertFalse(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.AT)), countryGraph));
         assertTrue(bloomer.isNetworkActionCloseToLocations(na2, Set.of(Optional.of(Country.AT)), countryGraph));
 
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network,  0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>(), pState);
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.DE)), countryGraph));
         assertFalse(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.AT)), countryGraph));
 
-        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, true, 2, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network,  0, Integer.MAX_VALUE, null, null, true, 2, new ArrayList<>(), pState);
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.AT)), countryGraph));
     }
 
@@ -430,7 +431,7 @@ class SearchTreeBloomerTest {
         Mockito.when(leaf.getOptimizedSetpoint(raBe1, pState)).thenReturn(5.);
         Mockito.when(leaf.getOptimizedSetpoint(nonActivatedRa, pState)).thenReturn(0.);
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,  0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         Set<String> activatedTsos = bloomer.getTsosWithActivatedNetworkActions(leaf);
 
         // only network actions count when counting activated RAs in previous leaf
@@ -441,8 +442,10 @@ class SearchTreeBloomerTest {
     void testDoNotRemoveCombinationDetectedInRao() {
         NetworkAction na1 = Mockito.mock(NetworkAction.class);
         NetworkAction na2 = Mockito.mock(NetworkAction.class);
+        Mockito.when(na1.getOperator()).thenReturn("fake_tso");
+        Mockito.when(na2.getOperator()).thenReturn("fake_tso");
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class),
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,
             Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), new HashMap<>(), false, 0,
             List.of(new NetworkActionCombination(Set.of(na2), true)), pState);
         Leaf leaf = Mockito.mock(Leaf.class);
@@ -475,8 +478,10 @@ class SearchTreeBloomerTest {
     void testFilterIdenticalCombinations() {
         NetworkAction na1 = Mockito.mock(NetworkAction.class);
         NetworkAction na2 = Mockito.mock(NetworkAction.class);
+        Mockito.when(na1.getOperator()).thenReturn("fake_tso");
+        Mockito.when(na2.getOperator()).thenReturn("fake_tso");
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class),
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,
             Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), new HashMap<>(), false, 0,
                 List.of(new NetworkActionCombination(Set.of(na1, na2), false),
                         new NetworkActionCombination(Set.of(na1, na2), false),

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomerTest.java
@@ -128,7 +128,9 @@ class SearchTreeBloomerTest {
     void testRemoveAlreadyActivatedNetworkActions() {
 
         // arrange naCombination list
-        List<NetworkActionCombination> naCombinations = List.of(indFr1, indFr2, indBe1, indFrDe, comb3Fr, comb2Fr, comb2FrDeBe);
+        List<NetworkActionCombination> listOfNaCombinations = List.of(indFr1, indFr2, indBe1, indFrDe, comb3Fr, comb2Fr, comb2FrDeBe);
+        Map<NetworkActionCombination, Boolean> naCombinations = new HashMap<>();
+        listOfNaCombinations.forEach(na -> naCombinations.put(na, false));
 
         // arrange previous Leaf -> naFr1 has already been activated
         Leaf previousLeaf = mock(Leaf.class);
@@ -136,18 +138,20 @@ class SearchTreeBloomerTest {
 
         // filter already activated NetworkAction
         SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
-        List<NetworkActionCombination> filteredNaCombinations = bloomer.removeAlreadyActivatedNetworkActions(naCombinations, previousLeaf);
+        Map<NetworkActionCombination, Boolean> filteredNaCombinations = bloomer.removeAlreadyActivatedNetworkActions(naCombinations, previousLeaf);
 
         assertEquals(5, filteredNaCombinations.size());
-        assertFalse(filteredNaCombinations.contains(indFr1));
-        assertFalse(filteredNaCombinations.contains(comb3Fr));
+        assertFalse(filteredNaCombinations.containsKey(indFr1));
+        assertFalse(filteredNaCombinations.containsKey(comb3Fr));
     }
 
     @Test
     void testRemoveAlreadyTestedCombinations() {
 
         // arrange naCombination list
-        List<NetworkActionCombination> naCombinations = List.of(indFr2, indBe2, indNl1, indDe1, indFrDe, comb2Fr, comb2FrNl);
+        List<NetworkActionCombination> listOfNaCombinations = List.of(indFr2, indBe2, indNl1, indDe1, indFrDe, comb2Fr, comb2FrNl);
+        Map<NetworkActionCombination, Boolean> naCombinations = new HashMap<>();
+        listOfNaCombinations.forEach(na -> naCombinations.put(na, false));
         List<NetworkActionCombination> preDefinedNaCombinations = List.of(comb2Fr, comb3Fr, comb3Be, comb2BeNl, comb2FrNl, comb2FrDeBe);
 
         // arrange previous Leaf -> naFr1 has already been activated
@@ -156,18 +160,20 @@ class SearchTreeBloomerTest {
 
         // filter already tested combinations
         SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, false, 0, preDefinedNaCombinations, pState);
-        List<NetworkActionCombination> filteredNaCombinations = bloomer.removeAlreadyTestedCombinations(naCombinations, previousLeaf);
+        Map<NetworkActionCombination, Boolean> filteredNaCombinations = bloomer.removeAlreadyTestedCombinations(naCombinations, previousLeaf);
 
         assertEquals(5, filteredNaCombinations.size());
-        assertFalse(filteredNaCombinations.contains(indNl1)); // already tested within preDefined comb2BeNl
-        assertFalse(filteredNaCombinations.contains(indFrDe)); // already tested within preDefined comb2FrDeBe
+        assertFalse(filteredNaCombinations.containsKey(indNl1)); // already tested within preDefined comb2BeNl
+        assertFalse(filteredNaCombinations.containsKey(indFrDe)); // already tested within preDefined comb2FrDeBe
     }
 
     @Test
     void testRemoveCombinationsWhichExceedMaxNumberOfRa() {
 
         // arrange naCombination list
-        List<NetworkActionCombination> naCombinations = List.of(indFr2, indBe1, indNlBe, indNl1, comb2Fr, comb3Be, comb2BeNl, comb2FrDeBe);
+        List<NetworkActionCombination> listOfNaCombinations = List.of(indFr2, indBe1, indNlBe, indNl1, comb2Fr, comb3Be, comb2BeNl, comb2FrDeBe);
+        Map<NetworkActionCombination, Boolean> naCombinations = new HashMap<>();
+        listOfNaCombinations.forEach(na -> naCombinations.put(na, false));
 
         // arrange previous Leaf -> naFr1 has already been activated
         Leaf previousLeaf = Mockito.mock(Leaf.class);
@@ -175,7 +181,7 @@ class SearchTreeBloomerTest {
 
         // filter - max 4 RAs
         SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 4, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
-        List<NetworkActionCombination> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
+        Map<NetworkActionCombination, Boolean> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(8, filteredNaCombination.size()); // no combination filtered
 
@@ -184,17 +190,17 @@ class SearchTreeBloomerTest {
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(7, filteredNaCombination.size()); // one combination filtered
-        assertFalse(filteredNaCombination.contains(comb3Be));
+        assertFalse(filteredNaCombination.containsKey(comb3Be));
 
         // max 2 RAs
         bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 2, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(4, filteredNaCombination.size());
-        assertTrue(filteredNaCombination.contains(indFr2));
-        assertTrue(filteredNaCombination.contains(indBe1));
-        assertTrue(filteredNaCombination.contains(indNlBe));
-        assertTrue(filteredNaCombination.contains(indNl1));
+        assertTrue(filteredNaCombination.containsKey(indFr2));
+        assertTrue(filteredNaCombination.containsKey(indBe1));
+        assertTrue(filteredNaCombination.containsKey(indNlBe));
+        assertTrue(filteredNaCombination.containsKey(indNl1));
 
         // max 1 RAs
         bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 1, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
@@ -207,7 +213,9 @@ class SearchTreeBloomerTest {
     void testRemoveCombinationsWhichExceedMaxNumberOfRaPerTso() {
 
         // arrange naCombination list
-        List<NetworkActionCombination> naCombinations = List.of(indFr2, indBe1, indNl1, indFrDe, comb2Fr, comb3Be, comb2BeNl, comb2FrNl);
+        List<NetworkActionCombination> listOfNaCombinations = List.of(indFr2, indBe1, indNl1, indFrDe, comb2Fr, comb3Be, comb2BeNl, comb2FrNl);
+        Map<NetworkActionCombination, Boolean> naCombinations = new HashMap<>();
+        listOfNaCombinations.forEach(na -> naCombinations.put(na, false));
 
         // arrange Leaf -> naFr1 and raBe1 have already been activated in previous leaf
         // but only naFr1 should count
@@ -219,11 +227,11 @@ class SearchTreeBloomerTest {
         // filter - max 2 topo in FR and DE
         Map<String, Integer> maxTopoPerTso = Map.of("fr", 2, "be", 2);
         SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>(), pState);
-        List<NetworkActionCombination> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
+        Map<NetworkActionCombination, Boolean> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(6, filteredNaCombination.size()); // 2 combinations filtered
-        assertFalse(filteredNaCombination.contains(comb2Fr));
-        assertFalse(filteredNaCombination.contains(comb3Be));
+        assertFalse(filteredNaCombination.containsKey(comb2Fr));
+        assertFalse(filteredNaCombination.containsKey(comb3Be));
 
         // filter - max 1 topo in FR
         maxTopoPerTso = Map.of("fr", 1);
@@ -231,10 +239,10 @@ class SearchTreeBloomerTest {
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(4, filteredNaCombination.size()); // 4 combinations filtered
-        assertTrue(filteredNaCombination.contains(indBe1));
-        assertTrue(filteredNaCombination.contains(indNl1));
-        assertTrue(filteredNaCombination.contains(comb3Be));
-        assertTrue(filteredNaCombination.contains(comb2BeNl));
+        assertTrue(filteredNaCombination.containsKey(indBe1));
+        assertTrue(filteredNaCombination.containsKey(indNl1));
+        assertTrue(filteredNaCombination.containsKey(comb3Be));
+        assertTrue(filteredNaCombination.containsKey(comb2BeNl));
 
         // filter - max 1 RA in FR and max 2 RA in BE
         Map<String, Integer> maxRaPerTso = Map.of("fr", 1, "be", 2);
@@ -242,9 +250,9 @@ class SearchTreeBloomerTest {
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(3, filteredNaCombination.size());
-        assertTrue(filteredNaCombination.contains(indBe1));
-        assertTrue(filteredNaCombination.contains(indNl1));
-        assertTrue(filteredNaCombination.contains(comb2BeNl));
+        assertTrue(filteredNaCombination.containsKey(indBe1));
+        assertTrue(filteredNaCombination.containsKey(indNl1));
+        assertTrue(filteredNaCombination.containsKey(comb2BeNl));
 
         // filter - max 2 topo in FR, max 0 topo in Nl and max 1 RA in BE
         maxTopoPerTso = Map.of("fr", 2, "nl", 0);
@@ -253,9 +261,9 @@ class SearchTreeBloomerTest {
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(3, filteredNaCombination.size());
-        assertTrue(filteredNaCombination.contains(indFr2));
-        assertTrue(filteredNaCombination.contains(indFrDe));
-        assertTrue(filteredNaCombination.contains(indBe1));
+        assertTrue(filteredNaCombination.containsKey(indFr2));
+        assertTrue(filteredNaCombination.containsKey(indFrDe));
+        assertTrue(filteredNaCombination.containsKey(indBe1));
 
         // filter - no RA in NL
         maxTopoPerTso = Map.of("fr", 10, "nl", 10, "be", 10);
@@ -264,16 +272,18 @@ class SearchTreeBloomerTest {
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(5, filteredNaCombination.size());
-        assertFalse(filteredNaCombination.contains(indNl1));
-        assertFalse(filteredNaCombination.contains(comb2BeNl));
-        assertFalse(filteredNaCombination.contains(comb2FrNl));
+        assertFalse(filteredNaCombination.containsKey(indNl1));
+        assertFalse(filteredNaCombination.containsKey(comb2BeNl));
+        assertFalse(filteredNaCombination.containsKey(comb2FrNl));
     }
 
     @Test
     void testRemoveCombinationsWhichExceedMaxNumberOfTsos() {
 
         // arrange naCombination list
-        List<NetworkActionCombination> naCombinations = List.of(indFr2, indBe1, indNl1, indFrDe, comb2Fr, comb3Be, comb2BeNl, comb2FrNl);
+        List<NetworkActionCombination> listOfNaCombinations = List.of(indFr2, indBe1, indNl1, indFrDe, comb2Fr, comb3Be, comb2BeNl, comb2FrNl);
+        Map<NetworkActionCombination, Boolean> naCombinations = new HashMap<>();
+        listOfNaCombinations.forEach(na -> naCombinations.put(na, false));
 
         // arrange previous Leaf -> naFr1 has already been activated
         Leaf previousLeaf = Mockito.mock(Leaf.class);
@@ -281,7 +291,7 @@ class SearchTreeBloomerTest {
 
         // max 3 TSOs
         SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, 3, null, null, false, 0, new ArrayList<>(), pState);
-        List<NetworkActionCombination> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
+        Map<NetworkActionCombination, Boolean> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
 
         assertEquals(8, filteredNaCombination.size()); // no combination filtered
 
@@ -290,23 +300,25 @@ class SearchTreeBloomerTest {
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
 
         assertEquals(7, filteredNaCombination.size());
-        assertFalse(filteredNaCombination.contains(comb2BeNl)); // one combination filtered
+        assertFalse(filteredNaCombination.containsKey(comb2BeNl)); // one combination filtered
 
         // max 1 TSO
         bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, 1, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
 
         assertEquals(3, filteredNaCombination.size());
-        assertTrue(filteredNaCombination.contains(indFr2));
-        assertTrue(filteredNaCombination.contains(indFrDe));
-        assertTrue(filteredNaCombination.contains(comb2Fr));
+        assertTrue(filteredNaCombination.containsKey(indFr2));
+        assertTrue(filteredNaCombination.containsKey(indFrDe));
+        assertTrue(filteredNaCombination.containsKey(comb2Fr));
     }
 
     @Test
     void testRemoveNetworkActionsFarFromMostLimitingElement() {
 
         // arrange naCombination list
-        List<NetworkActionCombination> naCombinations = List.of(indFr2, indDe1, indBe1, indNl1, indNlBe, indFrDe, indDeNl, comb3Be, comb2De, comb2FrDeBe, comb2BeNl);
+        List<NetworkActionCombination> listOfNaCombinations = List.of(indFr2, indDe1, indBe1, indNl1, indNlBe, indFrDe, indDeNl, comb3Be, comb2De, comb2FrDeBe, comb2BeNl);
+        Map<NetworkActionCombination, Boolean> naCombinations = new HashMap<>();
+        listOfNaCombinations.forEach(na -> naCombinations.put(na, false));
 
         // arrange previous Leaf -> most limiting element is in DE/FR
         Leaf previousLeaf = mock(Leaf.class);
@@ -315,17 +327,20 @@ class SearchTreeBloomerTest {
         // test - no border cross, most limiting element is in BE/FR
         Mockito.when(previousLeaf.getMostLimitingElements(1)).thenReturn(List.of(crac.getFlowCnec("cnec1basecase"))); // be fr
         SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, true, 0, new ArrayList<>(), pState);
-        List<NetworkActionCombination> filteredNaCombination = bloomer.removeCombinationsFarFromMostLimitingElement(naCombinations, previousLeaf);
+        Map<NetworkActionCombination, Boolean> filteredNaCombination = bloomer.removeCombinationsFarFromMostLimitingElement(naCombinations, previousLeaf);
 
         assertEquals(7, filteredNaCombination.size());
-        assertTrue(filteredNaCombination.containsAll(List.of(indFr2, indBe1, indNlBe, indFrDe, comb3Be, comb2FrDeBe, comb2BeNl)));
+        List<NetworkActionCombination> list1 = List.of(indFr2, indBe1, indNlBe, indFrDe, comb3Be, comb2FrDeBe, comb2BeNl);
+        Map<NetworkActionCombination, Boolean> finalFilteredNaCombination = filteredNaCombination;
+        list1.forEach(na -> assertTrue(finalFilteredNaCombination.containsKey(na)));
 
         // test - no border cross, most limiting element is in DE/FR
         Mockito.when(previousLeaf.getMostLimitingElements(1)).thenReturn(List.of(crac.getFlowCnec("cnec2basecase"))); // de fr
         filteredNaCombination = bloomer.removeCombinationsFarFromMostLimitingElement(naCombinations, previousLeaf);
 
         assertEquals(6, filteredNaCombination.size());
-        assertTrue(filteredNaCombination.containsAll(List.of(indFr2, indDe1, indFrDe, indDeNl, comb2De, comb2FrDeBe)));
+        List<NetworkActionCombination> list2 = List.of(indFr2, indDe1, indFrDe, indDeNl, comb2De, comb2FrDeBe);
+        list2.forEach(na -> assertTrue(finalFilteredNaCombination.containsKey(na)));
 
         // test - max 1 border cross, most limiting element is in BE
         Mockito.when(previousLeaf.getMostLimitingElements(1)).thenReturn(List.of(crac.getFlowCnec("cnecBe"))); // be
@@ -333,7 +348,8 @@ class SearchTreeBloomerTest {
         filteredNaCombination = bloomer.removeCombinationsFarFromMostLimitingElement(naCombinations, previousLeaf);
 
         assertEquals(9, filteredNaCombination.size());
-        assertTrue(filteredNaCombination.containsAll(List.of(indFr2, indBe1, indNl1, indNlBe, indFrDe, indDeNl, comb3Be, comb2FrDeBe, comb2BeNl)));
+        List<NetworkActionCombination> list3 = List.of(indFr2, indBe1, indNl1, indNlBe, indFrDe, indDeNl, comb3Be, comb2FrDeBe, comb2BeNl);
+        list3.forEach(na -> assertTrue(finalFilteredNaCombination.containsKey(na)));
     }
 
     @Test
@@ -431,10 +447,10 @@ class SearchTreeBloomerTest {
             List.of(new NetworkActionCombination(Set.of(na2), true)), pState);
         Leaf leaf = Mockito.mock(Leaf.class);
         Mockito.when(leaf.getActivatedNetworkActions()).thenReturn(Collections.emptySet());
-        List<NetworkActionCombination> result = bloomer.bloom(leaf, Set.of(na1, na2));
+        Map<NetworkActionCombination, Boolean> result = bloomer.bloom(leaf, Set.of(na1, na2));
         assertEquals(2, result.size());
-        assertTrue(result.stream().anyMatch(naCombi -> naCombi.getNetworkActionSet().size() == 1 && naCombi.getNetworkActionSet().contains(na1)));
-        assertTrue(result.stream().anyMatch(naCombi -> naCombi.getNetworkActionSet().size() == 1 && naCombi.getNetworkActionSet().contains(na2)));
+        assertTrue(result.keySet().stream().anyMatch(naCombi -> naCombi.getNetworkActionSet().size() == 1 && naCombi.getNetworkActionSet().contains(na1)));
+        assertTrue(result.keySet().stream().anyMatch(naCombi -> naCombi.getNetworkActionSet().size() == 1 && naCombi.getNetworkActionSet().contains(na2)));
     }
 
     private NetworkAction createNetworkActionWithOperator(String networkElementId, String operator) {
@@ -468,7 +484,7 @@ class SearchTreeBloomerTest {
         );
         Leaf leaf = Mockito.mock(Leaf.class);
         Mockito.when(leaf.getActivatedNetworkActions()).thenReturn(Collections.emptySet());
-        List<NetworkActionCombination> result = bloomer.bloom(leaf, Set.of(na1, na2));
+        Map<NetworkActionCombination, Boolean> result = bloomer.bloom(leaf, Set.of(na1, na2));
         assertEquals(4, result.size());
     }
 }

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomerTest.java
@@ -22,6 +22,7 @@ import com.farao_community.farao.data.crac_api.usage_rule.UsageMethod;
 import com.farao_community.farao.data.crac_impl.utils.CommonCracCreation;
 import com.farao_community.farao.data.crac_impl.utils.NetworkImportsUtil;
 import com.farao_community.farao.search_tree_rao.commons.NetworkActionCombination;
+import com.farao_community.farao.search_tree_rao.result.api.RangeActionSetpointResult;
 import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import org.junit.jupiter.api.BeforeEach;
@@ -134,7 +135,7 @@ class SearchTreeBloomerTest {
         Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Collections.singleton(naFr1));
 
         // filter already activated NetworkAction
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>());
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         List<NetworkActionCombination> filteredNaCombinations = bloomer.removeAlreadyActivatedNetworkActions(naCombinations, previousLeaf);
 
         assertEquals(5, filteredNaCombinations.size());
@@ -154,7 +155,7 @@ class SearchTreeBloomerTest {
         Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Set.of(naFr1, naBe1));
 
         // filter already tested combinations
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, false, 0, preDefinedNaCombinations);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, false, 0, preDefinedNaCombinations, pState);
         List<NetworkActionCombination> filteredNaCombinations = bloomer.removeAlreadyTestedCombinations(naCombinations, previousLeaf);
 
         assertEquals(5, filteredNaCombinations.size());
@@ -173,20 +174,20 @@ class SearchTreeBloomerTest {
         Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Collections.singleton(naFr1));
 
         // filter - max 4 RAs
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, 4, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>());
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 4, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         List<NetworkActionCombination> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(8, filteredNaCombination.size()); // no combination filtered
 
         // filter - max 3 RAs
-        bloomer = new SearchTreeBloomer(network, 3, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>());
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 3, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(7, filteredNaCombination.size()); // one combination filtered
         assertFalse(filteredNaCombination.contains(comb3Be));
 
         // max 2 RAs
-        bloomer = new SearchTreeBloomer(network, 2, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>());
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 2, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(4, filteredNaCombination.size());
@@ -196,7 +197,7 @@ class SearchTreeBloomerTest {
         assertTrue(filteredNaCombination.contains(indNl1));
 
         // max 1 RAs
-        bloomer = new SearchTreeBloomer(network, 1, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>());
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 1, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(0, filteredNaCombination.size()); // all combination filtered
@@ -217,7 +218,7 @@ class SearchTreeBloomerTest {
 
         // filter - max 2 topo in FR and DE
         Map<String, Integer> maxTopoPerTso = Map.of("fr", 2, "be", 2);
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>());
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>(), pState);
         List<NetworkActionCombination> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(6, filteredNaCombination.size()); // 2 combinations filtered
@@ -226,7 +227,7 @@ class SearchTreeBloomerTest {
 
         // filter - max 1 topo in FR
         maxTopoPerTso = Map.of("fr", 1);
-        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>());
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(4, filteredNaCombination.size()); // 4 combinations filtered
@@ -237,7 +238,7 @@ class SearchTreeBloomerTest {
 
         // filter - max 1 RA in FR and max 2 RA in BE
         Map<String, Integer> maxRaPerTso = Map.of("fr", 1, "be", 2);
-        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), maxRaPerTso, false, 0, new ArrayList<>());
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), maxRaPerTso, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(3, filteredNaCombination.size());
@@ -248,7 +249,7 @@ class SearchTreeBloomerTest {
         // filter - max 2 topo in FR, max 0 topo in Nl and max 1 RA in BE
         maxTopoPerTso = Map.of("fr", 2, "nl", 0);
         maxRaPerTso = Map.of("be", 1);
-        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>());
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(3, filteredNaCombination.size());
@@ -259,7 +260,7 @@ class SearchTreeBloomerTest {
         // filter - no RA in NL
         maxTopoPerTso = Map.of("fr", 10, "nl", 10, "be", 10);
         maxRaPerTso = Map.of("nl", 0);
-        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>());
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(5, filteredNaCombination.size());
@@ -279,20 +280,20 @@ class SearchTreeBloomerTest {
         Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Collections.singleton(naFr1));
 
         // max 3 TSOs
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, 3, null, null, false, 0, new ArrayList<>());
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, 3, null, null, false, 0, new ArrayList<>(), pState);
         List<NetworkActionCombination> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
 
         assertEquals(8, filteredNaCombination.size()); // no combination filtered
 
         // max 2 TSOs
-        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, 2, null, null, false, 0, new ArrayList<>());
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, 2, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
 
         assertEquals(7, filteredNaCombination.size());
         assertFalse(filteredNaCombination.contains(comb2BeNl)); // one combination filtered
 
         // max 1 TSO
-        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, 1, null, null, false, 0, new ArrayList<>());
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, 1, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
 
         assertEquals(3, filteredNaCombination.size());
@@ -313,7 +314,7 @@ class SearchTreeBloomerTest {
 
         // test - no border cross, most limiting element is in BE/FR
         Mockito.when(previousLeaf.getMostLimitingElements(1)).thenReturn(List.of(crac.getFlowCnec("cnec1basecase"))); // be fr
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, true, 0, new ArrayList<>());
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, true, 0, new ArrayList<>(), pState);
         List<NetworkActionCombination> filteredNaCombination = bloomer.removeCombinationsFarFromMostLimitingElement(naCombinations, previousLeaf);
 
         assertEquals(7, filteredNaCombination.size());
@@ -328,7 +329,7 @@ class SearchTreeBloomerTest {
 
         // test - max 1 border cross, most limiting element is in BE
         Mockito.when(previousLeaf.getMostLimitingElements(1)).thenReturn(List.of(crac.getFlowCnec("cnecBe"))); // be
-        bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>());
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsFarFromMostLimitingElement(naCombinations, previousLeaf);
 
         assertEquals(9, filteredNaCombination.size());
@@ -338,7 +339,7 @@ class SearchTreeBloomerTest {
     @Test
     void testGetOptimizedMostLimitingElementsLocation() {
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>());
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
 
         Leaf leaf = mock(Leaf.class);
         Mockito.when(leaf.getVirtualCostNames()).thenReturn(Set.of("mnec", "lf"));
@@ -384,7 +385,7 @@ class SearchTreeBloomerTest {
         boundaries.add(new CountryBoundary(Country.DE, Country.AT));
         CountryGraph countryGraph = new CountryGraph(boundaries);
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>());
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.empty()), countryGraph));
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.FR)), countryGraph));
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.BE)), countryGraph));
@@ -392,11 +393,11 @@ class SearchTreeBloomerTest {
         assertFalse(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.AT)), countryGraph));
         assertTrue(bloomer.isNetworkActionCloseToLocations(na2, Set.of(Optional.of(Country.AT)), countryGraph));
 
-        bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>());
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>(), pState);
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.DE)), countryGraph));
         assertFalse(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.AT)), countryGraph));
 
-        bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, true, 2, new ArrayList<>());
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, true, 2, new ArrayList<>(), pState);
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.AT)), countryGraph));
     }
 
@@ -413,7 +414,7 @@ class SearchTreeBloomerTest {
         Mockito.when(leaf.getOptimizedSetpoint(raBe1, pState)).thenReturn(5.);
         Mockito.when(leaf.getOptimizedSetpoint(nonActivatedRa, pState)).thenReturn(0.);
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>());
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         Set<String> activatedTsos = bloomer.getTsosWithActivatedNetworkActions(leaf);
 
         // only network actions count when counting activated RAs in previous leaf
@@ -425,9 +426,9 @@ class SearchTreeBloomerTest {
         NetworkAction na1 = Mockito.mock(NetworkAction.class);
         NetworkAction na2 = Mockito.mock(NetworkAction.class);
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class),
             Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), new HashMap<>(), false, 0,
-            List.of(new NetworkActionCombination(Set.of(na2), true)));
+            List.of(new NetworkActionCombination(Set.of(na2), true)), pState);
         Leaf leaf = Mockito.mock(Leaf.class);
         Mockito.when(leaf.getActivatedNetworkActions()).thenReturn(Collections.emptySet());
         List<NetworkActionCombination> result = bloomer.bloom(leaf, Set.of(na1, na2));
@@ -459,11 +460,11 @@ class SearchTreeBloomerTest {
         NetworkAction na1 = Mockito.mock(NetworkAction.class);
         NetworkAction na2 = Mockito.mock(NetworkAction.class);
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class),
             Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), new HashMap<>(), false, 0,
                 List.of(new NetworkActionCombination(Set.of(na1, na2), false),
                         new NetworkActionCombination(Set.of(na1, na2), false),
-                        new NetworkActionCombination(Set.of(na1, na2), true))
+                        new NetworkActionCombination(Set.of(na1, na2), true)), pState
         );
         Leaf leaf = Mockito.mock(Leaf.class);
         Mockito.when(leaf.getActivatedNetworkActions()).thenReturn(Collections.emptySet());

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomerTest.java
@@ -22,6 +22,7 @@ import com.farao_community.farao.data.crac_api.usage_rule.UsageMethod;
 import com.farao_community.farao.data.crac_impl.utils.CommonCracCreation;
 import com.farao_community.farao.data.crac_impl.utils.NetworkImportsUtil;
 import com.farao_community.farao.search_tree_rao.commons.NetworkActionCombination;
+import com.farao_community.farao.search_tree_rao.result.api.RangeActionSetpointResult;
 import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,7 +32,6 @@ import org.mockito.Mockito;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -67,7 +67,6 @@ class SearchTreeBloomerTest {
     private NetworkActionCombination comb2BeNl;
     private NetworkActionCombination comb2FrNl;
     private NetworkActionCombination comb2FrDeBe;
-    private NetworkActionCombination comb3FrNlBe;
 
     @BeforeEach
     public void setUp() {
@@ -75,7 +74,21 @@ class SearchTreeBloomerTest {
         crac = CommonCracCreation.create();
         pState = crac.getPreventiveState();
 
-        crac.newFlowCnec().withId("cnecBe").withNetworkElement("BBE1AA1  BBE2AA1  1").withInstant(Instant.PREVENTIVE).withOptimized(true).withOperator("operator1").newThreshold().withUnit(Unit.MEGAWATT).withSide(Side.LEFT).withMin(-1500.).withMax(1500.).add().withNominalVoltage(380.).withIMax(5000.).add();
+        crac.newFlowCnec()
+            .withId("cnecBe")
+            .withNetworkElement("BBE1AA1  BBE2AA1  1")
+            .withInstant(Instant.PREVENTIVE)
+            .withOptimized(true)
+            .withOperator("operator1")
+            .newThreshold()
+            .withUnit(Unit.MEGAWATT)
+            .withSide(Side.LEFT)
+            .withMin(-1500.)
+            .withMax(1500.)
+            .add()
+            .withNominalVoltage(380.)
+            .withIMax(5000.)
+            .add();
 
         naFr1 = createNetworkActionWithOperator("FFR1AA1  FFR2AA1  1", "fr");
         naBe1 = createNetworkActionWithOperator("BBE1AA1  BBE2AA1  1", "be");
@@ -109,37 +122,32 @@ class SearchTreeBloomerTest {
         comb2BeNl = new NetworkActionCombination(Set.of(naBe1, naNl1));
         comb2FrNl = new NetworkActionCombination(Set.of(naFr2, naNl1));
         comb2FrDeBe = new NetworkActionCombination(Set.of(naFrDe, naBe1));
-        comb3FrNlBe = new NetworkActionCombination(Set.of(naFr2, naBe2, naNlBe));
     }
 
     @Test
     void testRemoveAlreadyActivatedNetworkActions() {
 
         // arrange naCombination list
-        List<NetworkActionCombination> listOfNaCombinations = List.of(indFr1, indFr2, indBe1, indFrDe, comb3Fr, comb2Fr, comb2FrDeBe);
-        Map<NetworkActionCombination, Boolean> naCombinations = new HashMap<>();
-        listOfNaCombinations.forEach(na -> naCombinations.put(na, false));
+        List<NetworkActionCombination> naCombinations = List.of(indFr1, indFr2, indBe1, indFrDe, comb3Fr, comb2Fr, comb2FrDeBe);
 
         // arrange previous Leaf -> naFr1 has already been activated
         Leaf previousLeaf = mock(Leaf.class);
         Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Collections.singleton(naFr1));
 
         // filter already activated NetworkAction
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
-        Map<NetworkActionCombination, Boolean> filteredNaCombinations = bloomer.removeAlreadyActivatedNetworkActions(naCombinations, previousLeaf);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        List<NetworkActionCombination> filteredNaCombinations = bloomer.removeAlreadyActivatedNetworkActions(naCombinations, previousLeaf);
 
         assertEquals(5, filteredNaCombinations.size());
-        assertFalse(filteredNaCombinations.containsKey(indFr1));
-        assertFalse(filteredNaCombinations.containsKey(comb3Fr));
+        assertFalse(filteredNaCombinations.contains(indFr1));
+        assertFalse(filteredNaCombinations.contains(comb3Fr));
     }
 
     @Test
     void testRemoveAlreadyTestedCombinations() {
 
         // arrange naCombination list
-        List<NetworkActionCombination> listOfNaCombinations = List.of(indFr2, indBe2, indNl1, indDe1, indFrDe, comb2Fr, comb2FrNl);
-        Map<NetworkActionCombination, Boolean> naCombinations = new HashMap<>();
-        listOfNaCombinations.forEach(na -> naCombinations.put(na, false));
+        List<NetworkActionCombination> naCombinations = List.of(indFr2, indBe2, indNl1, indDe1, indFrDe, comb2Fr, comb2FrNl);
         List<NetworkActionCombination> preDefinedNaCombinations = List.of(comb2Fr, comb3Fr, comb3Be, comb2BeNl, comb2FrNl, comb2FrDeBe);
 
         // arrange previous Leaf -> naFr1 has already been activated
@@ -147,74 +155,59 @@ class SearchTreeBloomerTest {
         Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Set.of(naFr1, naBe1));
 
         // filter already tested combinations
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, false, 0, preDefinedNaCombinations, pState);
-        Map<NetworkActionCombination, Boolean> filteredNaCombinations = bloomer.removeAlreadyTestedCombinations(naCombinations, previousLeaf);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, false, 0, preDefinedNaCombinations, pState);
+        List<NetworkActionCombination> filteredNaCombinations = bloomer.removeAlreadyTestedCombinations(naCombinations, previousLeaf);
 
         assertEquals(5, filteredNaCombinations.size());
-        assertFalse(filteredNaCombinations.containsKey(indNl1)); // already tested within preDefined comb2BeNl
-        assertFalse(filteredNaCombinations.containsKey(indFrDe)); // already tested within preDefined comb2FrDeBe
+        assertFalse(filteredNaCombinations.contains(indNl1)); // already tested within preDefined comb2BeNl
+        assertFalse(filteredNaCombinations.contains(indFrDe)); // already tested within preDefined comb2FrDeBe
     }
 
     @Test
     void testRemoveCombinationsWhichExceedMaxNumberOfRa() {
 
         // arrange naCombination list
-        List<NetworkActionCombination> listOfNaCombinations = List.of(indFr2, indBe1, indNlBe, indNl1, comb2Fr, comb3Be, comb2BeNl, comb2FrDeBe);
-        Map<NetworkActionCombination, Boolean> naCombinations = new HashMap<>();
-        listOfNaCombinations.forEach(na -> naCombinations.put(na, false));
+        List<NetworkActionCombination> naCombinations = List.of(indFr2, indBe1, indNlBe, indNl1, comb2Fr, comb3Be, comb2BeNl, comb2FrDeBe);
 
         // arrange previous Leaf -> naFr1 has already been activated
         Leaf previousLeaf = Mockito.mock(Leaf.class);
         Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Collections.singleton(naFr1));
 
         // filter - max 4 RAs
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, 4, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
-        Map<NetworkActionCombination, Boolean> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 4, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        List<NetworkActionCombination> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(8, filteredNaCombination.size()); // no combination filtered
 
         // filter - max 3 RAs
-        bloomer = new SearchTreeBloomer(network, 3, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 3, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(7, filteredNaCombination.size()); // one combination filtered
-        assertFalse(filteredNaCombination.containsKey(comb3Be));
+        assertFalse(filteredNaCombination.contains(comb3Be));
 
         // max 2 RAs
-        bloomer = new SearchTreeBloomer(network, 2, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 2, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(4, filteredNaCombination.size());
-        assertTrue(filteredNaCombination.containsKey(indFr2));
-        assertTrue(filteredNaCombination.containsKey(indBe1));
-        assertTrue(filteredNaCombination.containsKey(indNlBe));
-        assertTrue(filteredNaCombination.containsKey(indNl1));
+        assertTrue(filteredNaCombination.contains(indFr2));
+        assertTrue(filteredNaCombination.contains(indBe1));
+        assertTrue(filteredNaCombination.contains(indNlBe));
+        assertTrue(filteredNaCombination.contains(indNl1));
 
         // max 1 RAs
-        bloomer = new SearchTreeBloomer(network, 1, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 1, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(0, filteredNaCombination.size()); // all combination filtered
-
-        // check booleans in hashmap -> max 4 RAs
-        previousLeaf = Mockito.mock(Leaf.class);
-        bloomer = new SearchTreeBloomer(network, 4, Integer.MAX_VALUE, new HashMap<>(), new HashMap<>(), false, 0, new ArrayList<>(), pState);
-
-        Mockito.when(previousLeaf.getNumberOfActivatedRangeActions()).thenReturn(1L);
-        Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Set.of(naFr1, naBe1));
-
-        Map<NetworkActionCombination, Boolean> naToRemove = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
-        Map<NetworkActionCombination, Boolean> expectedResult = Map.of(indFr2, false, indBe1, false, indNlBe, false, indNl1, false, comb2Fr, true, comb2BeNl, true, comb2FrDeBe, true);
-        assertEquals(expectedResult, naToRemove);
     }
 
     @Test
     void testRemoveCombinationsWhichExceedMaxNumberOfRaPerTso() {
 
         // arrange naCombination list
-        List<NetworkActionCombination> listOfNaCombinations = List.of(indFr2, indBe2, indNl1, indFrDe, comb2Fr, comb3Be, comb2BeNl, comb2FrNl);
-        Map<NetworkActionCombination, Boolean> naCombinations = new HashMap<>();
-        listOfNaCombinations.forEach(na -> naCombinations.put(na, false));
+        List<NetworkActionCombination> naCombinations = List.of(indFr2, indBe1, indNl1, indFrDe, comb2Fr, comb3Be, comb2BeNl, comb2FrNl);
 
         // arrange Leaf -> naFr1 and raBe1 have already been activated in previous leaf
         // but only naFr1 should count
@@ -225,125 +218,95 @@ class SearchTreeBloomerTest {
 
         // filter - max 2 topo in FR and DE
         Map<String, Integer> maxTopoPerTso = Map.of("fr", 2, "be", 2);
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>(), pState);
-        Map<NetworkActionCombination, Boolean> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>(), pState);
+        List<NetworkActionCombination> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(6, filteredNaCombination.size()); // 2 combinations filtered
-        assertFalse(filteredNaCombination.containsKey(comb2Fr));
-        assertFalse(filteredNaCombination.containsKey(comb3Be));
+        assertFalse(filteredNaCombination.contains(comb2Fr));
+        assertFalse(filteredNaCombination.contains(comb3Be));
 
         // filter - max 1 topo in FR
         maxTopoPerTso = Map.of("fr", 1);
-        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(4, filteredNaCombination.size()); // 4 combinations filtered
-        assertTrue(filteredNaCombination.containsKey(indBe2));
-        assertTrue(filteredNaCombination.containsKey(indNl1));
-        assertTrue(filteredNaCombination.containsKey(comb3Be));
-        assertTrue(filteredNaCombination.containsKey(comb2BeNl));
+        assertTrue(filteredNaCombination.contains(indBe1));
+        assertTrue(filteredNaCombination.contains(indNl1));
+        assertTrue(filteredNaCombination.contains(comb3Be));
+        assertTrue(filteredNaCombination.contains(comb2BeNl));
 
         // filter - max 1 RA in FR and max 2 RA in BE
         Map<String, Integer> maxRaPerTso = Map.of("fr", 1, "be", 2);
-        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), maxRaPerTso, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), maxRaPerTso, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(3, filteredNaCombination.size());
-        assertTrue(filteredNaCombination.containsKey(indBe2));
-        assertTrue(filteredNaCombination.containsKey(indNl1));
-        assertTrue(filteredNaCombination.containsKey(comb2BeNl));
+        assertTrue(filteredNaCombination.contains(indBe1));
+        assertTrue(filteredNaCombination.contains(indNl1));
+        assertTrue(filteredNaCombination.contains(comb2BeNl));
 
         // filter - max 2 topo in FR, max 0 topo in Nl and max 1 RA in BE
         maxTopoPerTso = Map.of("fr", 2, "nl", 0);
         maxRaPerTso = Map.of("be", 1);
-        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(3, filteredNaCombination.size());
-        assertTrue(filteredNaCombination.containsKey(indFr2));
-        assertTrue(filteredNaCombination.containsKey(indFrDe));
-        assertTrue(filteredNaCombination.containsKey(indBe2));
+        assertTrue(filteredNaCombination.contains(indFr2));
+        assertTrue(filteredNaCombination.contains(indFrDe));
+        assertTrue(filteredNaCombination.contains(indBe1));
 
         // filter - no RA in NL
         maxTopoPerTso = Map.of("fr", 10, "nl", 10, "be", 10);
         maxRaPerTso = Map.of("nl", 0);
-        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(5, filteredNaCombination.size());
-        assertFalse(filteredNaCombination.containsKey(indNl1));
-        assertFalse(filteredNaCombination.containsKey(comb2BeNl));
-        assertFalse(filteredNaCombination.containsKey(comb2FrNl));
-
-        // check booleans in hashmap
-        //Map<NetworkActionCombination, Boolean> naCombinations = Map.of(indFr2, false, indBe2, false, comb3Be, false);
-        Leaf leaf = Mockito.mock(Leaf.class);
-        Mockito.when(leaf.getActivatedNetworkActions()).thenReturn(Set.of(naBe1));
-        Mockito.when(leaf.getActivatedRangeActions(Mockito.any(State.class))).thenReturn(Set.of(raBe1));
-
-        Map<String, Integer> maxNaPerTso = Map.of("fr", 1, "be", 2);
-        maxRaPerTso = Map.of("fr", 2, "be", 2);
-
-        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, maxNaPerTso, maxRaPerTso, false, 0, new ArrayList<>(), pState);
-        // indFr2, indBe1, indNl1, indFrDe, comb2Fr, comb3Be, comb2BeNl, comb2FrNl
-        Map<NetworkActionCombination, Boolean> naToRemove = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, leaf);
-        Map<NetworkActionCombination, Boolean> expectedResult = Map.of(indFr2, false, indBe2, true, indNl1, false, indFrDe, false, comb2BeNl, true, comb2FrNl, false);
-        assertEquals(expectedResult, naToRemove);
+        assertFalse(filteredNaCombination.contains(indNl1));
+        assertFalse(filteredNaCombination.contains(comb2BeNl));
+        assertFalse(filteredNaCombination.contains(comb2FrNl));
     }
 
     @Test
     void testRemoveCombinationsWhichExceedMaxNumberOfTsos() {
 
         // arrange naCombination list
-        List<NetworkActionCombination> listOfNaCombinations = List.of(indFr2, indBe1, indNl1, indFrDe, comb2Fr, comb3Be, comb2BeNl, comb2FrNl, comb3FrNlBe);
-        Map<NetworkActionCombination, Boolean> naCombinations = new HashMap<>();
-        listOfNaCombinations.forEach(na -> naCombinations.put(na, false));
+        List<NetworkActionCombination> naCombinations = List.of(indFr2, indBe1, indNl1, indFrDe, comb2Fr, comb3Be, comb2BeNl, comb2FrNl);
 
         // arrange previous Leaf -> naFr1 has already been activated
         Leaf previousLeaf = Mockito.mock(Leaf.class);
         Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Collections.singleton(naFr1));
 
         // max 3 TSOs
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, 3, null, null, false, 0, new ArrayList<>(), pState);
-        Map<NetworkActionCombination, Boolean> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, 3, null, null, false, 0, new ArrayList<>(), pState);
+        List<NetworkActionCombination> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
 
-        assertEquals(9, filteredNaCombination.size()); // no combination filtered
+        assertEquals(8, filteredNaCombination.size()); // no combination filtered
 
         // max 2 TSOs
-        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, 2, null, null, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, 2, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
 
         assertEquals(7, filteredNaCombination.size());
-        assertFalse(filteredNaCombination.containsKey(comb2BeNl)); // one combination filtered
+        assertFalse(filteredNaCombination.contains(comb2BeNl)); // one combination filtered
 
         // max 1 TSO
-        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, 1, null, null, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, 1, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
 
         assertEquals(3, filteredNaCombination.size());
-        assertTrue(filteredNaCombination.containsKey(indFr2));
-        assertTrue(filteredNaCombination.containsKey(indFrDe));
-        assertTrue(filteredNaCombination.containsKey(comb2Fr));
-
-        // check booleans in hashmap -> max 2 TSOs
-        Leaf leaf = Mockito.mock(Leaf.class);
-        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, 2, new HashMap<>(), new HashMap<>(), false, 0, new ArrayList<>(), pState);
-
-        Mockito.when(leaf.getActivatedNetworkActions()).thenReturn(Set.of(naFr1));
-        Mockito.when(leaf.getActivatedRangeActions(Mockito.any(State.class))).thenReturn(Set.of(raBe1));
-
-        Map<NetworkActionCombination, Boolean> naToRemove = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, leaf);
-        Map<NetworkActionCombination, Boolean> expectedResult = Map.of(indFr2, false, indBe1, false, indNl1, true, indFrDe, false, comb2Fr, false, comb3Be, false, comb2FrNl, true);
-        assertEquals(expectedResult, naToRemove);
+        assertTrue(filteredNaCombination.contains(indFr2));
+        assertTrue(filteredNaCombination.contains(indFrDe));
+        assertTrue(filteredNaCombination.contains(comb2Fr));
     }
 
     @Test
     void testRemoveNetworkActionsFarFromMostLimitingElement() {
 
         // arrange naCombination list
-        List<NetworkActionCombination> listOfNaCombinations = List.of(indFr2, indDe1, indBe1, indNl1, indNlBe, indFrDe, indDeNl, comb3Be, comb2De, comb2FrDeBe, comb2BeNl);
-        Map<NetworkActionCombination, Boolean> naCombinations = new HashMap<>();
-        listOfNaCombinations.forEach(na -> naCombinations.put(na, false));
+        List<NetworkActionCombination> naCombinations = List.of(indFr2, indDe1, indBe1, indNl1, indNlBe, indFrDe, indDeNl, comb3Be, comb2De, comb2FrDeBe, comb2BeNl);
 
         // arrange previous Leaf -> most limiting element is in DE/FR
         Leaf previousLeaf = mock(Leaf.class);
@@ -351,38 +314,32 @@ class SearchTreeBloomerTest {
 
         // test - no border cross, most limiting element is in BE/FR
         Mockito.when(previousLeaf.getMostLimitingElements(1)).thenReturn(List.of(crac.getFlowCnec("cnec1basecase"))); // be fr
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, true, 0, new ArrayList<>(), pState);
-        Map<NetworkActionCombination, Boolean> filteredNaCombination = bloomer.removeCombinationsFarFromMostLimitingElement(naCombinations, previousLeaf);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, true, 0, new ArrayList<>(), pState);
+        List<NetworkActionCombination> filteredNaCombination = bloomer.removeCombinationsFarFromMostLimitingElement(naCombinations, previousLeaf);
 
         assertEquals(7, filteredNaCombination.size());
-        List<NetworkActionCombination> list1 = List.of(indFr2, indBe1, indNlBe, indFrDe, comb3Be, comb2FrDeBe, comb2BeNl);
-        Map<NetworkActionCombination, Boolean> finalFilteredNaCombination = filteredNaCombination;
-        list1.forEach(na -> assertTrue(finalFilteredNaCombination.containsKey(na)));
+        assertTrue(filteredNaCombination.containsAll(List.of(indFr2, indBe1, indNlBe, indFrDe, comb3Be, comb2FrDeBe, comb2BeNl)));
 
         // test - no border cross, most limiting element is in DE/FR
         Mockito.when(previousLeaf.getMostLimitingElements(1)).thenReturn(List.of(crac.getFlowCnec("cnec2basecase"))); // de fr
         filteredNaCombination = bloomer.removeCombinationsFarFromMostLimitingElement(naCombinations, previousLeaf);
 
         assertEquals(6, filteredNaCombination.size());
-        List<NetworkActionCombination> list2 = List.of(indFr2, indDe1, indFrDe, indDeNl, comb2De, comb2FrDeBe);
-        Map<NetworkActionCombination, Boolean> finalFilteredNaCombination2 = filteredNaCombination;
-        list2.forEach(na -> assertTrue(finalFilteredNaCombination2.containsKey(na)));
+        assertTrue(filteredNaCombination.containsAll(List.of(indFr2, indDe1, indFrDe, indDeNl, comb2De, comb2FrDeBe)));
 
         // test - max 1 border cross, most limiting element is in BE
         Mockito.when(previousLeaf.getMostLimitingElements(1)).thenReturn(List.of(crac.getFlowCnec("cnecBe"))); // be
-        bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsFarFromMostLimitingElement(naCombinations, previousLeaf);
 
         assertEquals(9, filteredNaCombination.size());
-        List<NetworkActionCombination> list3 = List.of(indFr2, indBe1, indNl1, indNlBe, indFrDe, indDeNl, comb3Be, comb2FrDeBe, comb2BeNl);
-        Map<NetworkActionCombination, Boolean> finalFilteredNaCombination3 = filteredNaCombination;
-        list3.forEach(na -> assertTrue(finalFilteredNaCombination3.containsKey(na)));
+        assertTrue(filteredNaCombination.containsAll(List.of(indFr2, indBe1, indNl1, indNlBe, indFrDe, indDeNl, comb3Be, comb2FrDeBe, comb2BeNl)));
     }
 
     @Test
     void testGetOptimizedMostLimitingElementsLocation() {
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
 
         Leaf leaf = mock(Leaf.class);
         Mockito.when(leaf.getVirtualCostNames()).thenReturn(Set.of("mnec", "lf"));
@@ -415,7 +372,10 @@ class SearchTreeBloomerTest {
 
     @Test
     void testIsNetworkActionCloseToLocations() {
-        NetworkAction na1 = crac.newNetworkAction().withId("na").newTopologicalAction().withNetworkElement("BBE2AA1  FFR3AA1  1").withActionType(ActionType.OPEN).add().newOnInstantUsageRule().withUsageMethod(UsageMethod.AVAILABLE).withInstant(Instant.PREVENTIVE).add().add();
+        NetworkAction na1 = crac.newNetworkAction().withId("na")
+            .newTopologicalAction().withNetworkElement("BBE2AA1  FFR3AA1  1").withActionType(ActionType.OPEN).add()
+            .newOnInstantUsageRule().withUsageMethod(UsageMethod.AVAILABLE).withInstant(Instant.PREVENTIVE).add()
+            .add();
         NetworkAction na2 = mock(NetworkAction.class);
         Mockito.when(na2.getLocation(network)).thenReturn(Set.of(Optional.of(Country.FR), Optional.empty()));
 
@@ -425,7 +385,7 @@ class SearchTreeBloomerTest {
         boundaries.add(new CountryBoundary(Country.DE, Country.AT));
         CountryGraph countryGraph = new CountryGraph(boundaries);
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.empty()), countryGraph));
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.FR)), countryGraph));
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.BE)), countryGraph));
@@ -433,11 +393,11 @@ class SearchTreeBloomerTest {
         assertFalse(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.AT)), countryGraph));
         assertTrue(bloomer.isNetworkActionCloseToLocations(na2, Set.of(Optional.of(Country.AT)), countryGraph));
 
-        bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>(), pState);
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.DE)), countryGraph));
         assertFalse(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.AT)), countryGraph));
 
-        bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, true, 2, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, true, 2, new ArrayList<>(), pState);
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.AT)), countryGraph));
     }
 
@@ -454,7 +414,7 @@ class SearchTreeBloomerTest {
         Mockito.when(leaf.getOptimizedSetpoint(raBe1, pState)).thenReturn(5.);
         Mockito.when(leaf.getOptimizedSetpoint(nonActivatedRa, pState)).thenReturn(0.);
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class), 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         Set<String> activatedTsos = bloomer.getTsosWithActivatedNetworkActions(leaf);
 
         // only network actions count when counting activated RAs in previous leaf
@@ -465,40 +425,50 @@ class SearchTreeBloomerTest {
     void testDoNotRemoveCombinationDetectedInRao() {
         NetworkAction na1 = Mockito.mock(NetworkAction.class);
         NetworkAction na2 = Mockito.mock(NetworkAction.class);
-        Mockito.when(na1.getOperator()).thenReturn("fake_tso");
-        Mockito.when(na2.getOperator()).thenReturn("fake_tso");
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), new HashMap<>(), false, 0, List.of(new NetworkActionCombination(Set.of(na2), true)), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class),
+            Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), new HashMap<>(), false, 0,
+            List.of(new NetworkActionCombination(Set.of(na2), true)), pState);
         Leaf leaf = Mockito.mock(Leaf.class);
         Mockito.when(leaf.getActivatedNetworkActions()).thenReturn(Collections.emptySet());
-        Map<NetworkActionCombination, Boolean> result = bloomer.bloom(leaf, Set.of(na1, na2));
+        List<NetworkActionCombination> result = bloomer.bloom(leaf, Set.of(na1, na2));
         assertEquals(2, result.size());
-        assertTrue(result.keySet().stream().anyMatch(naCombi -> naCombi.getNetworkActionSet().size() == 1 && naCombi.getNetworkActionSet().contains(na1)));
-        assertTrue(result.keySet().stream().anyMatch(naCombi -> naCombi.getNetworkActionSet().size() == 1 && naCombi.getNetworkActionSet().contains(na2)));
+        assertTrue(result.stream().anyMatch(naCombi -> naCombi.getNetworkActionSet().size() == 1 && naCombi.getNetworkActionSet().contains(na1)));
+        assertTrue(result.stream().anyMatch(naCombi -> naCombi.getNetworkActionSet().size() == 1 && naCombi.getNetworkActionSet().contains(na2)));
     }
 
     private NetworkAction createNetworkActionWithOperator(String networkElementId, String operator) {
-        return crac.newNetworkAction().withId("na - " + networkElementId).withOperator(operator).newTopologicalAction().withNetworkElement(networkElementId).withActionType(ActionType.OPEN).add().add();
+        return crac.newNetworkAction().withId("na - " + networkElementId).withOperator(operator)
+            .newTopologicalAction().withNetworkElement(networkElementId).withActionType(ActionType.OPEN).add()
+            .add();
     }
 
     private PstRangeAction createPstRangeActionWithOperator(String networkElementId, String operator) {
         Map<Integer, Double> conversionMap = new HashMap<>();
         conversionMap.put(0, 0.);
         conversionMap.put(1, 1.);
-        return crac.newPstRangeAction().withId("pst - " + networkElementId).withOperator(operator).withNetworkElement(networkElementId).newOnInstantUsageRule().withInstant(Instant.PREVENTIVE).withUsageMethod(UsageMethod.AVAILABLE).add().newTapRange().withRangeType(RangeType.ABSOLUTE).withMinTap(-16).withMaxTap(16).add().withInitialTap(0).withTapToAngleConversionMap(conversionMap).add();
+        return crac.newPstRangeAction().withId("pst - " + networkElementId).withOperator(operator).withNetworkElement(networkElementId)
+            .newOnInstantUsageRule().withInstant(Instant.PREVENTIVE).withUsageMethod(UsageMethod.AVAILABLE).add()
+            .newTapRange().withRangeType(RangeType.ABSOLUTE).withMinTap(-16).withMaxTap(16).add()
+            .withInitialTap(0)
+            .withTapToAngleConversionMap(conversionMap)
+            .add();
     }
 
     @Test
     void testFilterIdenticalCombinations() {
         NetworkAction na1 = Mockito.mock(NetworkAction.class);
         NetworkAction na2 = Mockito.mock(NetworkAction.class);
-        Mockito.when(na1.getOperator()).thenReturn("fake_tso");
-        Mockito.when(na2.getOperator()).thenReturn("fake_tso");
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), new HashMap<>(), false, 0, List.of(new NetworkActionCombination(Set.of(na1, na2), false), new NetworkActionCombination(Set.of(na1, na2), false), new NetworkActionCombination(Set.of(na1, na2), true)), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, mock(RangeActionSetpointResult.class),
+            Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), new HashMap<>(), false, 0,
+                List.of(new NetworkActionCombination(Set.of(na1, na2), false),
+                        new NetworkActionCombination(Set.of(na1, na2), false),
+                        new NetworkActionCombination(Set.of(na1, na2), true)), pState
+        );
         Leaf leaf = Mockito.mock(Leaf.class);
         Mockito.when(leaf.getActivatedNetworkActions()).thenReturn(Collections.emptySet());
-        Map<NetworkActionCombination, Boolean> result = bloomer.bloom(leaf, Set.of(na1, na2));
+        List<NetworkActionCombination> result = bloomer.bloom(leaf, Set.of(na1, na2));
         assertEquals(4, result.size());
     }
 }

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomerTest.java
@@ -75,7 +75,19 @@ class SearchTreeBloomerTest {
         crac = CommonCracCreation.create();
         pState = crac.getPreventiveState();
 
-        crac.newFlowCnec().withId("cnecBe").withNetworkElement("BBE1AA1  BBE2AA1  1").withInstant(Instant.PREVENTIVE).withOptimized(true).withOperator("operator1").newThreshold().withUnit(Unit.MEGAWATT).withSide(Side.LEFT).withMin(-1500.).withMax(1500.).add().withNominalVoltage(380.).withIMax(5000.).add();
+        crac.newFlowCnec()
+            .withId("cnecBe")
+            .withNetworkElement("BBE1AA1  BBE2AA1  1")
+            .withInstant(Instant.PREVENTIVE).withOptimized(true)
+            .withOperator("operator1").newThreshold()
+            .withUnit(Unit.MEGAWATT)
+            .withSide(Side.LEFT)
+            .withMin(-1500.)
+            .withMax(1500.)
+            .add()
+            .withNominalVoltage(380.)
+            .withIMax(5000.)
+            .add();
 
         naFr1 = createNetworkActionWithOperator("FFR1AA1  FFR2AA1  1", "fr");
         naBe1 = createNetworkActionWithOperator("BBE1AA1  BBE2AA1  1", "be");

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomerTest.java
@@ -515,7 +515,7 @@ class SearchTreeBloomerTest {
     }
 
     @Test
-    void testNotKeptCombinationBecauseItExceeedsMaxNaForSecondTso() {
+    void testNotKeptCombinationBecauseItExceedsMaxNaForSecondTso() {
         // The network action combination does not exceed the maximum number of network actions but exceeds the maximum number of range actions for the first TSO.
         // It exceeds the maximum number of network actions for the second TSO.
         // We ensure that the combination is not kept.

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeBloomerTest.java
@@ -31,6 +31,7 @@ import org.mockito.Mockito;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -73,21 +74,7 @@ class SearchTreeBloomerTest {
         crac = CommonCracCreation.create();
         pState = crac.getPreventiveState();
 
-        crac.newFlowCnec()
-            .withId("cnecBe")
-            .withNetworkElement("BBE1AA1  BBE2AA1  1")
-            .withInstant(Instant.PREVENTIVE)
-            .withOptimized(true)
-            .withOperator("operator1")
-            .newThreshold()
-            .withUnit(Unit.MEGAWATT)
-            .withSide(Side.LEFT)
-            .withMin(-1500.)
-            .withMax(1500.)
-            .add()
-            .withNominalVoltage(380.)
-            .withIMax(5000.)
-            .add();
+        crac.newFlowCnec().withId("cnecBe").withNetworkElement("BBE1AA1  BBE2AA1  1").withInstant(Instant.PREVENTIVE).withOptimized(true).withOperator("operator1").newThreshold().withUnit(Unit.MEGAWATT).withSide(Side.LEFT).withMin(-1500.).withMax(1500.).add().withNominalVoltage(380.).withIMax(5000.).add();
 
         naFr1 = createNetworkActionWithOperator("FFR1AA1  FFR2AA1  1", "fr");
         naBe1 = createNetworkActionWithOperator("BBE1AA1  BBE2AA1  1", "be");
@@ -202,7 +189,7 @@ class SearchTreeBloomerTest {
         assertTrue(filteredNaCombination.containsKey(indNl1));
 
         // max 1 RAs
-        bloomer = new SearchTreeBloomer(network,  1, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, 1, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, previousLeaf);
 
         assertEquals(0, filteredNaCombination.size()); // all combination filtered
@@ -225,7 +212,7 @@ class SearchTreeBloomerTest {
 
         // filter - max 2 topo in FR and DE
         Map<String, Integer> maxTopoPerTso = Map.of("fr", 2, "be", 2);
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,  Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>(), pState);
         Map<NetworkActionCombination, Boolean> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(6, filteredNaCombination.size()); // 2 combinations filtered
@@ -234,7 +221,7 @@ class SearchTreeBloomerTest {
 
         // filter - max 1 topo in FR
         maxTopoPerTso = Map.of("fr", 1);
-        bloomer = new SearchTreeBloomer(network,  Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, new HashMap<>(), false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(4, filteredNaCombination.size()); // 4 combinations filtered
@@ -245,7 +232,7 @@ class SearchTreeBloomerTest {
 
         // filter - max 1 RA in FR and max 2 RA in BE
         Map<String, Integer> maxRaPerTso = Map.of("fr", 1, "be", 2);
-        bloomer = new SearchTreeBloomer(network,  Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), maxRaPerTso, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), maxRaPerTso, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(3, filteredNaCombination.size());
@@ -256,7 +243,7 @@ class SearchTreeBloomerTest {
         // filter - max 2 topo in FR, max 0 topo in Nl and max 1 RA in BE
         maxTopoPerTso = Map.of("fr", 2, "nl", 0);
         maxRaPerTso = Map.of("be", 1);
-        bloomer = new SearchTreeBloomer(network,  Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(3, filteredNaCombination.size());
@@ -267,7 +254,7 @@ class SearchTreeBloomerTest {
         // filter - no RA in NL
         maxTopoPerTso = Map.of("fr", 10, "nl", 10, "be", 10);
         maxRaPerTso = Map.of("nl", 0);
-        bloomer = new SearchTreeBloomer(network,  Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, maxTopoPerTso, maxRaPerTso, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, previousLeaf);
 
         assertEquals(5, filteredNaCombination.size());
@@ -289,20 +276,20 @@ class SearchTreeBloomerTest {
         Mockito.when(previousLeaf.getActivatedNetworkActions()).thenReturn(Collections.singleton(naFr1));
 
         // max 3 TSOs
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,  Integer.MAX_VALUE, 3, null, null, false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, 3, null, null, false, 0, new ArrayList<>(), pState);
         Map<NetworkActionCombination, Boolean> filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
 
         assertEquals(8, filteredNaCombination.size()); // no combination filtered
 
         // max 2 TSOs
-        bloomer = new SearchTreeBloomer(network,  Integer.MAX_VALUE, 2, null, null, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, 2, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
 
         assertEquals(7, filteredNaCombination.size());
         assertFalse(filteredNaCombination.containsKey(comb2BeNl)); // one combination filtered
 
         // max 1 TSO
-        bloomer = new SearchTreeBloomer(network,  Integer.MAX_VALUE, 1, null, null, false, 0, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, 1, null, null, false, 0, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, previousLeaf);
 
         assertEquals(3, filteredNaCombination.size());
@@ -325,7 +312,7 @@ class SearchTreeBloomerTest {
 
         // test - no border cross, most limiting element is in BE/FR
         Mockito.when(previousLeaf.getMostLimitingElements(1)).thenReturn(List.of(crac.getFlowCnec("cnec1basecase"))); // be fr
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,  Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, true, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, true, 0, new ArrayList<>(), pState);
         Map<NetworkActionCombination, Boolean> filteredNaCombination = bloomer.removeCombinationsFarFromMostLimitingElement(naCombinations, previousLeaf);
 
         assertEquals(7, filteredNaCombination.size());
@@ -344,7 +331,7 @@ class SearchTreeBloomerTest {
 
         // test - max 1 border cross, most limiting element is in BE
         Mockito.when(previousLeaf.getMostLimitingElements(1)).thenReturn(List.of(crac.getFlowCnec("cnecBe"))); // be
-        bloomer = new SearchTreeBloomer(network,  0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>(), pState);
         filteredNaCombination = bloomer.removeCombinationsFarFromMostLimitingElement(naCombinations, previousLeaf);
 
         assertEquals(9, filteredNaCombination.size());
@@ -356,7 +343,7 @@ class SearchTreeBloomerTest {
     @Test
     void testGetOptimizedMostLimitingElementsLocation() {
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,  0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
 
         Leaf leaf = mock(Leaf.class);
         Mockito.when(leaf.getVirtualCostNames()).thenReturn(Set.of("mnec", "lf"));
@@ -389,10 +376,7 @@ class SearchTreeBloomerTest {
 
     @Test
     void testIsNetworkActionCloseToLocations() {
-        NetworkAction na1 = crac.newNetworkAction().withId("na")
-            .newTopologicalAction().withNetworkElement("BBE2AA1  FFR3AA1  1").withActionType(ActionType.OPEN).add()
-            .newOnInstantUsageRule().withUsageMethod(UsageMethod.AVAILABLE).withInstant(Instant.PREVENTIVE).add()
-            .add();
+        NetworkAction na1 = crac.newNetworkAction().withId("na").newTopologicalAction().withNetworkElement("BBE2AA1  FFR3AA1  1").withActionType(ActionType.OPEN).add().newOnInstantUsageRule().withUsageMethod(UsageMethod.AVAILABLE).withInstant(Instant.PREVENTIVE).add().add();
         NetworkAction na2 = mock(NetworkAction.class);
         Mockito.when(na2.getLocation(network)).thenReturn(Set.of(Optional.of(Country.FR), Optional.empty()));
 
@@ -402,7 +386,7 @@ class SearchTreeBloomerTest {
         boundaries.add(new CountryBoundary(Country.DE, Country.AT));
         CountryGraph countryGraph = new CountryGraph(boundaries);
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,  0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.empty()), countryGraph));
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.FR)), countryGraph));
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.BE)), countryGraph));
@@ -410,11 +394,11 @@ class SearchTreeBloomerTest {
         assertFalse(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.AT)), countryGraph));
         assertTrue(bloomer.isNetworkActionCloseToLocations(na2, Set.of(Optional.of(Country.AT)), countryGraph));
 
-        bloomer = new SearchTreeBloomer(network,  0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, true, 1, new ArrayList<>(), pState);
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.DE)), countryGraph));
         assertFalse(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.AT)), countryGraph));
 
-        bloomer = new SearchTreeBloomer(network,  0, Integer.MAX_VALUE, null, null, true, 2, new ArrayList<>(), pState);
+        bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, true, 2, new ArrayList<>(), pState);
         assertTrue(bloomer.isNetworkActionCloseToLocations(na1, Set.of(Optional.of(Country.AT)), countryGraph));
     }
 
@@ -431,7 +415,7 @@ class SearchTreeBloomerTest {
         Mockito.when(leaf.getOptimizedSetpoint(raBe1, pState)).thenReturn(5.);
         Mockito.when(leaf.getOptimizedSetpoint(nonActivatedRa, pState)).thenReturn(0.);
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,  0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, 0, Integer.MAX_VALUE, null, null, false, 0, new ArrayList<>(), pState);
         Set<String> activatedTsos = bloomer.getTsosWithActivatedNetworkActions(leaf);
 
         // only network actions count when counting activated RAs in previous leaf
@@ -445,9 +429,7 @@ class SearchTreeBloomerTest {
         Mockito.when(na1.getOperator()).thenReturn("fake_tso");
         Mockito.when(na2.getOperator()).thenReturn("fake_tso");
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,
-            Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), new HashMap<>(), false, 0,
-            List.of(new NetworkActionCombination(Set.of(na2), true)), pState);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), new HashMap<>(), false, 0, List.of(new NetworkActionCombination(Set.of(na2), true)), pState);
         Leaf leaf = Mockito.mock(Leaf.class);
         Mockito.when(leaf.getActivatedNetworkActions()).thenReturn(Collections.emptySet());
         Map<NetworkActionCombination, Boolean> result = bloomer.bloom(leaf, Set.of(na1, na2));
@@ -457,21 +439,14 @@ class SearchTreeBloomerTest {
     }
 
     private NetworkAction createNetworkActionWithOperator(String networkElementId, String operator) {
-        return crac.newNetworkAction().withId("na - " + networkElementId).withOperator(operator)
-            .newTopologicalAction().withNetworkElement(networkElementId).withActionType(ActionType.OPEN).add()
-            .add();
+        return crac.newNetworkAction().withId("na - " + networkElementId).withOperator(operator).newTopologicalAction().withNetworkElement(networkElementId).withActionType(ActionType.OPEN).add().add();
     }
 
     private PstRangeAction createPstRangeActionWithOperator(String networkElementId, String operator) {
         Map<Integer, Double> conversionMap = new HashMap<>();
         conversionMap.put(0, 0.);
         conversionMap.put(1, 1.);
-        return crac.newPstRangeAction().withId("pst - " + networkElementId).withOperator(operator).withNetworkElement(networkElementId)
-            .newOnInstantUsageRule().withInstant(Instant.PREVENTIVE).withUsageMethod(UsageMethod.AVAILABLE).add()
-            .newTapRange().withRangeType(RangeType.ABSOLUTE).withMinTap(-16).withMaxTap(16).add()
-            .withInitialTap(0)
-            .withTapToAngleConversionMap(conversionMap)
-            .add();
+        return crac.newPstRangeAction().withId("pst - " + networkElementId).withOperator(operator).withNetworkElement(networkElementId).newOnInstantUsageRule().withInstant(Instant.PREVENTIVE).withUsageMethod(UsageMethod.AVAILABLE).add().newTapRange().withRangeType(RangeType.ABSOLUTE).withMinTap(-16).withMaxTap(16).add().withInitialTap(0).withTapToAngleConversionMap(conversionMap).add();
     }
 
     @Test
@@ -481,15 +456,136 @@ class SearchTreeBloomerTest {
         Mockito.when(na1.getOperator()).thenReturn("fake_tso");
         Mockito.when(na2.getOperator()).thenReturn("fake_tso");
 
-        SearchTreeBloomer bloomer = new SearchTreeBloomer(network,
-            Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), new HashMap<>(), false, 0,
-                List.of(new NetworkActionCombination(Set.of(na1, na2), false),
-                        new NetworkActionCombination(Set.of(na1, na2), false),
-                        new NetworkActionCombination(Set.of(na1, na2), true)), pState
-        );
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, Integer.MAX_VALUE, new HashMap<>(), new HashMap<>(), false, 0, List.of(new NetworkActionCombination(Set.of(na1, na2), false), new NetworkActionCombination(Set.of(na1, na2), false), new NetworkActionCombination(Set.of(na1, na2), true)), pState);
         Leaf leaf = Mockito.mock(Leaf.class);
         Mockito.when(leaf.getActivatedNetworkActions()).thenReturn(Collections.emptySet());
         Map<NetworkActionCombination, Boolean> result = bloomer.bloom(leaf, Set.of(na1, na2));
         assertEquals(4, result.size());
+    }
+
+    @Test
+    void testBooleansInHashMapAfterMaxNumberOfRaFilter() {
+        NetworkAction alreadyAppliedNA1 = Mockito.mock(NetworkAction.class);
+        NetworkAction alreadyAppliedNA2 = Mockito.mock(NetworkAction.class);
+        NetworkAction na1 = Mockito.mock(NetworkAction.class);
+        NetworkAction na2 = Mockito.mock(NetworkAction.class);
+        NetworkAction na3 = Mockito.mock(NetworkAction.class);
+
+        NetworkActionCombination combinationToKeep = new NetworkActionCombination(Set.of(na1), true);
+        NetworkActionCombination combinationToRemove = new NetworkActionCombination(Set.of(na1, na2), true);
+        NetworkActionCombination combinationWithNumberOfNAExceedingTheLimit = new NetworkActionCombination(Set.of(na1, na2, na3), true);
+
+        assertEquals(1, combinationToKeep.getNetworkActionSet().size());
+        assertEquals(2, combinationToRemove.getNetworkActionSet().size());
+        assertEquals(3, combinationWithNumberOfNAExceedingTheLimit.getNetworkActionSet().size());
+
+        Map<NetworkActionCombination, Boolean> naCombinations = new HashMap<>();
+        naCombinations.put(combinationToKeep, false);
+        naCombinations.put(combinationToRemove, false);
+        naCombinations.put(combinationWithNumberOfNAExceedingTheLimit, false);
+
+        Leaf leaf = Mockito.mock(Leaf.class);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, 4, Integer.MAX_VALUE, new HashMap<>(), new HashMap<>(), false, 0, new ArrayList<>(), pState);
+
+        Mockito.when(leaf.getNumberOfActivatedRangeActions()).thenReturn(1L);
+        Mockito.when(leaf.getActivatedNetworkActions()).thenReturn(Set.of(alreadyAppliedNA1, alreadyAppliedNA2));
+
+        assertEquals(2, leaf.getActivatedNetworkActions().size());
+
+        Map<NetworkActionCombination, Boolean> naToRemove = bloomer.removeCombinationsWhichExceedMaxNumberOfRa(naCombinations, leaf);
+        Map<NetworkActionCombination, Boolean> expectedResult = new HashMap<>();
+        expectedResult.put(combinationToKeep, false);
+        expectedResult.put(combinationToRemove, true);
+        assertEquals(expectedResult, naToRemove);
+    }
+
+    @Test
+    void testBooleansInHashMapAfterMaxNumberOfRaPerTsoFilter() {
+        NetworkAction alreadyAppliedNa1 = Mockito.mock(NetworkAction.class);
+        NetworkAction alreadyAppliedNa2 = Mockito.mock(NetworkAction.class);
+        NetworkAction alreadyAppliedNa3 = Mockito.mock(NetworkAction.class);
+        Mockito.when(alreadyAppliedNa1.getOperator()).thenReturn("TSO-1");
+        Mockito.when(alreadyAppliedNa2.getOperator()).thenReturn("TSO-2");
+        Mockito.when(alreadyAppliedNa3.getOperator()).thenReturn("TSO-2");
+
+        NetworkAction na1 = Mockito.mock(NetworkAction.class);
+        NetworkAction na2 = Mockito.mock(NetworkAction.class);
+        NetworkAction na3 = Mockito.mock(NetworkAction.class);
+        Mockito.when(na1.getOperator()).thenReturn("TSO-1");
+        Mockito.when(na2.getOperator()).thenReturn("TSO-2");
+        Mockito.when(na3.getOperator()).thenReturn("TSO-2");
+
+        RangeAction alreadyAppliedRangeAction1 = Mockito.mock(RangeAction.class);
+        RangeAction alreadyAppliedRangeAction2 = Mockito.mock(RangeAction.class);
+        Mockito.when(alreadyAppliedRangeAction1.getOperator()).thenReturn("TSO-1");
+        Mockito.when(alreadyAppliedRangeAction2.getOperator()).thenReturn("TSO-2");
+
+        NetworkActionCombination combinationToKeep = new NetworkActionCombination(Set.of(na1), true);
+        NetworkActionCombination combinationToRemoveBecauseNumberOfRaForTso2IsExceeded = new NetworkActionCombination(Set.of(na2), true);
+        NetworkActionCombination combinationWithNumberOfRaForTso2Exceeded = new NetworkActionCombination(Set.of(na2, na3), true);
+
+        Map<NetworkActionCombination, Boolean> naCombinations = new HashMap<>();
+        naCombinations.put(combinationToKeep, false);
+        naCombinations.put(combinationToRemoveBecauseNumberOfRaForTso2IsExceeded, false);
+        naCombinations.put(combinationWithNumberOfRaForTso2Exceeded, false);
+
+        Leaf leaf = Mockito.mock(Leaf.class);
+        Mockito.when(leaf.getActivatedNetworkActions()).thenReturn(Set.of(alreadyAppliedNa1, alreadyAppliedNa2, alreadyAppliedNa3));
+        Mockito.when(leaf.getActivatedRangeActions(Mockito.any(State.class))).thenReturn(Set.of(alreadyAppliedRangeAction1, alreadyAppliedRangeAction2));
+
+        Map<String, Integer> maxNaPerTso = new HashMap<>();
+        maxNaPerTso.put("TSO-1", 2);
+        maxNaPerTso.put("TSO-2", 3);
+
+        Map<String, Integer> maxRaPerTso = new HashMap<>();
+        maxRaPerTso.put("TSO-1", 3);
+        maxRaPerTso.put("TSO-2", 3);
+
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, 3, maxNaPerTso, maxRaPerTso, false, 0, new ArrayList<>(), pState);
+
+        Map<NetworkActionCombination, Boolean> naToRemove = bloomer.removeCombinationsWhichExceedMaxNumberOfRaPerTso(naCombinations, leaf);
+        Map<NetworkActionCombination, Boolean> expectedResult = new HashMap<>();
+        expectedResult.put(combinationToKeep, false);
+        expectedResult.put(combinationToRemoveBecauseNumberOfRaForTso2IsExceeded, true);
+        assertEquals(expectedResult, naToRemove);
+    }
+
+    @Test
+    void testBooleansInHashMapAfterMaxNumberOfTsosFilter() {
+        NetworkAction alreadyAppliedNATso1 = Mockito.mock(NetworkAction.class);
+        NetworkAction alreadyAppliedNATso2 = Mockito.mock(NetworkAction.class);
+        Mockito.when(alreadyAppliedNATso1.getOperator()).thenReturn("TSO-1");
+        Mockito.when(alreadyAppliedNATso2.getOperator()).thenReturn("TSO-2");
+
+        NetworkAction na1 = Mockito.mock(NetworkAction.class);
+        NetworkAction na2 = Mockito.mock(NetworkAction.class);
+        NetworkAction na3 = Mockito.mock(NetworkAction.class);
+        Mockito.when(na1.getOperator()).thenReturn("TSO-1");
+        Mockito.when(na2.getOperator()).thenReturn("TSO-3");
+        Mockito.when(na3.getOperator()).thenReturn("TSO-4");
+
+        RangeAction alreadyAppliedRangeAction = Mockito.mock(RangeAction.class);
+        Mockito.when(alreadyAppliedRangeAction.getOperator()).thenReturn("TSO-5");
+
+        NetworkActionCombination combinationToKeep = new NetworkActionCombination(Set.of(na1), true);
+        NetworkActionCombination combinationToRemove = new NetworkActionCombination(Set.of(na1, na2), true);
+        NetworkActionCombination combinationWithNumberOfTsoExceedingTheLimit = new NetworkActionCombination(Set.of(na1, na2, na3), true);
+
+        Map<NetworkActionCombination, Boolean> naCombinations = new HashMap<>();
+        naCombinations.put(combinationToKeep, false);
+        naCombinations.put(combinationToRemove, false);
+        naCombinations.put(combinationWithNumberOfTsoExceedingTheLimit, false);
+
+        Leaf leaf = Mockito.mock(Leaf.class);
+        SearchTreeBloomer bloomer = new SearchTreeBloomer(network, Integer.MAX_VALUE, 3, new HashMap<>(), new HashMap<>(), false, 0, new ArrayList<>(), pState);
+
+        Mockito.when(leaf.getActivatedNetworkActions()).thenReturn(Set.of(alreadyAppliedNATso1, alreadyAppliedNATso2));
+        Mockito.when(leaf.getActivatedRangeActions(Mockito.any(State.class))).thenReturn(Set.of(alreadyAppliedRangeAction));
+
+        Map<NetworkActionCombination, Boolean> naToRemove = bloomer.removeCombinationsWhichExceedMaxNumberOfTsos(naCombinations, leaf);
+        Map<NetworkActionCombination, Boolean> expectedResult = new HashMap<>();
+        expectedResult.put(combinationToKeep, false);
+        expectedResult.put(combinationToRemove, true);
+        assertEquals(expectedResult, naToRemove);
     }
 }

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
@@ -231,7 +231,7 @@ class SearchTreeTest {
     }
 
     @Test
-    void runTest() {
+    void testCreateChildLeafFiltersOutRangeActionWhenNeeded() {
         searchTreeWithOneChildLeaf();
         when(networkAction.apply(network)).thenReturn(true);
         NetworkActionCombination naCombination = new NetworkActionCombination(networkAction);

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
@@ -277,11 +277,11 @@ class SearchTreeTest {
 
         when(childLeaf1.getStatus()).thenReturn(Leaf.Status.EVALUATED, Leaf.Status.OPTIMIZED);
         when(childLeaf1.getCost()).thenReturn(childLeaf1CostAfterOptim);
-        Mockito.doReturn(childLeaf1).when(searchTree).createChildLeaf(any(), eq(availableNaCombinations.get(0)), eq(false));
+        Mockito.doReturn(childLeaf1).when(searchTree).createChildLeaf(any(), eq(availableNaCombinations.get(0)), false);
 
         when(childLeaf2.getStatus()).thenReturn(Leaf.Status.EVALUATED, Leaf.Status.OPTIMIZED);
         when(childLeaf2.getCost()).thenReturn(childLeaf2CostAfterOptim);
-        Mockito.doReturn(childLeaf2).when(searchTree).createChildLeaf(any(), eq(availableNaCombinations.get(1)), eq(false));
+        Mockito.doReturn(childLeaf2).when(searchTree).createChildLeaf(any(), eq(availableNaCombinations.get(1)), false);
 
         OptimizationResult result = searchTree.run().get();
         assertEquals(childLeaf1, result);
@@ -366,7 +366,7 @@ class SearchTreeTest {
         when(childLeaf.getStatus()).thenReturn(Leaf.Status.EVALUATED, Leaf.Status.OPTIMIZED);
         when(childLeaf.getCost()).thenReturn(childLeafCostAfterOptim);
         when(childLeaf.getVirtualCost()).thenReturn(childLeafCostAfterOptim);
-        Mockito.doReturn(childLeaf).when(searchTree).createChildLeaf(eq(network), any(), eq(false));
+        Mockito.doReturn(childLeaf).when(searchTree).createChildLeaf(eq(network), any(), false);
     }
 
     private void mockNetworkPool(Network network) throws Exception {

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
@@ -277,11 +277,11 @@ class SearchTreeTest {
 
         when(childLeaf1.getStatus()).thenReturn(Leaf.Status.EVALUATED, Leaf.Status.OPTIMIZED);
         when(childLeaf1.getCost()).thenReturn(childLeaf1CostAfterOptim);
-        Mockito.doReturn(childLeaf1).when(searchTree).createChildLeaf(any(), eq(availableNaCombinations.get(0)), false);
+        Mockito.doReturn(childLeaf1).when(searchTree).createChildLeaf(any(), eq(availableNaCombinations.get(0)), eq(false));
 
         when(childLeaf2.getStatus()).thenReturn(Leaf.Status.EVALUATED, Leaf.Status.OPTIMIZED);
         when(childLeaf2.getCost()).thenReturn(childLeaf2CostAfterOptim);
-        Mockito.doReturn(childLeaf2).when(searchTree).createChildLeaf(any(), eq(availableNaCombinations.get(1)), false);
+        Mockito.doReturn(childLeaf2).when(searchTree).createChildLeaf(any(), eq(availableNaCombinations.get(1)), eq(false));
 
         OptimizationResult result = searchTree.run().get();
         assertEquals(childLeaf1, result);
@@ -366,7 +366,7 @@ class SearchTreeTest {
         when(childLeaf.getStatus()).thenReturn(Leaf.Status.EVALUATED, Leaf.Status.OPTIMIZED);
         when(childLeaf.getCost()).thenReturn(childLeafCostAfterOptim);
         when(childLeaf.getVirtualCost()).thenReturn(childLeafCostAfterOptim);
-        Mockito.doReturn(childLeaf).when(searchTree).createChildLeaf(eq(network), any(), false);
+        Mockito.doReturn(childLeaf).when(searchTree).createChildLeaf(eq(network), any(), eq(false));
     }
 
     private void mockNetworkPool(Network network) throws Exception {

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
@@ -209,7 +209,7 @@ class SearchTreeTest {
 
         Leaf childLeaf = Mockito.mock(Leaf.class);
         when(childLeaf.getStatus()).thenReturn(Leaf.Status.ERROR);
-        Mockito.doReturn(childLeaf).when(searchTree).createChildLeaf(network, new NetworkActionCombination(networkAction));
+        Mockito.doReturn(childLeaf).when(searchTree).createChildLeaf(network, new NetworkActionCombination(networkAction), false);
 
         OptimizationResult result = searchTree.run().get();
         assertEquals(rootLeaf, result);
@@ -277,11 +277,11 @@ class SearchTreeTest {
 
         when(childLeaf1.getStatus()).thenReturn(Leaf.Status.EVALUATED, Leaf.Status.OPTIMIZED);
         when(childLeaf1.getCost()).thenReturn(childLeaf1CostAfterOptim);
-        Mockito.doReturn(childLeaf1).when(searchTree).createChildLeaf(any(), eq(availableNaCombinations.get(0)));
+        Mockito.doReturn(childLeaf1).when(searchTree).createChildLeaf(any(), eq(availableNaCombinations.get(0)), false);
 
         when(childLeaf2.getStatus()).thenReturn(Leaf.Status.EVALUATED, Leaf.Status.OPTIMIZED);
         when(childLeaf2.getCost()).thenReturn(childLeaf2CostAfterOptim);
-        Mockito.doReturn(childLeaf2).when(searchTree).createChildLeaf(any(), eq(availableNaCombinations.get(1)));
+        Mockito.doReturn(childLeaf2).when(searchTree).createChildLeaf(any(), eq(availableNaCombinations.get(1)), false);
 
         OptimizationResult result = searchTree.run().get();
         assertEquals(childLeaf1, result);
@@ -366,7 +366,7 @@ class SearchTreeTest {
         when(childLeaf.getStatus()).thenReturn(Leaf.Status.EVALUATED, Leaf.Status.OPTIMIZED);
         when(childLeaf.getCost()).thenReturn(childLeafCostAfterOptim);
         when(childLeaf.getVirtualCost()).thenReturn(childLeafCostAfterOptim);
-        Mockito.doReturn(childLeaf).when(searchTree).createChildLeaf(eq(network), any());
+        Mockito.doReturn(childLeaf).when(searchTree).createChildLeaf(eq(network), any(), false);
     }
 
     private void mockNetworkPool(Network network) throws Exception {

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/SearchTreeTest.java
@@ -111,6 +111,7 @@ class SearchTreeTest {
         NetworkActionParameters networkActionParameters = Mockito.mock(NetworkActionParameters.class);
         when(searchTreeParameters.getNetworkActionParameters()).thenReturn(networkActionParameters);
         predefinedNaCombination = Mockito.mock(NetworkActionCombination.class);
+        when(predefinedNaCombination.getConcatenatedId()).thenReturn("predefinedNa");
         when(networkActionParameters.getNetworkActionCombinations()).thenReturn(List.of(predefinedNaCombination));
     }
 
@@ -382,6 +383,7 @@ class SearchTreeTest {
         networkAction = Mockito.mock(NetworkAction.class);
         when(networkAction.getUsageMethod(any())).thenReturn(UsageMethod.AVAILABLE);
         when(networkAction.getOperator()).thenReturn("operator");
+        when(networkAction.getId()).thenReturn("na1");
         availableNetworkActions.add(networkAction);
         availableNaCombinations.add(new NetworkActionCombination(networkAction));
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** 
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?**

[FAR-832]

**What kind of change does this PR introduce?**

This PR introduces 2 things :
-  It takes over the behavior that existed prior to the [#730](https://github.com/farao-community/farao-core/pull/730) PR:
_In search-tree, when range actions are applied at a given leaf, they are kept at their optimal set-points in children leaves. This improves search-tree computation performance._
- When `max_CRA` parameters are defined, network actions can now be selected by the search Tree.

**What is the current behaviour?**

1) In the search tree, at the beginning of every leaf, range actions are reset to their pre-perimeter set-points.
2) If any `max_CRA` constraint is reached at a given search Tree depth, the research stops.

**What is the new behavior ?**

1) As explained above, when range actions are applied at a given leaf, they are kept at their optimal set-points in children leaves
Therefore, the search tree is now faster and due to its quicker convergence, it can produce best result when the max number of MIP iterations is low.
2)  If `max_CRA` is reached at any depth of the tree, the search Tree can now reset range Actions set-points to their pre-perimeter value to allow the evaluation of network actions while respecting the `max_CRA` constraints.
It allows the RAO to find better solutions.

