### PR TITLE
Pst Regulation - Fix Auto instant margin for curative cnecs

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/castor/algorithm/CastorFullOptimization.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/castor/algorithm/CastorFullOptimization.java
@@ -435,10 +435,16 @@ public class CastorFullOptimization {
         OptimizationResult newOptimizationResult = new OptimizationResultImpl(postCraSensitivityAnalysisOutput, postCraSensitivityAnalysisOutput, postCraSensitivityAnalysisOutput, new NetworkActionsResultImpl(appliedNetworkActions), postRegulationRangeActionActivationResult);
 
         for (State state : postContingencyResults.keySet()) {
-            postRegulationPostContingencyResults.put(state, new PostPerimeterResult(
-                regulatedStates.contains(state) ? newOptimizationResult : postContingencyResults.get(state).optimizationResult(),
-                postCraSensitivityAnalysisOutput
-            ));
+            // For instants before pst regulation instant, keep previous results
+            if (state.getInstant().comesBefore(crac.getLastInstant())) {
+                postRegulationPostContingencyResults.put(state, postContingencyResults.get(state));
+            } else {
+                // For curative instant, update regulatedStates with newly computed sensi result
+                postRegulationPostContingencyResults.put(state, new PostPerimeterResult(
+                    regulatedStates.contains(state) ? newOptimizationResult : postContingencyResults.get(state).optimizationResult(),
+                    postCraSensitivityAnalysisOutput
+                ));
+            }
         }
 
         return postRegulationPostContingencyResults;


### PR DESCRIPTION
Pst Regulation  - Fix Auto instant margin for curative cnecs

**What kind of change does this PR introduce?**
Fix : ARA instant margin for curative cnecs was fixed; it now correctly fetches pre pst regulation instant results
