### PR TITLE
Fix Monitoring tests by using a countDownLatch

### DIFF
--- a/monitoring/src/test/java/com/powsybl/openrao/monitoring/MonitoringTestUtil.java
+++ b/monitoring/src/test/java/com/powsybl/openrao/monitoring/MonitoringTestUtil.java
@@ -3,6 +3,7 @@ package com.powsybl.openrao.monitoring;
 import com.powsybl.computation.local.LocalComputationManager;
 
 import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -11,7 +12,7 @@ public final class MonitoringTestUtil {
         // Util class
     }
 
-    public static LocalComputationManager getComputationManager(final AtomicInteger firstReferenceValue, final AtomicInteger secondReferenceValue) throws IOException {
+    public static LocalComputationManager getComputationManager(final AtomicInteger referenceValue, final CountDownLatch latch) throws IOException {
         return new LocalComputationManager() {
             /**
              * The getExecutor method is called by OpenLoadFlow to run the loadflow with the executor.
@@ -23,9 +24,9 @@ public final class MonitoringTestUtil {
                 final Executor delegate = super.getExecutor();
                 return command ->
                     delegate.execute(() -> {
-                        firstReferenceValue.incrementAndGet();
+                        referenceValue.incrementAndGet();
                         command.run(); // Loadflow execution goes here
-                        secondReferenceValue.decrementAndGet();
+                        latch.countDown();
                     });
             }
         };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
In some situations, monitoring unit tests with ComputationManager fail, probably due to an incorrect thread processing order. This PR uses a CountDownLatch to ensure the threads are handled in the correct order.


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
