### PR TITLE
fix `ra-range-shrinking` parameter

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFiller.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFiller.java
@@ -51,12 +51,14 @@ public class CoreProblemFiller implements ProblemFiller {
     private final Unit unit;
     private int iteration = 0;
     private static final double RANGE_SHRINK_RATE = 0.667;
+    private final boolean raRangeShrinking;
 
     public CoreProblemFiller(OptimizationPerimeter optimizationContext,
                              RangeActionSetpointResult prePerimeterRangeActionSetpoints,
                              RangeActionActivationResult raActivationFromParentLeaf,
                              RangeActionsOptimizationParameters rangeActionParameters,
-                             Unit unit) {
+                             Unit unit,
+                             boolean raRangeShrinking) {
         this.optimizationContext = optimizationContext;
         this.flowCnecs = new TreeSet<>(Comparator.comparing(Identifiable::getId));
         this.flowCnecs.addAll(optimizationContext.getFlowCnecs());
@@ -64,6 +66,7 @@ public class CoreProblemFiller implements ProblemFiller {
         this.raActivationFromParentLeaf = raActivationFromParentLeaf;
         this.rangeActionParameters = rangeActionParameters;
         this.unit = unit;
+        this.raRangeShrinking = raRangeShrinking;
     }
 
     @Override
@@ -85,7 +88,9 @@ public class CoreProblemFiller implements ProblemFiller {
     public void updateBetweenSensiIteration(LinearProblem linearProblem, FlowResult flowResult, SensitivityResult sensitivityResult, RangeActionActivationResult rangeActionActivationResult) {
         // update reference flow and sensitivities of flow constraints
         updateFlowConstraints(linearProblem, flowResult, sensitivityResult, rangeActionActivationResult);
-        updateRangeActionConstraints(linearProblem, rangeActionActivationResult);
+        if (raRangeShrinking) {
+            updateRangeActionConstraints(linearProblem, rangeActionActivationResult);
+        }
     }
 
     @Override

--- a/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblemBuilder.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/linear_problem/LinearProblemBuilder.java
@@ -135,7 +135,8 @@ public class LinearProblemBuilder {
             inputs.getPrePerimeterSetpoints(),
             inputs.getRaActivationFromParentLeaf(),
             parameters.getRangeActionParameters(),
-            parameters.getObjectiveFunctionUnit()
+            parameters.getObjectiveFunctionUnit(),
+            parameters.getRaRangeShrinking()
         );
     }
 

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/ContinuousRangeActionGroupFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/ContinuousRangeActionGroupFillerTest.java
@@ -63,7 +63,8 @@ class ContinuousRangeActionGroupFillerTest extends AbstractFillerTest {
             initialRangeActionSetpointResult,
             new RangeActionActivationResultImpl(initialRangeActionSetpointResult),
             rangeActionParameters,
-            Unit.MEGAWATT);
+            Unit.MEGAWATT,
+            false);
 
         ContinuousRangeActionGroupFiller continuousRangeActionGroupFiller = new ContinuousRangeActionGroupFiller(
             rangeActions);

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFillerTest.java
@@ -67,18 +67,14 @@ class CoreProblemFillerTest extends AbstractFillerTest {
     }
 
     private void initializeForPreventive(double pstSensitivityThreshold, double hvdcSensitivityThreshold, double injectionSensitivityThreshold) {
-        initialize(Set.of(cnec1), pstSensitivityThreshold, hvdcSensitivityThreshold, injectionSensitivityThreshold, crac.getPreventiveState());
-    }
-
-    private void initializeForCurative() {
-        initialize(Set.of(cnec2), 0, 0, 0, cnec2.getState());
+        initialize(Set.of(cnec1), pstSensitivityThreshold, hvdcSensitivityThreshold, injectionSensitivityThreshold, crac.getPreventiveState(), false);
     }
 
     private void initializeForGlobal() {
-        initialize(Set.of(cnec1, cnec2), 0, 0, 0, crac.getPreventiveState());
+        initialize(Set.of(cnec1, cnec2), 0, 0, 0, crac.getPreventiveState(), false);
     }
 
-    private void initialize(Set<FlowCnec> cnecs, double pstSensitivityThreshold, double hvdcSensitivityThreshold, double injectionSensitivityThreshold, State mainState) {
+    private void initialize(Set<FlowCnec> cnecs, double pstSensitivityThreshold, double hvdcSensitivityThreshold, double injectionSensitivityThreshold, State mainState, boolean raRangeShrinking) {
         OptimizationPerimeter optimizationPerimeter = Mockito.mock(OptimizationPerimeter.class);
         Mockito.when(optimizationPerimeter.getFlowCnecs()).thenReturn(cnecs);
         Mockito.when(optimizationPerimeter.getMainOptimizationState()).thenReturn(mainState);
@@ -98,7 +94,7 @@ class CoreProblemFillerTest extends AbstractFillerTest {
             initialRangeActionSetpointResult,
             new RangeActionActivationResultImpl(initialRangeActionSetpointResult),
             rangeActionParameters,
-            Unit.MEGAWATT, false);
+            Unit.MEGAWATT, raRangeShrinking);
         buildLinearProblem();
     }
 
@@ -224,7 +220,7 @@ class CoreProblemFillerTest extends AbstractFillerTest {
 
     @Test
     void fillTestOnCurative() {
-        initializeForCurative();
+        initialize(Set.of(cnec2), 0, 0, 0, cnec2.getState(), false);
         State state = cnec2.getState();
 
         // check range action setpoint variable
@@ -426,23 +422,21 @@ class CoreProblemFillerTest extends AbstractFillerTest {
         assertNull(flowConstraint2);
 
         // check the number of variables and constraints
+        // No iterative relative variation constraint should be created since CoreProblemFiller.raRangeShrinking = false
         // total number of variables 3 :
         //      - 1 per CNEC (flow)
-        //      - 2 per range action (set-point and variation)
-        // total number of constraints 4 :
+        //      - 2 per range action (set-point)
+        // total number of constraints 3 :
         //      - 1 per CNEC (flow constraint)
-        //      - 3 per range action (absolute variation constraints and iterative relative variation constraint: created before 2nd iteration)
-        assertEquals(3, linearProblem.numVariables());
-        assertEquals(4, linearProblem.numConstraints());
+        //      - 2 per range action (absolute variation constraints)
 
-        // assert that no other constraint is created after 2nd iteration
-        updateLinearProblem();
-        assertEquals(4, linearProblem.numConstraints());
+        assertEquals(3, linearProblem.numVariables());
+        assertEquals(3, linearProblem.numConstraints());
     }
 
     @Test
-    void updateTestOnCurative() {
-        initializeForCurative();
+    void updateTestOnCurativeWithRaRangeShrinking() {
+        initialize(Set.of(cnec2), 0, 0, 0, cnec2.getState(), true);
         State state = cnec2.getState();
         // update the problem with new data
         updateLinearProblem();
@@ -527,7 +521,7 @@ class CoreProblemFillerTest extends AbstractFillerTest {
 
         // (sensi = 2) < 2.5 should be filtered
         when(flowResult.getMargin(cnec1, Unit.MEGAWATT)).thenReturn(-1.0);
-        initialize(Set.of(cnec1), 2.5, 2.5, 2.5, crac.getPreventiveState());
+        initialize(Set.of(cnec1), 2.5, 2.5, 2.5, crac.getPreventiveState(), false);
         flowConstraint = linearProblem.getFlowConstraint(cnec1, Side.LEFT);
         rangeActionSetpoint = linearProblem.getRangeActionSetpointVariable(pstRangeAction, cnec1.getState());
         assertEquals(0, flowConstraint.getCoefficient(rangeActionSetpoint), DOUBLE_TOLERANCE);
@@ -544,7 +538,7 @@ class CoreProblemFillerTest extends AbstractFillerTest {
 
         // (sensi = 2) > 1/.5 should not be filtered
         when(flowResult.getMargin(cnec1, Side.LEFT, Unit.MEGAWATT)).thenReturn(-1.0);
-        initialize(Set.of(cnec1), 1.5, 1.5, 1.5, crac.getPreventiveState());
+        initialize(Set.of(cnec1), 1.5, 1.5, 1.5, crac.getPreventiveState(), false);
         flowConstraint = linearProblem.getFlowConstraint(cnec1, Side.LEFT);
         rangeActionSetpoint = linearProblem.getRangeActionSetpointVariable(pstRangeAction, cnec1.getState());
         assertEquals(-2, flowConstraint.getCoefficient(rangeActionSetpoint), DOUBLE_TOLERANCE);

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/CoreProblemFillerTest.java
@@ -98,7 +98,7 @@ class CoreProblemFillerTest extends AbstractFillerTest {
             initialRangeActionSetpointResult,
             new RangeActionActivationResultImpl(initialRangeActionSetpointResult),
             rangeActionParameters,
-            Unit.MEGAWATT);
+            Unit.MEGAWATT, false);
         buildLinearProblem();
     }
 
@@ -505,7 +505,8 @@ class CoreProblemFillerTest extends AbstractFillerTest {
             initialRangeActionSetpointResult,
             new RangeActionActivationResultImpl(initialRangeActionSetpointResult),
             rangeActionParameters,
-            Unit.MEGAWATT);
+            Unit.MEGAWATT,
+            false);
         linearProblem = new LinearProblemBuilder()
             .withProblemFiller(coreProblemFiller)
             .withSolver(mpSolver)

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/DiscretePstGroupFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/DiscretePstGroupFillerTest.java
@@ -64,7 +64,8 @@ class DiscretePstGroupFillerTest extends AbstractFillerTest {
             initialRangeActionSetpointResult,
             new RangeActionActivationResultImpl(initialRangeActionSetpointResult),
             rangeActionParameters,
-            Unit.MEGAWATT);
+            Unit.MEGAWATT,
+            false);
 
         Map<State, Set<PstRangeAction>> pstRangeActions = new HashMap<>();
         pstRangeActions.put(state, Set.of(pstRa1, pstRa2));

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/DiscretePstTapFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/DiscretePstTapFillerTest.java
@@ -59,7 +59,8 @@ class DiscretePstTapFillerTest extends AbstractFillerTest {
             initialRangeActionSetpointResult,
             new RangeActionActivationResultImpl(initialRangeActionSetpointResult),
             rangeActionParameters,
-            Unit.MEGAWATT);
+            Unit.MEGAWATT,
+            false);
 
         Map<State, Set<PstRangeAction>> pstRangeActions = new HashMap<>();
         pstRangeActions.put(state, Set.of(pstRangeAction));

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/MaxLoopFlowFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/MaxLoopFlowFillerTest.java
@@ -78,7 +78,8 @@ class MaxLoopFlowFillerTest extends AbstractFillerTest {
             initialRangeActionSetpointResult,
             new RangeActionActivationResultImpl(initialRangeActionSetpointResult),
             rangeActionParameters,
-            Unit.MEGAWATT
+            Unit.MEGAWATT,
+            false
         );
         cnec1.newExtension(LoopFlowThresholdAdder.class).withValue(100.).withUnit(Unit.MEGAWATT).add();
     }

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/MaxMinMarginFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/MaxMinMarginFillerTest.java
@@ -66,7 +66,8 @@ class MaxMinMarginFillerTest extends AbstractFillerTest {
             initialRangeActionSetpointResult,
             new RangeActionActivationResultImpl(initialRangeActionSetpointResult),
             rangeActionParameters,
-            Unit.MEGAWATT);
+            Unit.MEGAWATT,
+            false);
     }
 
     private void createMaxMinMarginFiller(Unit unit) {

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/MaxMinRelativeMarginFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/MaxMinRelativeMarginFillerTest.java
@@ -79,7 +79,8 @@ class MaxMinRelativeMarginFillerTest extends AbstractFillerTest {
             initialRangeActionSetpointResult,
             new RangeActionActivationResultImpl(initialRangeActionSetpointResult),
             rangeActionParameters,
-            MEGAWATT);
+            MEGAWATT,
+            false);
     }
 
     private void createMaxMinRelativeMarginFiller(Unit unit, double cnecInitialAbsolutePtdfSum) {

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/MnecFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/MnecFillerTest.java
@@ -109,7 +109,8 @@ class MnecFillerTest extends AbstractFillerTest {
                 initialRangeActionSetpointResult,
                 new RangeActionActivationResultImpl(initialRangeActionSetpointResult),
                 rangeActionParameters,
-                Unit.MEGAWATT);
+                Unit.MEGAWATT,
+            false);
     }
 
     private void fillProblemWithFiller(Unit unit) {

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/RaUsageLimitsFillerTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/RaUsageLimitsFillerTest.java
@@ -115,7 +115,8 @@ class RaUsageLimitsFillerTest extends AbstractFillerTest {
             prePerimeterRangeActionSetpointResult,
             prePerimeterRangeActionActivationResult,
             rangeActionParameters,
-            Unit.MEGAWATT);
+            Unit.MEGAWATT,
+            false);
     }
 
     @Test

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/UnoptimizedCnecFillerMarginDecreaseRuleTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/UnoptimizedCnecFillerMarginDecreaseRuleTest.java
@@ -88,7 +88,8 @@ class UnoptimizedCnecFillerMarginDecreaseRuleTest extends AbstractFillerTest {
             initialRangeActionSetpointResult,
             new RangeActionActivationResultImpl(initialRangeActionSetpointResult),
             rangeActionParameters,
-            MEGAWATT);
+            MEGAWATT,
+            false);
     }
 
     private void buildLinearProblemWithMaxMinMargin() {

--- a/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/UnoptimizedCnecFillerPstLimitationRuleTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/farao_community/farao/search_tree_rao/linear_optimisation/algorithms/fillers/UnoptimizedCnecFillerPstLimitationRuleTest.java
@@ -104,7 +104,8 @@ class UnoptimizedCnecFillerPstLimitationRuleTest extends AbstractFillerTest {
             initialRangeActionSetpointResult,
             new RangeActionActivationResultImpl(initialRangeActionSetpointResult),
             rangeActionParameters,
-            MEGAWATT);
+            MEGAWATT,
+            false);
     }
 
     private void buildLinearProblemWithMaxMinMarginAndPositiveSensitivityValue() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?**

No

**What kind of change does this PR introduce?**

Bug fix

**What is the current behavior?**

At the 2nd iteration of the LP, the raRangeShrinking constraints are applied, no matter what. See the [website documentation on those equations](https://farao-community.github.io/docs/castor/linear-optimisation-problem/core-problem-filler#ra-range-shrinking).

**What is the new behavior (if this is a feature change)?**

The constraints are only applied when they are supposed to, according to the `ra-range-shrinking` field.

**Does this PR introduce a breaking change?**

No

**Other information**:

All tests pass on farao-cucumber master branch.
