### PR TITLE
[NetworkCracCreator] When creating a CT RA, only consider generators with positive targetP

### DIFF
--- a/data/crac/crac-io/crac-io-network/src/main/java/com/powsybl/openrao/data/crac/io/network/CountertradingRangeActionsCreator.java
+++ b/data/crac/crac-io/crac-io-network/src/main/java/com/powsybl/openrao/data/crac/io/network/CountertradingRangeActionsCreator.java
@@ -65,6 +65,7 @@ class CountertradingRangeActionsCreator {
             .filter(generator -> Utils.injectionIsInCountries(generator, Set.of(country)))
             .filter(generator -> parameters.shouldIncludeInjection(generator, instant, creationContext))
             .filter(generator -> !creationContext.isInjectionUsedInAction(instant, generator.getId()))
+            .filter(generator -> generator.getTargetP() >= 0)
             .collect(Collectors.toSet());
 
         Utils.addInjectionRangeAction(

--- a/data/crac/crac-io/crac-io-network/src/test/java/com/powsybl/openrao/data/crac/io/network/NetworkCracCreatorTest.java
+++ b/data/crac/crac-io/crac-io-network/src/test/java/com/powsybl/openrao/data/crac/io/network/NetworkCracCreatorTest.java
@@ -390,6 +390,38 @@ class NetworkCracCreatorTest {
     }
 
     @Test
+    void testUcteCtWithNegativeTargetP() {
+        parameters.getRedispatchingRangeActions().setIncludeAllInjections(false);
+        parameters.getCountertradingRangeActions().setCountryFilter(Set.of(Country.NL));
+        parameters.getCountertradingRangeActions().setRaRangeProvider((country, instant) ->
+            instant.isPreventive() ? new MinAndMax<>(-1000., 1000.) : new MinAndMax<>(0., 0.));
+        parameters.getCountertradingRangeActions().setRaCostsProvider((country, instant) -> new InjectionRangeActionCosts(10., 20., 30.));
+
+        // Mock network to have a generator with negative targetP
+        String networkName = "TestCase12Nodes.uct";
+        network = Network.read(networkName, getClass().getResourceAsStream("/" + networkName));
+        network.getGenerator("NNL1AA1 _generator").setTargetP(-100.0);
+
+        try {
+            creationContext = Crac.readWithContext(networkName, getClass().getResourceAsStream("/" + networkName), network, cracCreationParameters);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        crac = creationContext.getCrac();
+
+        assertTrue(creationContext.isCreationSuccessful());
+        assertEquals(1, crac.getInjectionRangeActions().size());
+        InjectionRangeAction ra = crac.getInjectionRangeAction("CT_NETHERLANDS_preventive");
+        assertNotNull(ra);
+
+        // NNL1AA1 _generator should be excluded because targetP < 0
+        Map<String, Double> keys = getKeys("CT_NETHERLANDS_preventive");
+        assertFalse(keys.containsKey("NNL1AA1 _generator"));
+        assertTrue(keys.containsKey("NNL3AA1 _generator"));
+        assertTrue(keys.containsKey("NNL2AA1 _generator"));
+    }
+
+    @Test
     void testUcteBalancing() {
         parameters.getRedispatchingRangeActions().setIncludeAllInjections(false);
         parameters.getBalancingRangeAction().setInjectionPredicate((injection, instant, c) -> instant.isPreventive() && injection.getId().contains("FFR"));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When the network crac creator creates CT actions, it doesn't filter out potential generators with negative targetP.
this can lead to a CT action with a mix of positive and negative distribution keys, which is hard to explain.

**What is the new behavior (if this is a feature change)?**
We now filter out generators with a negative targetP.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
