### PR TITLE
ci: do not deploy open-rao-tests module 

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -9,6 +9,7 @@
     </parent>
     <properties>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

We had some issue with the deployment of the test module. 

We changed this module's pom to be able to generate a jar-with-dependencies using the maven-assembly-plugin see #1516. Our hypothesis is that using this stops the creation of the sources and javadocs files that we need to properly deploy the module on maven central. 

Considering the fact that it is not useful to deploy the test module we will skip it in our future release
