### PR TITLE
Reduce parallel timeout

### DIFF
--- a/monitoring/voltage-monitoring/src/main/java/com/farao_community/farao/monitoring/voltage_monitoring/VoltageMonitoring.java
+++ b/monitoring/voltage-monitoring/src/main/java/com/farao_community/farao/monitoring/voltage_monitoring/VoltageMonitoring.java
@@ -37,6 +37,7 @@ import static com.farao_community.farao.commons.logs.FaraoLoggerProvider.*;
  */
 public class VoltageMonitoring {
     public static final String CONTINGENCY_ERROR = "At least one contingency could not be monitored within the given time (24 hours). This should not happen.";
+    public static final int TIMEOUT_PER_CONTINGENCY_STATE = 10; // 10 minutes to simulate one contingency
     private final Crac crac;
     private final Network network;
     private final RaoResult raoResult;
@@ -81,6 +82,7 @@ public class VoltageMonitoring {
                      AbstractNetworkPool.create(network, network.getVariantManager().getWorkingVariantId(), Math.min(numberOfLoadFlowsInParallel, contingencyStates.size()), true)
             ) {
                 CountDownLatch stateCountDownLatch = new CountDownLatch(contingencyStates.size());
+                int timeout = (int) Math.ceil((double) contingencyStates.size() / networkPool.getParallelism()) * TIMEOUT_PER_CONTINGENCY_STATE;
                 contingencyStates.forEach(state ->
                     networkPool.submit(() -> {
                         Network networkClone = null;
@@ -110,7 +112,7 @@ public class VoltageMonitoring {
                         }
                     }
                 ));
-                boolean success = stateCountDownLatch.await(24, TimeUnit.HOURS);
+                boolean success = stateCountDownLatch.await(timeout, TimeUnit.MINUTES);
                 if (!success) {
                     throw new FaraoException(CONTINGENCY_ERROR);
                 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
When parallelizing computations (in search tree or in monitoring algorithms), if a thread fails, an exception is raised 24 hours afterwards.


**What is the new behavior (if this is a feature change)?**
Now the wait is reduced to a functional minimum, so that calling applications are aware of the problem ASAP.

