### PR TITLE
only apply activatedRA in mergeRaoAndPstRegulationResults

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/castor/algorithm/CastorFullOptimization.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/castor/algorithm/CastorFullOptimization.java
@@ -14,6 +14,7 @@ import com.powsybl.openrao.data.crac.api.InstantKind;
 import com.powsybl.openrao.data.crac.api.State;
 import com.powsybl.openrao.data.crac.api.cnec.FlowCnec;
 import com.powsybl.openrao.data.crac.api.networkaction.NetworkAction;
+import com.powsybl.openrao.data.crac.api.rangeaction.RangeAction;
 import com.powsybl.openrao.data.raoresult.api.ComputationStatus;
 import com.powsybl.openrao.data.raoresult.api.OptimizationStepsExecuted;
 import com.powsybl.openrao.data.raoresult.api.RaoResult;
@@ -410,7 +411,7 @@ public class CastorFullOptimization {
                     if (autoState != null) {
                         previousStates.add(autoState);
                         appliedArasAndCras.addAppliedNetworkActions(autoState, postContingencyResults.get(autoState).optimizationResult().getActivatedNetworkActions());
-                        appliedArasAndCras.addAppliedRangeActions(autoState, postContingencyResults.get(autoState).optimizationResult().getOptimizedSetpointsOnState(autoState));
+                        appliedArasAndCras.addAppliedRangeActions(autoState, getAppliedRangeActionsAndSetPoint(autoState, postContingencyResults.get(autoState).optimizationResult()));
                         appliedNetworkActions.put(autoState, appliedArasAndCras.getAppliedNetworkActions(autoState));
                     }
                 }
@@ -419,7 +420,7 @@ public class CastorFullOptimization {
                     .forEach(cState -> {
                         previousStates.add(cState);
                         appliedArasAndCras.addAppliedNetworkActions(cState, postContingencyResults.get(cState).optimizationResult().getActivatedNetworkActions());
-                        appliedArasAndCras.addAppliedRangeActions(cState, postContingencyResults.get(cState).optimizationResult().getOptimizedSetpointsOnState(cState));
+                        appliedArasAndCras.addAppliedRangeActions(cState, getAppliedRangeActionsAndSetPoint(cState, postContingencyResults.get(cState).optimizationResult()));
                         appliedNetworkActions.put(cState, appliedArasAndCras.getAppliedNetworkActions(cState));
                     });
                 pstRegulationResult.regulatedTapPerPst().forEach((pstRangeAction, regulatedTap) -> appliedArasAndCras.addAppliedRangeAction(curativeState, pstRangeAction, pstRangeAction.convertTapToAngle(regulatedTap)));
@@ -447,6 +448,12 @@ public class CastorFullOptimization {
             }
         }
         return postRegulationPostContingencyResults;
+    }
+
+    private static Map<RangeAction<?>, Double> getAppliedRangeActionsAndSetPoint(State state, OptimizationResult optimizationResult) {
+        Map<RangeAction<?>, Double> optimizedRangeActions = new HashMap<>();
+        optimizationResult.getActivatedRangeActions(state).forEach(rangeAction -> optimizedRangeActions.put(rangeAction, optimizationResult.getOptimizedSetpoint(rangeAction, state)));
+        return optimizedRangeActions;
     }
 
     /**

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/castor/algorithm/pstregulation/CastorPstRegulation.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/castor/algorithm/pstregulation/CastorPstRegulation.java
@@ -164,6 +164,7 @@ public final class CastorPstRegulation {
     }
 
     private static void applyOptimalRemedialActionsForState(Network networkClone, RaoResult raoResult, State state) {
+        // network actions need to be applied BEFORE range actions because to apply HVDC range actions we need to apply AC emulation deactivation network actions beforehand
         raoResult.getActivatedNetworkActionsDuringState(state).forEach(networkAction -> networkAction.apply(networkClone));
         raoResult.getActivatedRangeActionsDuringState(state).forEach(rangeAction -> rangeAction.apply(networkClone, raoResult.getOptimizedSetPointOnState(state, rangeAction)));
     }

--- a/sensitivity-analysis/src/main/java/com/powsybl/openrao/sensitivityanalysis/RangeActionSensitivityProvider.java
+++ b/sensitivity-analysis/src/main/java/com/powsybl/openrao/sensitivityanalysis/RangeActionSensitivityProvider.java
@@ -93,7 +93,6 @@ public class RangeActionSensitivityProvider extends LoadflowProvider {
             } else if (ra instanceof HvdcRangeAction hvdcRangeAction) {
                 HvdcLine hvdcLine = network.getHvdcLine(hvdcRangeAction.getNetworkElement().getId());
                 if (hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class) != null && hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class).isEnabled()) {
-                    TECHNICAL_LOGS.debug("Unable to compute sensitivity for ({}) because it's in AC emulation", hvdcRangeAction.getId());
                     continue;
                 }
                 sensitivityVariables.put(hvdcRangeAction.getNetworkElement().getId(), SensitivityVariableType.HVDC_LINE_ACTIVE_POWER);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
no



**What kind of change does this PR introduce?**
Bug fix : when merging results after pst regulation, instead of applying activated range actions during state we were applying a set of memorized range actions (for conveniency). 



**What is the current behavior?**
Only activated range actions are now applied

