### PR TITLE
Fix equals in AbstractRangeAction

### DIFF
--- a/data/crac-creation/crac-creator-csa-profiles/src/main/java/com/farao_community/farao/data/crac_creation/creator/csa_profile/crac_creator/CsaProfileCracCreator.java
+++ b/data/crac-creation/crac-creator-csa-profiles/src/main/java/com/farao_community/farao/data/crac_creation/creator/csa_profile/crac_creator/CsaProfileCracCreator.java
@@ -14,6 +14,7 @@ import com.farao_community.farao.data.crac_creation.creator.csa_profile.CsaProfi
 import com.farao_community.farao.data.crac_creation.creator.csa_profile.crac_creator.cnec.CsaProfileCnecCreator;
 import com.farao_community.farao.data.crac_creation.creator.csa_profile.crac_creator.contingency.CsaProfileContingencyCreator;
 import com.farao_community.farao.data.crac_creation.creator.csa_profile.crac_creator.remedial_action.CsaProfileRemedialActionsCreator;
+import com.google.auto.service.AutoService;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.triplestore.api.PropertyBags;
 
@@ -22,6 +23,7 @@ import java.time.OffsetDateTime;
 /**
  * @author Jean-Pierre Arnould {@literal <jean-pierre.arnould at rte-france.com>}
  */
+@AutoService(CracCreator.class)
 public class CsaProfileCracCreator implements CracCreator<CsaProfileCrac, CsaProfileCracCreationContext> {
 
     private Crac crac;

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/AbstractRangeAction.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/AbstractRangeAction.java
@@ -37,7 +37,7 @@ public abstract class AbstractRangeAction<T extends RangeAction<T>> extends Abst
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        AbstractRangeAction otherRa = (AbstractRangeAction) o;
+        AbstractRangeAction<?> otherRa = (AbstractRangeAction<?>) o;
 
         return super.equals(o)
                 && (groupId == null && otherRa.getGroupId().isEmpty() || groupId != null && groupId.equals(otherRa.getGroupId().orElse(null)));

--- a/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/AbstractRangeAction.java
+++ b/data/crac/crac-impl/src/main/java/com/farao_community/farao/data/crac_impl/AbstractRangeAction.java
@@ -40,7 +40,7 @@ public abstract class AbstractRangeAction<T extends RangeAction<T>> extends Abst
         AbstractRangeAction otherRa = (AbstractRangeAction) o;
 
         return super.equals(o)
-                && (groupId == null && otherRa.getGroupId().isEmpty()) || (groupId != null && groupId.equals(otherRa.getGroupId().orElse(null)));
+                && (groupId == null && otherRa.getGroupId().isEmpty() || groupId != null && groupId.equals(otherRa.getGroupId().orElse(null)));
     }
 
     @Override

--- a/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/PstRangeActionImplTest.java
+++ b/data/crac/crac-impl/src/test/java/com/farao_community/farao/data/crac_impl/PstRangeActionImplTest.java
@@ -209,8 +209,8 @@ class PstRangeActionImplTest {
     @Test
     void pstEquals() {
 
-        PstRangeAction pstRa1 = pstRangeActionAdder.add();
-        PstRangeAction pstRa2 = pstRangeActionAdder.withId("anotherId").add();
+        PstRangeAction pstRa1 = pstRangeActionAdder.withGroupId("g1").add();
+        PstRangeAction pstRa2 = pstRangeActionAdder.withId("anotherId").withGroupId("g1").add();
 
         assertEquals(pstRa1.hashCode(), pstRa1.hashCode());
         assertEquals(pstRa1, pstRa1);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The equal method returns true if the groupId is present and equal in both RAs, even if the rest isnt


**What is the new behavior (if this is a feature change)?**
It now checks if the rest is even before checking group id
(fixed parentheses for the && and || order)


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
maybe? 


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
