### PR TITLE
extract from loop variable definition for variables which will not ch…

### DIFF
--- a/data/crac/crac-io/crac-io-network/src/main/java/com/powsybl/openrao/data/crac/io/network/CnecCreator.java
+++ b/data/crac/crac-io/crac-io-network/src/main/java/com/powsybl/openrao/data/crac/io/network/CnecCreator.java
@@ -43,12 +43,15 @@ class CnecCreator {
     }
 
     void addCnecs() {
+        Set<Contingency> contingencies = crac.getContingencies();
+        Instant outageInstant = crac.getOutageInstant();
+
         for (Branch<?> branch : network.getBranches()) {
             if (branchShouldBeConsidered(branch)) {
                 try {
                     CriticalElements.OptimizedMonitored optimizedMonitoredInPreventive = isOptimizedMonitored(branch, null);
                     addPreventiveCnec(branch, optimizedMonitoredInPreventive.optimized(), optimizedMonitoredInPreventive.monitored());
-                    for (Contingency contingency : crac.getContingencies()) {
+                    for (Contingency contingency : contingencies) {
                         if (contingency.getElements().stream().anyMatch(e -> e.getId().equals(branch.getId()))) {
                             continue;
                         }
@@ -58,7 +61,7 @@ class CnecCreator {
                             contingency,
                             optimizedMonitoredAfterContingency.optimized(),
                             optimizedMonitoredAfterContingency.monitored(),
-                            crac.getOutageInstant()
+                            outageInstant
                         );
                         for (String curativeInstantId : specificParameters.getInstants().get(InstantKind.CURATIVE)) {
                             addPostContingencyCnec(


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Performance


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Currently some variables are computed many times in the loops, even though they are always the same. Some of them require the creation of complex java objects (like a TreeMap), so with so many iterations, it's noticeable.


**What is the new behavior (if this is a feature change)?**
The variables are computed once.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
