### PR TITLE
Avoid StateTree useless creation in FastRAO

### DIFF
--- a/data/crac/crac-api/src/main/java/com/powsybl/openrao/data/crac/api/Crac.java
+++ b/data/crac/crac-api/src/main/java/com/powsybl/openrao/data/crac/api/Crac.java
@@ -576,6 +576,8 @@ public interface Crac extends Identifiable<Crac> {
      */
     RaUsageLimitsAdder newRaUsageLimits(String instantName);
 
+    Set<String> findOperatorsNotSharingCras();
+
     /**
      * Get the CRAC format
      *

--- a/data/crac/crac-api/src/test/java/com/powsybl/openrao/data/crac/api/MockCrac.java
+++ b/data/crac/crac-api/src/test/java/com/powsybl/openrao/data/crac/api/MockCrac.java
@@ -31,12 +31,7 @@ import com.powsybl.openrao.data.crac.api.rangeaction.PstRangeActionAdder;
 import com.powsybl.openrao.data.crac.api.rangeaction.RangeAction;
 
 import java.time.OffsetDateTime;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.SortedSet;
+import java.util.*;
 
 /**
  * @author Thomas Bouquet {@literal <thomas.bouquet at rte-france.com>}
@@ -440,6 +435,11 @@ public final class MockCrac implements Crac {
     @Override
     public RaUsageLimitsAdder newRaUsageLimits(String instantName) {
         return null;
+    }
+
+    @Override
+    public Set<String> findOperatorsNotSharingCras() {
+        return Collections.emptySet();
     }
 
     @Override

--- a/data/crac/crac-impl/src/main/java/com/powsybl/openrao/data/crac/impl/CracImpl.java
+++ b/data/crac/crac-impl/src/main/java/com/powsybl/openrao/data/crac/impl/CracImpl.java
@@ -950,6 +950,22 @@ public class CracImpl extends AbstractIdentifiable<Crac> implements Crac {
     }
 
     @Override
+    public Set<String> findOperatorsNotSharingCras() {
+        Set<String> tsos = getFlowCnecs().stream().map(Cnec::getOperator).collect(Collectors.toSet());
+        tsos.addAll(getRemedialActions().stream().map(RemedialAction::getOperator).collect(Collectors.toSet()));
+        // <!> If a CNEC's operator is not null, filter it out of the list of operators not sharing CRAs
+        return tsos.stream().filter(tso -> Objects.nonNull(tso) && !tsoHasCra(tso)).collect(Collectors.toSet());
+    }
+
+    private boolean tsoHasCra(String tso) {
+        Set<State> optimizedCurativeStates = getCurativeStates();
+        return optimizedCurativeStates.stream().anyMatch(state ->
+                getNetworkActions(state).stream().map(RemedialAction::getOperator).anyMatch(tso::equals) ||
+                        getRangeActions(state).stream().map(RemedialAction::getOperator).anyMatch(tso::equals)
+        );
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/data/crac/crac-impl/src/test/java/com/powsybl/openrao/data/crac/impl/CracImplTest.java
+++ b/data/crac/crac-impl/src/test/java/com/powsybl/openrao/data/crac/impl/CracImplTest.java
@@ -16,12 +16,7 @@ import com.powsybl.iidm.network.TwoSides;
 import com.powsybl.openrao.commons.OpenRaoException;
 import com.powsybl.openrao.commons.PhysicalParameter;
 import com.powsybl.openrao.commons.Unit;
-import com.powsybl.openrao.data.crac.api.ContingencyAdder;
-import com.powsybl.openrao.data.crac.api.Instant;
-import com.powsybl.openrao.data.crac.api.InstantKind;
-import com.powsybl.openrao.data.crac.api.NetworkElement;
-import com.powsybl.openrao.data.crac.api.RaUsageLimits;
-import com.powsybl.openrao.data.crac.api.State;
+import com.powsybl.openrao.data.crac.api.*;
 import com.powsybl.openrao.data.crac.api.cnec.AngleCnec;
 import com.powsybl.openrao.data.crac.api.cnec.FlowCnec;
 import com.powsybl.openrao.data.crac.api.cnec.FlowCnecAdder;
@@ -35,6 +30,7 @@ import com.powsybl.openrao.data.crac.api.rangeaction.HvdcRangeActionAdder;
 import com.powsybl.openrao.data.crac.api.rangeaction.PstRangeAction;
 import com.powsybl.openrao.data.crac.api.rangeaction.PstRangeActionAdder;
 import com.powsybl.openrao.data.crac.api.rangeaction.RangeAction;
+import com.powsybl.openrao.data.crac.impl.utils.CommonCracCreation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -1321,5 +1317,14 @@ class CracImplTest {
         badCrac.newInstant("curative", InstantKind.CURATIVE);
         OpenRaoException exception = assertThrows(OpenRaoException.class, () -> badCrac.newInstant("auto", InstantKind.AUTO));
         assertEquals("Only one auto instant is allowed and it must occur between outage and curative instants", exception.getMessage());
+    }
+
+    @Test
+    void testFindOperatorsNotSharingCras() {
+        Crac crac2 = CommonCracCreation.create(new CracImplFactory(), Set.of(TwoSides.ONE));
+        assertEquals(Set.of("operator1", "operator2"), crac2.findOperatorsNotSharingCras());
+
+        crac2 = CommonCracCreation.createWithCurativePstRange();
+        assertEquals(Set.of("operator2"), crac2.findOperatorsNotSharingCras());
     }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/castor/algorithm/StateTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/castor/algorithm/StateTree.java
@@ -13,17 +13,10 @@ import com.powsybl.openrao.commons.logs.OpenRaoLoggerProvider;
 import com.powsybl.openrao.data.crac.api.Crac;
 import com.powsybl.openrao.data.crac.api.Instant;
 import com.powsybl.openrao.data.crac.api.InstantKind;
-import com.powsybl.openrao.data.crac.api.RemedialAction;
 import com.powsybl.openrao.data.crac.api.State;
-import com.powsybl.openrao.data.crac.api.cnec.Cnec;
 import org.apache.commons.lang3.tuple.Pair;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -45,7 +38,7 @@ public class StateTree {
             processAutoAndCurativeInstants(contingency, crac);
         }
 
-        this.operatorsNotSharingCras = findOperatorsNotSharingCras(crac);
+        this.operatorsNotSharingCras = crac.findOperatorsNotSharingCras();
     }
 
     /**
@@ -216,20 +209,5 @@ public class StateTree {
     private static boolean anyAvailableRemedialAction(Crac crac, State state) {
         return !crac.getNetworkActions(state).isEmpty() ||
             !crac.getRangeActions(state).isEmpty();
-    }
-
-    private static Set<String> findOperatorsNotSharingCras(Crac crac) {
-        Set<String> tsos = crac.getFlowCnecs().stream().map(Cnec::getOperator).collect(Collectors.toSet());
-        tsos.addAll(crac.getRemedialActions().stream().map(RemedialAction::getOperator).collect(Collectors.toSet()));
-        // <!> If a CNEC's operator is not null, filter it out of the list of operators not sharing CRAs
-        return tsos.stream().filter(tso -> Objects.nonNull(tso) && !tsoHasCra(tso, crac)).collect(Collectors.toSet());
-    }
-
-    static boolean tsoHasCra(String tso, Crac crac) {
-        Set<State> optimizedCurativeStates = crac.getCurativeStates();
-        return optimizedCurativeStates.stream().anyMatch(state ->
-            crac.getNetworkActions(state).stream().map(RemedialAction::getOperator).anyMatch(tso::equals) ||
-                crac.getRangeActions(state).stream().map(RemedialAction::getOperator).anyMatch(tso::equals)
-        );
     }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/fastrao/FastRao.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/fastrao/FastRao.java
@@ -32,7 +32,6 @@ import com.powsybl.openrao.raoapi.parameters.extensions.OpenRaoSearchTreeParamet
 import com.powsybl.openrao.searchtreerao.castor.algorithm.CastorFullOptimization;
 import com.powsybl.openrao.searchtreerao.castor.algorithm.PostPerimeterSensitivityAnalysis;
 import com.powsybl.openrao.searchtreerao.castor.algorithm.PrePerimeterSensitivityAnalysis;
-import com.powsybl.openrao.searchtreerao.castor.algorithm.StateTree;
 import com.powsybl.openrao.searchtreerao.commons.RaoLogger;
 import com.powsybl.openrao.searchtreerao.commons.RaoUtil;
 import com.powsybl.openrao.searchtreerao.commons.ToolProvider;
@@ -311,11 +310,10 @@ public class FastRao implements RaoProvider {
         BUSINESS_LOGS.info("[FAST RAO] Iteration {}: Run full sensitivity analysis [start]", counter);
 
         // Compute sensitivity analyses after PRA, after ARA, after CRA to build RaoResult
-        StateTree stateTree = new StateTree(crac);
-
         Network networkCopyPra = networkPool.getAvailableNetwork();
         Network networkCopyAra = networkPool.getAvailableNetwork();
         Network networkCopyCra = networkPool.getAvailableNetwork();
+        Set<String> operatorsNotSharingCras = crac.findOperatorsNotSharingCras();
 
         // 1) Post PRA
         CompletableFuture<PostPerimeterResult> postPraSensi = runPostPerimeterAnalysis(
@@ -325,7 +323,7 @@ public class FastRao implements RaoProvider {
             initialResult,
             initialRangeActionSetpointResult,
             CompletableFuture.completedFuture(initialResult),
-            stateTree,
+            operatorsNotSharingCras,
             parameters,
             toolProvider,
             InstantKind.PREVENTIVE
@@ -339,7 +337,7 @@ public class FastRao implements RaoProvider {
             initialResult,
             initialRangeActionSetpointResult,
             postPraSensi.thenApply(PostPerimeterResult::prePerimeterResultForAllFollowingStates),
-            stateTree,
+            operatorsNotSharingCras,
             parameters,
             toolProvider,
             InstantKind.AUTO
@@ -353,7 +351,7 @@ public class FastRao implements RaoProvider {
             initialResult,
             initialRangeActionSetpointResult,
             postAraSensi.thenApply(PostPerimeterResult::prePerimeterResultForAllFollowingStates),
-            stateTree,
+            operatorsNotSharingCras,
             parameters,
             toolProvider,
             InstantKind.CURATIVE
@@ -397,7 +395,7 @@ public class FastRao implements RaoProvider {
         PrePerimeterResult initialResult,
         RangeActionSetpointResult initialRangeActionSetpointResult,
         CompletableFuture<PrePerimeterResult> previousSensiFuture,
-        StateTree stateTree,
+        Set<String> operatorsNotSharingCras,
         RaoParameters parameters,
         ToolProvider toolProvider,
         InstantKind instantKind) {
@@ -431,7 +429,7 @@ public class FastRao implements RaoProvider {
             networkCopy,
             initialResult,
             previousSensiFuture,
-            stateTree.getOperatorsNotSharingCras(),
+            operatorsNotSharingCras,
             remedialActionActivationResult,
             appliedRemedialActions
         );


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Performance issue.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
With a large number of states and remedial action instantiation of `StateTree` could be very time consuming (> 1 min). In the FastRAO implementation we can avoid the last `StateTree` which is useless because only operatorsNotSharingCras are needed.


**What is the new behavior (if this is a feature change)?**
In my real case, in addition to https://github.com/powsybl/powsybl-open-rao/pull/1730, this PR allows to go from 8m24s to 5m 52s



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
