### PR TITLE
changed hashsets to treesets to improve reproducibility

### DIFF
--- a/data/time-coupled-constraints/src/main/java/com/powsybl/openrao/data/timecoupledconstraints/TimeCoupledConstraints.java
+++ b/data/time-coupled-constraints/src/main/java/com/powsybl/openrao/data/timecoupledconstraints/TimeCoupledConstraints.java
@@ -7,8 +7,9 @@
 
 package com.powsybl.openrao.data.timecoupledconstraints;
 
-import java.util.HashSet;
+import java.util.Comparator;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * @author Thomas Bouquet {@literal <thomas.bouquet at rte-france.com>}
@@ -18,13 +19,13 @@ public class TimeCoupledConstraints {
     private final Set<AdjustmentConstraints> adjustmentConstraints;
 
     public TimeCoupledConstraints() {
-        this.generatorConstraints = new HashSet<>();
-        this.adjustmentConstraints = new HashSet<>();
+        this.generatorConstraints = new TreeSet<>(Comparator.comparing(GeneratorConstraints::getGeneratorId));
+        this.adjustmentConstraints = new TreeSet<>(Comparator.comparing(AdjustmentConstraints::getRangeActionId));
     }
 
     public TimeCoupledConstraints(Set<GeneratorConstraints> generatorConstraints) {
         this.generatorConstraints = generatorConstraints;
-        this.adjustmentConstraints = new HashSet<>();
+        this.adjustmentConstraints = new TreeSet<>(Comparator.comparing(AdjustmentConstraints::getRangeActionId));
     }
 
     public void addGeneratorConstraints(GeneratorConstraints generatorConstraints) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Currently inter temporal constraints are ordered randomly in the mip because we're using hashset, which causes results to be very variable.


**What is the new behavior (if this is a feature change)?**
Replaced with TreeSets ordered by id.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
