### PR TITLE
change unoptimized cnecs equations to fit with the ones on the website

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/UnoptimizedCnecFiller.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/UnoptimizedCnecFiller.java
@@ -225,7 +225,7 @@ public class UnoptimizedCnecFiller implements ProblemFiller {
                             LinearProblem.infinity(), cnec,
                             side,
                             LinearProblem.MarginExtension.BELOW_THRESHOLD);
-                    extendSetpointBounds.setCoefficient(flowVariable, 1);
+                    extendSetpointBounds.setCoefficient(flowVariable, sensitivity >= 0 ? 1 : -1);
                 } else {
                     extendSetpointBounds = linearProblem.getDontOptimizeCnecConstraint(cnec, side, LinearProblem.MarginExtension.BELOW_THRESHOLD);
                     if (extendSetpointBounds == null) {
@@ -234,12 +234,7 @@ public class UnoptimizedCnecFiller implements ProblemFiller {
                 }
                 extendSetpointBounds.setCoefficient(setPointVariable, -sensitivity);
                 extendSetpointBounds.setCoefficient(optimizeCnecBinaryVariable, bigM * abs(sensitivity));
-                double lb =  minFlow.get();
-                if (sensitivity >= 0) {
-                    lb += -maxSetpoint * sensitivity;
-                } else {
-                    lb += -minSetpoint * sensitivity;
-                }
+                double lb = sensitivity >= 0 ? minFlow.get() - maxSetpoint * sensitivity : -minFlow.get() - minSetpoint * sensitivity;
                 extendSetpointBounds.setLb(lb);
             }
             if (maxFlow.isPresent()) {
@@ -249,7 +244,7 @@ public class UnoptimizedCnecFiller implements ProblemFiller {
                             -LinearProblem.infinity(),
                             LinearProblem.infinity(), cnec, side,
                             LinearProblem.MarginExtension.ABOVE_THRESHOLD);
-                    extendSetpointBounds.setCoefficient(flowVariable, -1);
+                    extendSetpointBounds.setCoefficient(flowVariable, sensitivity >= 0 ? -1 : 1);
                 } else {
                     extendSetpointBounds = linearProblem.getDontOptimizeCnecConstraint(cnec, side, LinearProblem.MarginExtension.ABOVE_THRESHOLD);
                     if (extendSetpointBounds == null) {
@@ -258,12 +253,7 @@ public class UnoptimizedCnecFiller implements ProblemFiller {
                 }
                 extendSetpointBounds.setCoefficient(setPointVariable, sensitivity);
                 extendSetpointBounds.setCoefficient(optimizeCnecBinaryVariable, bigM * abs(sensitivity));
-                double lb =  -maxFlow.get();
-                if (sensitivity >= 0) {
-                    lb += minSetpoint * abs(sensitivity);
-                } else {
-                    lb += maxSetpoint * abs(sensitivity);
-                }
+                double lb = sensitivity >= 0 ? -maxFlow.get() + minSetpoint * sensitivity : maxFlow.get() + maxSetpoint * sensitivity;
                 extendSetpointBounds.setLb(lb);
             }
         }));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No.


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Code of the class `UnoptimizedCnecFiller` did not produce the same equations as the ones on the website.
As the right ones were on the website doc, this PR changes the code in the class `UnoptimizedCnecFiller` to fit with those :  [unoptimized cnec equations](https://farao-community.github.io/docs/castor/linear-optimisation-problem/unoptimized-cnec-filler-pst)

**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*

No.

**Other information**:

All cucumber tests passed on this branch : [farao-cucumber PR](https://devin-source.rte-france.com/farao/farao-cucumber-tests/-/merge_requests/355)
Nonetheless, investigations must be carried out on the last test on the cucumber branch to validate this PR.
