### PR TITLE
Use JSpecify Nullable annotation instead of javax.annotations' one

### DIFF
--- a/data/crac/crac-io/crac-io-cse/src/main/java/com/powsybl/openrao/data/crac/io/cse/criticalbranch/CriticalBranchReader.java
+++ b/data/crac/crac-io/crac-io-cse/src/main/java/com/powsybl/openrao/data/crac/io/cse/criticalbranch/CriticalBranchReader.java
@@ -22,7 +22,6 @@ import com.powsybl.openrao.data.crac.io.cse.xsd.TBranch;
 import com.powsybl.openrao.data.crac.io.cse.xsd.TImax;
 import com.powsybl.openrao.data.crac.io.cse.xsd.TOutage;
 
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -30,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 
 /**
  * @author Peter Mitri {@literal <peter.mitri at rte-france.com>}

--- a/data/crac/crac-io/crac-io-network/src/main/java/com/powsybl/openrao/data/crac/io/network/CnecCreator.java
+++ b/data/crac/crac-io/crac-io-network/src/main/java/com/powsybl/openrao/data/crac/io/network/CnecCreator.java
@@ -21,8 +21,8 @@ import com.powsybl.openrao.data.crac.io.commons.api.ImportStatus;
 import com.powsybl.openrao.data.crac.io.network.parameters.CriticalElements;
 import com.powsybl.openrao.data.crac.io.network.parameters.NetworkCracCreationParameters;
 
-import javax.annotation.Nullable;
 import java.util.*;
+import org.jspecify.annotations.Nullable;
 
 /**
  * @author Peter Mitri {@literal <peter.mitri at rte-france.com>}

--- a/data/crac/crac-io/crac-io-network/src/main/java/com/powsybl/openrao/data/crac/io/network/parameters/AbstractCountriesFilter.java
+++ b/data/crac/crac-io/crac-io-network/src/main/java/com/powsybl/openrao/data/crac/io/network/parameters/AbstractCountriesFilter.java
@@ -9,9 +9,9 @@ package com.powsybl.openrao.data.crac.io.network.parameters;
 
 import com.powsybl.iidm.network.Country;
 
-import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Allows filtering elements on a list of countries.

--- a/data/crac/crac-io/crac-io-network/src/main/java/com/powsybl/openrao/data/crac/io/network/parameters/Contingencies.java
+++ b/data/crac/crac-io/crac-io-network/src/main/java/com/powsybl/openrao/data/crac/io/network/parameters/Contingencies.java
@@ -9,10 +9,10 @@ package com.powsybl.openrao.data.crac.io.network.parameters;
 
 import com.powsybl.iidm.network.Branch;
 
-import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Indicates what elements to simulate as contingencies (N-1).

--- a/data/crac/crac-io/crac-io-network/src/main/java/com/powsybl/openrao/data/crac/io/network/parameters/CriticalElements.java
+++ b/data/crac/crac-io/crac-io-network/src/main/java/com/powsybl/openrao/data/crac/io/network/parameters/CriticalElements.java
@@ -14,9 +14,9 @@ import com.powsybl.openrao.data.crac.api.Instant;
 import com.powsybl.openrao.data.crac.io.network.NetworkCracCreationContext;
 import org.apache.commons.lang3.function.TriFunction;
 
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Configures how CNECs must be created.

--- a/data/crac/crac-io/crac-io-network/src/main/java/com/powsybl/openrao/data/crac/io/network/parameters/MinAndMax.java
+++ b/data/crac/crac-io/crac-io-network/src/main/java/com/powsybl/openrao/data/crac/io/network/parameters/MinAndMax.java
@@ -9,9 +9,9 @@ package com.powsybl.openrao.data.crac.io.network.parameters;
 
 import com.powsybl.openrao.commons.OpenRaoException;
 
-import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 
 /**
  * @author Peter Mitri {@literal <peter.mitri at rte-france.com>}

--- a/data/crac/crac-io/crac-io-network/src/main/java/com/powsybl/openrao/data/crac/io/network/parameters/NetworkCracCreationParameters.java
+++ b/data/crac/crac-io/crac-io-network/src/main/java/com/powsybl/openrao/data/crac/io/network/parameters/NetworkCracCreationParameters.java
@@ -11,8 +11,8 @@ import com.powsybl.openrao.commons.OpenRaoException;
 import com.powsybl.openrao.data.crac.api.InstantKind;
 import com.powsybl.openrao.data.crac.api.parameters.AbstractAlignedRaCracCreationParameters;
 
-import javax.annotation.Nullable;
 import java.util.*;
+import org.jspecify.annotations.Nullable;
 
 /**
  * @author Peter Mitri {@literal <peter.mitri at rte-france.com>}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Adaptation to powsybl-core / powsybl-open-loadflow changes


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The "Nullable" annotation used is from `javax.annotation`. This package is no more present (dependency deleted from upstream projects).


**What is the new behavior (if this is a feature change)?**
Use JSpecify "Nullable" annotation instead.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

This PR is needed as an adaption to powsybl/powsybl-core#3599 and powsybl/powsybl-open-loadflow#1431
(See also powsybl/powsybl-diagram#822)
