### PR TITLE
[FIX] compute time gap with seconds/3600 instead of hours (rounding to 0)

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/linearoptimisation/algorithms/fillers/PowerGradientConstraintFiller.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/linearoptimisation/algorithms/fillers/PowerGradientConstraintFiller.java
@@ -62,7 +62,7 @@ public class PowerGradientConstraintFiller implements ProblemFiller {
      * p^{-}(g) * delta(t, t + 1) <= P(g, t + 1) - P(g, t) <= p^{+}(g) * delta_t(t, t + 1)
      * */
     private static void addPowerGradientConstraint(LinearProblem linearProblem, GeneratorConstraints generatorConstraints, OffsetDateTime currentTimestamp, OffsetDateTime previousTimestamp, OpenRaoMPVariable generatorPowerVariable) {
-        double timeGap = previousTimestamp.until(currentTimestamp, ChronoUnit.HOURS);
+        double timeGap = previousTimestamp.until(currentTimestamp, ChronoUnit.SECONDS) / 3600.;
         double lb = generatorConstraints.getDownwardPowerGradient().map(minValue -> minValue * timeGap).orElse(-linearProblem.infinity());
         double ub = generatorConstraints.getUpwardPowerGradient().map(maxValue -> maxValue * timeGap).orElse(linearProblem.infinity());
         String generatorId = generatorConstraints.getGeneratorId();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Currently the gradient constraints compute the gap between two timestamps with .until(xx, HOURS) which returns a long (and not a double so returns 0 for shorter time gaps)


**What is the new behavior (if this is a feature change)?**
We now do .until(xx, SECONDS)/3600. .


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
