### PR TITLE
Modify leaf get range actions method

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/Leaf.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/Leaf.java
@@ -479,13 +479,7 @@ public class Leaf implements OptimizationResult {
 
     @Override
     public Set<RangeAction<?>> getRangeActions() {
-        if (status == Status.EVALUATED) {
-            return raActivationResultFromParentLeaf.getRangeActions();
-        } else if (status == Status.OPTIMIZED) {
-            return postOptimResult.getRangeActions();
-        } else {
-            throw new FaraoException(NO_RESULTS_AVAILABLE);
-        }
+        return optimizationPerimeter.getRangeActions();
     }
 
     @Override

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
@@ -557,6 +557,7 @@ class LeafTest {
         rangeActions.add(pstRangeAction);
         rangeActions.add(rangeAction);
         when(prePerimeterResult.getRangeActions()).thenReturn(rangeActions);
+        when(optimizationPerimeter.getRangeActions()).thenReturn(rangeActions);
         when(prePerimeterResult.getTap(pstRangeAction)).thenReturn(optimalTap);
         when(prePerimeterResult.getSetpoint(rangeAction)).thenReturn(optimalSetpoint);
         when(prePerimeterResult.getSetpoint(pstRangeAction)).thenReturn(optimalSetpoint);
@@ -595,7 +596,7 @@ class LeafTest {
         rangeActions.add(pstRangeAction);
         rangeActions.add(rangeAction);
 
-        when(linearOptimizationResult.getRangeActions()).thenReturn(rangeActions);
+        when(optimizationPerimeter.getRangeActions()).thenReturn(rangeActions);
         assertEquals(rangeActions, leaf.getRangeActions());
 
         when(linearOptimizationResult.getOptimizedTap(pstRangeAction, optimizedState)).thenReturn(optimalTap);

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/search_tree/algorithms/LeafTest.java
@@ -615,7 +615,17 @@ class LeafTest {
     @Test
     void getRangeActionsBeforeEvaluation() {
         Leaf leaf = buildNotEvaluatedRootLeaf();
-        assertThrows(FaraoException.class, leaf::getRangeActions);
+        assertEquals(Leaf.Status.CREATED, leaf.getStatus());
+        assertTrue(leaf.getRangeActions().isEmpty());
+
+        PstRangeAction pstRangeAction = Mockito.mock(PstRangeAction.class);
+        RangeAction<?> rangeAction = Mockito.mock(RangeAction.class);
+        Set<RangeAction<?>> rangeActions = new HashSet<>();
+        rangeActions.add(pstRangeAction);
+        rangeActions.add(rangeAction);
+        when(optimizationPerimeter.getRangeActions()).thenReturn(rangeActions);
+        assertEquals(Leaf.Status.CREATED, leaf.getStatus());
+        assertEquals(rangeActions, leaf.getRangeActions());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** 
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

A PR modifying a real test case has been opened on farao-cucumber repository

**Does this PR already have an issue describing the problem ?** 

- [FAR-837] Investigate Leaf getRangeActions() method

- This also solves the second issue of the 2 described in the internal Confluence page : "Sujets en cours", on the SWE case.

**What kind of change does this PR introduce?** 

Bug fix.

**What is the current behavior?** *(You can also link to an open issue here)*

Current method : 
```java
@Override
public Set<RangeAction<?>> getRangeActions() {
    if (status == Status.EVALUATED) {
        return prePerimeterActivationResult.getRangeActions();
    } else if (status == Status.OPTIMIZED) {
        return postOptimResult.getRangeActions();
    } else {
        throw new FaraoException(NO_RESULTS_AVAILABLE);
    }
```
`prePerimeterActivationResult.getRangeActions()` returns every available range action in the CRAC.
On certain conditions described in the Confluence page, `postOptimResult.getRangeActions()` returns the same thing.

**What is the new behavior (if this is a feature change)?**

New method:
```java
@Override
public Set<RangeAction<?>> getRangeActions() {
    if ((status == Status.EVALUATED) || (status == Status.OPTIMIZED)) {
        return optimizationPerimeter.getRangeActions();
    } else {
        throw new FaraoException(NO_RESULTS_AVAILABLE);
    }
```

The getRangeActions() method now only returns the rangeActions that belong to the optimizationPerimeter and only these ones. 

**Does this PR introduce a breaking change?** 

No
